### PR TITLE
fix: surface OAuth-not-configured error when connecting GitHub

### DIFF
--- a/frontend/src/components/CreateProjectModal.tsx
+++ b/frontend/src/components/CreateProjectModal.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export function CreateProjectModal({ onClose, onCreated }: Props) {
-  const { status, loading: statusLoading, refresh } = useGitHubStatus();
+  const { status, loading: statusLoading, error: statusError, refresh } = useGitHubStatus();
   const [step, setStep] = useState(1);
   const [selectedRepo, setSelectedRepo] = useState<GitHubRepo | null>(null);
   const [formData, setFormData] = useState<CreateProjectInput>({
@@ -80,6 +80,11 @@ export function CreateProjectModal({ onClose, onCreated }: Props) {
         {step === 1 && (
           <div>
             <h3 className="font-medium mb-3 text-gray-900 dark:text-white">Connect GitHub</h3>
+            {statusError && (
+              <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4 text-sm">
+                {statusError}
+              </div>
+            )}
             {statusLoading ? (
               <p className="text-sm text-gray-500 dark:text-gray-400">Checking connection...</p>
             ) : (

--- a/frontend/src/components/GitHubConnectButton.tsx
+++ b/frontend/src/components/GitHubConnectButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { githubService } from '../services/github';
+import { ApiError } from '../services/api';
 
 interface Props {
   connected: boolean;
@@ -8,14 +9,18 @@ interface Props {
 
 export function GitHubConnectButton({ connected, onDisconnect }: Props) {
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleConnect = async () => {
     setLoading(true);
+    setError(null);
     try {
       const { url } = await githubService.getAuthUrl();
       window.location.href = url;
-    } catch {
+    } catch (err) {
       setLoading(false);
+      const serverMsg = err instanceof ApiError && typeof err.body?.error === 'string' ? err.body.error : null;
+      setError(serverMsg ?? 'Could not start GitHub connection. Please try again.');
     }
   };
 
@@ -45,12 +50,19 @@ export function GitHubConnectButton({ connected, onDisconnect }: Props) {
   }
 
   return (
-    <button
-      onClick={handleConnect}
-      disabled={loading}
-      className="px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-800 disabled:opacity-50"
-    >
-      {loading ? 'Connecting...' : 'Connect GitHub'}
-    </button>
+    <div className="flex flex-col gap-2">
+      <button
+        onClick={handleConnect}
+        disabled={loading}
+        className="px-4 py-2 bg-gray-900 text-white rounded hover:bg-gray-800 disabled:opacity-50 self-start"
+      >
+        {loading ? 'Connecting...' : 'Connect GitHub'}
+      </button>
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-3 py-2 rounded text-sm">
+          {error}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/hooks/useGitHubStatus.ts
+++ b/frontend/src/hooks/useGitHubStatus.ts
@@ -1,17 +1,22 @@
 import { useState, useEffect } from 'react';
 import { githubService, type GitHubStatus } from '../services/github';
+import { ApiError } from '../services/api';
 
 export function useGitHubStatus() {
   const [status, setStatus] = useState<GitHubStatus | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const refresh = async () => {
     setLoading(true);
+    setError(null);
     try {
       const data = await githubService.getStatus();
       setStatus(data);
-    } catch {
+    } catch (err) {
       setStatus({ connected: false });
+      const serverMsg = err instanceof ApiError && typeof err.body?.error === 'string' ? err.body.error : null;
+      setError(serverMsg ?? 'Could not check GitHub connection status.');
     } finally {
       setLoading(false);
     }
@@ -19,5 +24,5 @@ export function useGitHubStatus() {
 
   useEffect(() => { refresh(); }, []);
 
-  return { status, loading, refresh };
+  return { status, loading, error, refresh };
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { projectsService, type Project } from '@/services/projects';
 import { CreateProjectModal } from '@/components/CreateProjectModal';
 import { Card, CardContent } from '@/components/ui/card';
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils';
 
 export default function Dashboard() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -40,6 +41,13 @@ export default function Dashboard() {
   useEffect(() => {
     loadProjects();
   }, [loadProjects]);
+
+  useEffect(() => {
+    if (searchParams.get('reopenCreateProject') === '1') {
+      setShowCreateModal(true);
+      setSearchParams({}, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
 
   const handleDeleteConfirm = async () => {
     if (!confirmDelete) return;

--- a/frontend/src/pages/GitHubCallback.tsx
+++ b/frontend/src/pages/GitHubCallback.tsx
@@ -24,7 +24,7 @@ export default function GitHubCallback() {
       .then(data => {
         if (data.success) {
           setStatus('success');
-          setTimeout(() => navigate('/dashboard'), 1500);
+          setTimeout(() => navigate('/dashboard?reopenCreateProject=1'), 1500);
         } else {
           setStatus('error');
           setError(data.error || 'Failed to connect GitHub');

--- a/lambda/github/index.js
+++ b/lambda/github/index.js
@@ -10,11 +10,41 @@ const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const secrets = new SecretsManagerClient({});
 const ssm = new SSMClient({});
 
+const OAUTH_NOT_CONFIGURED = 'GitHub OAuth is not configured on this environment. See README §4 for setup instructions.';
+
+const oauthNotConfiguredError = () => {
+  const err = new Error(OAUTH_NOT_CONFIGURED);
+  err.statusCode = 503;
+  err.errorCode = 'OAUTH_NOT_CONFIGURED';
+  return err;
+};
+
 const getOAuthCredentials = async () => {
-  const { SecretString } = await secrets.send(new GetSecretValueCommand({
-    SecretId: process.env.GITHUB_OAUTH_SECRET_NAME
-  }));
-  return JSON.parse(SecretString);
+  let result;
+  try {
+    result = await secrets.send(new GetSecretValueCommand({
+      SecretId: process.env.GITHUB_OAUTH_SECRET_NAME
+    }));
+  } catch (e) {
+    if (e.name === 'ResourceNotFoundException') {
+      throw oauthNotConfiguredError();
+    }
+    throw e;
+  }
+  if (!result.SecretString) {
+    throw oauthNotConfiguredError();
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(result.SecretString);
+  } catch {
+    throw oauthNotConfiguredError();
+  }
+  const { client_id, client_secret } = parsed || {};
+  if (typeof client_id !== 'string' || !client_id || typeof client_secret !== 'string' || !client_secret) {
+    throw oauthNotConfiguredError();
+  }
+  return { client_id, client_secret };
 };
 
 // Create HMAC-signed state parameter to prevent CSRF/forgery attacks on OAuth callback
@@ -406,6 +436,9 @@ exports.handler = async (event) => {
     return response(404, { error: 'Not found' });
   } catch (err) {
     console.error('Error:', err);
+    if (err.statusCode) {
+      return response(err.statusCode, { error: err.message, code: err.errorCode });
+    }
     return response(500, { error: 'Internal server error' });
   }
 };

--- a/lambda/github/index.js
+++ b/lambda/github/index.js
@@ -10,14 +10,14 @@ const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const secrets = new SecretsManagerClient({});
 const ssm = new SSMClient({});
 
-const OAUTH_NOT_CONFIGURED = 'GitHub OAuth is not configured on this environment. See README §4 for setup instructions.';
-
-const oauthNotConfiguredError = () => {
-  const err = new Error(OAUTH_NOT_CONFIGURED);
-  err.statusCode = 503;
-  err.errorCode = 'OAUTH_NOT_CONFIGURED';
-  return err;
-};
+class OAuthNotConfiguredError extends Error {
+  constructor() {
+    super('GitHub OAuth is not configured on this environment. See README §4 for setup instructions.');
+    this.name = 'OAuthNotConfiguredError';
+    this.statusCode = 503;
+    this.errorCode = 'OAUTH_NOT_CONFIGURED';
+  }
+}
 
 const getOAuthCredentials = async () => {
   let result;
@@ -27,22 +27,22 @@ const getOAuthCredentials = async () => {
     }));
   } catch (e) {
     if (e.name === 'ResourceNotFoundException') {
-      throw oauthNotConfiguredError();
+      throw new OAuthNotConfiguredError();
     }
     throw e;
   }
   if (!result.SecretString) {
-    throw oauthNotConfiguredError();
+    throw new OAuthNotConfiguredError();
   }
   let parsed;
   try {
     parsed = JSON.parse(result.SecretString);
   } catch {
-    throw oauthNotConfiguredError();
+    throw new OAuthNotConfiguredError();
   }
   const { client_id, client_secret } = parsed || {};
   if (typeof client_id !== 'string' || !client_id || typeof client_secret !== 'string' || !client_secret) {
-    throw oauthNotConfiguredError();
+    throw new OAuthNotConfiguredError();
   }
   return { client_id, client_secret };
 };


### PR DESCRIPTION
## Summary

Closes #70.

On a fresh deploy, the GitHub OAuth Secrets Manager secret exists but isn't populated until the operator runs the README §4 steps. Clicking **Connect GitHub** in that state did nothing visible: the button spinner cleared, no toast, no banner. This PR surfaces the failure at every layer, and also fixes a related UX paper-cut where the Create Project modal disappeared after a *successful* OAuth redirect.

### Lambda (`lambda/github/index.js`)

`getOAuthCredentials` now classifies three flavors of "not configured" as a tagged 503 (`OAUTH_NOT_CONFIGURED`) with a README-pointing message:

- Secrets Manager `ResourceNotFoundException`
- empty/absent `SecretString`
- parsed JSON missing non-empty `client_id` / `client_secret`

The outer catch passes `statusCode`/`errorCode` through instead of flattening to a generic 500. This also incidentally fixes two related symptoms: the `crypto.createHmac` crash when `client_secret` is `undefined` (was a 500), and the redirect-to-GitHub's-own-404 when `client_id` is empty (the Lambda now short-circuits before building the authorize URL).

### Frontend

- Replaced the silent `catch {}` blocks in `GitHubConnectButton` and `useGitHubStatus` with error state. The connect button renders a red-box inline error below itself; the status hook exposes `error` so the Create Project modal can show a banner in step 1 distinguishing "check failed" from "not connected yet". Both read `ApiError.body.error` from the existing `services/api.ts` wrapper — no new dependencies, no toast library.
- Reopen the Create Project modal after a successful OAuth redirect. The OAuth flow navigates the browser away from the SPA, tearing down modal state, so users previously landed on a bare `/dashboard` after connecting and had to re-click New Project. Now `GitHubCallback` navigates to `/dashboard?reopenCreateProject=1` on success and `Dashboard` opens the modal (and strips the param via `replace`).

## Test plan

- [x] Empty the Secrets Manager value via AWS console → banner appears in step 1 with the README §4 hint.
- [x] Click **Connect GitHub** in that state → inline red message below the button; spinner clears; `GET /github/auth` returns 503 `{"error":"GitHub OAuth is not configured...","code":"OAUTH_NOT_CONFIGURED"}`.
- [x] Empty `client_id` / `client_secret` in the secret via AWS console → same 503 banner (instead of a crash or GitHub.com's 404).
- [x] Populate the secret properly → Connect navigates to GitHub OAuth authorize and callback completes.
- [x] After successful OAuth callback → user lands on `/dashboard` with the Create Project modal reopened at step 1 showing "✓ GitHub Connected"; clicking Next proceeds to repo select.