### PR TITLE
fix: route GitHub OAuth callback through SPA and correct README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,17 @@ After deployment, agent workers authenticate with Kiro CLI via device flow. Chec
 
 ### 4. Configure GitHub OAuth
 
-[Create a GitHub OAuth App](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) and store the credentials in the Secrets Manager secret `collaborative-ai-dlc-dev-github-oauth` with `client_id` and `client_secret` fields:
+[Create a GitHub **OAuth App**](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) (not a GitHub App — the flow here expects OAuth App semantics). When prompted, use:
 
-Replace `your_github_client_id` and `your_github_client_secret` with the actual values from your GitHub OAuth App.
+- **Homepage URL**: `https://$(terraform -chdir=terraform output -raw cloudfront_domain_name)`
+- **Authorization callback URL**: `https://$(terraform -chdir=terraform output -raw cloudfront_domain_name)/github/callback`
+
+Then store the OAuth App's credentials in the Secrets Manager secret that terraform created (replace `your_github_client_id` and `your_github_client_secret` with the actual values):
 
 ```bash
-aws secretsmanager update-secret \
-  --secret-id collaborative-ai-dlc-dev-github-oauth \
-  --secret-string '{"client_id":"your_github_client_id","client_secret":"your_github_client_secret"}'  
+aws secretsmanager put-secret-value \
+  --secret-id $(terraform -chdir=terraform output -raw github_oauth_secret_name) \
+  --secret-string '{"client_id":"your_github_client_id","client_secret":"your_github_client_secret"}'
 ```
 
 ### 5. Create Users

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -168,7 +168,7 @@ module "lambda" {
   github_oauth_secret_arn    = module.git.github_oauth_secret_arn
   git_connections_table_name = module.git.git_connections_table_name
   git_connections_table_arn  = module.git.git_connections_table_arn
-  github_redirect_uri        = "https://${module.frontend.cloudfront_domain_name}/api/github/callback"
+  github_redirect_uri        = "https://${module.frontend.cloudfront_domain_name}/github/callback"
   state_machine_arn          = "arn:${local.partition}:states:${var.aws_region}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.project_name}-agent-workflow-${var.environment}"
   agent_questions_table_name = module.dynamodb.agent_questions_table_name
   agent_questions_table_arn  = module.dynamodb.agent_questions_table_arn

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -229,3 +229,9 @@ output "agent_event_bus_name" {
   description = "EventBridge event bus name for agent events"
   value       = module.events.event_bus_name
 }
+
+# GitHub OAuth
+output "github_oauth_secret_name" {
+  description = "Name of the Secrets Manager secret holding the GitHub OAuth client_id/client_secret"
+  value       = module.git.github_oauth_secret_name
+}


### PR DESCRIPTION
Closes #68.

## Summary

- `terraform/main.tf`: `github_redirect_uri` now points at `/github/callback` (SPA route) instead of `/api/github/callback` (API Gateway path). GitHub requires the OAuth App's registered callback to match the `redirect_uri` on the authorize URL, so pointing the Lambda at the API path forced users to register the API path too — which bypassed the SPA's post-connect UX (`frontend/src/pages/GitHubCallback.tsx`) and left the browser staring at raw JSON.
- `terraform/outputs.tf`: expose `github_oauth_secret_name` at the root so the README can reference it without users needing to grep for the prefix-suffixed secret name.
- `README.md` §4: (1) spell out the Authorization callback URL to register on the OAuth App, (2) use `terraform output -raw` for both the CloudFront domain and the secret name instead of hardcoded values that don't exist, (3) use `put-secret-value` instead of `update-secret`.

## Test plan

- [x] Fix applied and verified end-to-end in dev: `Connect GitHub` → authorize → land on `/dashboard`, token stored in SSM, status endpoint returns `connected: true`.
- [x] README commands copy-pasteable after `terraform apply`: `terraform output -raw github_oauth_secret_name` returns the real suffixed name; `put-secret-value` against it succeeds.