### PR TITLE
ci: add GitHub Actions workflow for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` running `npm test` against Node 22 and 24
- Triggers on pushes to `main`, all pull requests, and manual dispatch
- Concurrency group cancels superseded runs on the same ref
- Pins actions to SHAs (dependabot `github-actions` ecosystem is already configured, so bumps will arrive as PRs)

## Notes on fork safety
The workflow uses `pull_request` (not `pull_request_target`), so PRs from forks run with a read-only `GITHUB_TOKEN` and no secrets. For additional protection against runner-minute abuse, configure **Settings → Actions → General → Fork pull request workflows from outside collaborators** to require approval.

## Test plan
- [x] Workflow appears and runs on this PR
- [x] Both Node 22 and Node 24 jobs pass

Closes #42