### PR TITLE
fix(cognito-users): drop AttributesToGet from ListUsers call

### DIFF
--- a/lambda/cognito-users/index.js
+++ b/lambda/cognito-users/index.js
@@ -35,7 +35,6 @@ exports.handler = async (event) => {
         UserPoolId: userPoolId,
         Limit: 60,
         PaginationToken: paginationToken,
-        AttributesToGet: ['sub', 'email', 'custom:display_name'],
       });
 
       const result = await client.send(cmd);


### PR DESCRIPTION
## Summary
- `lambda/cognito-users/index.js` was passing `AttributesToGet: ['sub', 'email', 'custom:display_name']` to `ListUsersCommand`. Cognito rejects `sub` here (it is always returned automatically and is not a valid requestable attribute), causing `InvalidParameterException` and a 500 from the endpoint.
- Drop `AttributesToGet` entirely so the default behavior returns all attributes. The handler already maps over `u.Attributes`, so no other changes are needed.

Fixes #52

## Test plan
- [ ] Deploy the updated Lambda
- [ ] Sign in to the app and open the "share project" dialog
- [ ] Confirm the user list populates and no `InvalidParameterException` appears in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)