### PR TITLE
chore: remove unused uuid dependency from users and phases lambdas

### DIFF
--- a/lambda/phases/package.json
+++ b/lambda/phases/package.json
@@ -2,7 +2,6 @@
   "name": "phases-lambda",
   "version": "1.0.0",
   "dependencies": {
-    "gremlin": "^3.7.0",
-    "uuid": "^9.0.0"
+    "gremlin": "^3.7.0"
   }
 }

--- a/lambda/users/package.json
+++ b/lambda/users/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "gremlin": "^3.7.0",
-    "uuid": "^9.0.0",
     "gremlin-aws-sigv4": "^3.6.0",
     "@aws-sdk/credential-providers": "^3.0.0",
     "@smithy/node-config-provider": "^3.0.0",


### PR DESCRIPTION
## Summary
- Removed `uuid` from `lambda/users/package.json` and `lambda/phases/package.json` — neither lambda imports the package.
- Follow-up to #33, which left these two alone because they weren't part of the uuid→crypto swap.

Also closes out dependabot's open bump for `lambda/users/uuid` by removing the dep entirely.