### PR TITLE
refactor: replace uuid package with built-in crypto.randomUUID

### DIFF
--- a/lambda/agents/index.js
+++ b/lambda/agents/index.js
@@ -696,7 +696,6 @@ exports.handler = async (event) => {
             // Only track top-level phase agents (not sub-agents like construction task workers).
             const isTopLevelAgent = !input.taskId;
             if (isTopLevelAgent) {
-              const { v4: uuidv4 } = require('uuid');
               const normalizedPhase = (job.agentType || 'inception').toLowerCase().replace('construction-orchestrator', 'construction').replace(/^review.*/, 'review');
               const phaseLabel = normalizedPhase.toUpperCase();
 

--- a/lambda/artifacts/index.js
+++ b/lambda/artifacts/index.js
@@ -1,6 +1,6 @@
 const gremlin = require('gremlin');
 const { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } = require('@aws-sdk/client-s3');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -66,7 +66,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
         const s3Key = `${projectId}/${id}`;
         
         if (data.content) {

--- a/lambda/artifacts/package.json
+++ b/lambda/artifacts/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0",
     "@aws-sdk/client-s3": "^3.0.0",

--- a/lambda/code-files/index.js
+++ b/lambda/code-files/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -49,7 +49,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
 
         await g.V().has('Sprint', 'id', sprintId).as('s')
           .addV('CodeFile')

--- a/lambda/code-files/package.json
+++ b/lambda/code-files/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0"
   }

--- a/lambda/general-info/index.js
+++ b/lambda/general-info/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -50,7 +50,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
         const now = new Date().toISOString();
 
         await g.V().has('Sprint', 'id', sprintId).as('s')

--- a/lambda/general-info/package.json
+++ b/lambda/general-info/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "@aws-sdk/credential-providers": "^3.0.0",
     "gremlin-aws-sigv4": "^3.6.0"
   }

--- a/lambda/projects/index.js
+++ b/lambda/projects/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -123,7 +123,7 @@ exports.handler = async (event) => {
         if (!userId) return response(401, { error: 'Unauthorized' });
         
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
         const createdAt = new Date().toISOString();
         
         // Create the project vertex with creator tracking

--- a/lambda/projects/package.json
+++ b/lambda/projects/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0",
     "@smithy/node-config-provider": "^3.0.0",

--- a/lambda/questions/index.js
+++ b/lambda/questions/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { DynamoDBClient } = require('@aws-sdk/client-dynamodb');
@@ -70,7 +70,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
         const createdAt = new Date().toISOString();
         const questionsJson = JSON.stringify(data.questions);
 

--- a/lambda/questions/package.json
+++ b/lambda/questions/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0",
     "@aws-sdk/client-dynamodb": "^3.0.0",

--- a/lambda/requirements/index.js
+++ b/lambda/requirements/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -49,7 +49,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
 
         await g.V().has('Sprint', 'id', sprintId).as('s')
           .addV('Requirement')

--- a/lambda/requirements/package.json
+++ b/lambda/requirements/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0"
   }

--- a/lambda/reviews/index.js
+++ b/lambda/reviews/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -61,7 +61,7 @@ exports.handler = async (event) => {
         if (existing.value > 0) return res(409, { error: 'Review already exists for this sprint' });
 
         const data = JSON.parse(body || '{}');
-        const id = uuidv4();
+        const id = randomUUID();
 
         await g.V().has('Sprint', 'id', sprintId).as('s')
           .addV('Review')

--- a/lambda/reviews/package.json
+++ b/lambda/reviews/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0"
   }

--- a/lambda/sprints/index.js
+++ b/lambda/sprints/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -70,7 +70,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
         const createdAt = new Date().toISOString();
         const phase = data.phase || 'INCEPTION';
         if (!VALID_PHASES.includes(phase)) return res(400, { error: 'Invalid phase' });

--- a/lambda/sprints/package.json
+++ b/lambda/sprints/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0"
   }

--- a/lambda/tasks/index.js
+++ b/lambda/tasks/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -50,7 +50,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
         const dependencies = data.dependencies || [];
 
         await g.V().has('Sprint', 'id', sprintId).as('s')

--- a/lambda/tasks/package.json
+++ b/lambda/tasks/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0"
   }

--- a/lambda/timeline-events/index.js
+++ b/lambda/timeline-events/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -49,7 +49,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
         const timestamp = data.timestamp || new Date().toISOString();
 
         await g.V().has('Sprint', 'id', sprintId).as('s')

--- a/lambda/timeline-events/package.json
+++ b/lambda/timeline-events/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0"
   }

--- a/lambda/user-stories/index.js
+++ b/lambda/user-stories/index.js
@@ -1,5 +1,5 @@
 const gremlin = require('gremlin');
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
 const { buildResponse } = require('./shared/response');
@@ -49,7 +49,7 @@ exports.handler = async (event) => {
 
       case 'POST': {
         const data = JSON.parse(body);
-        const id = uuidv4();
+        const id = randomUUID();
 
         await g.V().has('Sprint', 'id', sprintId).as('s')
           .addV('UserStory')

--- a/lambda/user-stories/package.json
+++ b/lambda/user-stories/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0"
   }


### PR DESCRIPTION
## Summary
- Replaced `uuid` package with Node's built-in `crypto.randomUUID` across 11 lambda handlers (timeline-events, artifacts, general-info, tasks, sprints, projects, code-files, requirements, user-stories, questions, reviews).
- Removed an unused inline `require('uuid')` inside `lambda/agents/index.js`.
- Dropped the now-unused `uuid` dependency from the affected package.json files.

Relates to #7.