### PR TITLE
docs: add missing AWS services to prerequisites and fix CDS style issues

### DIFF
--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -4,7 +4,7 @@ Before you begin, install and verify the following tools.
 
 ## Local development
 
-You need the following tools to run AIDLC Collaborative locally.
+To run AIDLC Collaborative locally, install the following tools.
 
 | Tool | Version | Purpose |
 |------|---------|---------|
@@ -22,13 +22,13 @@ git --version    # Expected output: 2.x
 
 ## AWS deployment
 
-You need the following additional tools to deploy AIDLC Collaborative to AWS. For detailed deployment instructions, see [Setup](setup.md).
+To deploy AIDLC Collaborative to AWS, install the following additional tools. For detailed deployment instructions, see [Setup](setup.md).
 
 | Tool | Version | Purpose |
 |------|---------|---------|
-| **[Terraform](https://developer.hashicorp.com/terraform/install)** | 1.0 or later | Infrastructure provisioning |
-| **[AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)** | v2 | AWS resource management and credential handling |
-| **[Docker](https://docs.docker.com/get-docker/)** | 20.10 or later | Lambda packaging and container builds |
+| [Terraform](https://developer.hashicorp.com/terraform/install) | 1.0 or later | Infrastructure provisioning |
+| [AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) | v2 | AWS resource management and credential handling |
+| [Docker](https://docs.docker.com/get-docker/) | 20.10 or later | Lambda packaging and container builds |
 
 Run the following commands to confirm your deployment tools are installed.
 
@@ -38,15 +38,16 @@ aws --version        # Expected output: aws-cli/2.x
 docker --version     # Expected output: Docker version 20.10 or later
 ```
 
-You also need an AWS account with permissions to manage the following services.
+You must also have an AWS account with permissions to manage the following services.
 
 | Category | Services |
 |----------|----------|
-| Compute | Lambda, ECS Fargate, Step Functions |
-| Networking | VPC, API Gateway, CloudFront |
-| Storage | S3, DynamoDB, Neptune |
-| Security | Cognito, IAM, Secrets Manager |
-| Integration | EventBridge, ECR |
+| Compute | AWS Lambda, Amazon ECS with Fargate, AWS Step Functions |
+| Networking | Amazon VPC, Amazon API Gateway (REST and WebSocket), Amazon CloudFront, Elastic Load Balancing |
+| Storage | Amazon S3, Amazon DynamoDB, Amazon Neptune |
+| Security | Amazon Cognito, AWS Identity and Access Management (IAM), AWS Secrets Manager, AWS Systems Manager Parameter Store |
+| Integration | Amazon EventBridge, Amazon Elastic Container Registry (Amazon ECR), Amazon SQS |
+| Observability | Amazon CloudWatch Logs |
 
 
 ## Optional tools
@@ -60,20 +61,20 @@ The following tools are optional. Install them to enable additional features.
 
 ## Agent authentication
 
-Agents authenticate using API keys configured through the platform UI. Two options are supported:
+Agents authenticate using API keys configured through the platform UI. The platform supports two options:
 
-### Kiro CLI API Key
+### Kiro CLI API key
 
-In the platform settings, enter your Kiro CLI API key. This is used by agent containers to authenticate with the Kiro CLI during Construction.
+In the platform settings, enter your Kiro CLI API key. Agent containers use this key to authenticate with the Kiro CLI during Construction.
 
-### Bedrock API Key (for Claude Code and OpenCode setups)
+### Amazon Bedrock API key (for Claude Code and OpenCode setups)
 
-For agents using Claude Code or OpenCode with Amazon Bedrock, enter your Bedrock credentials (Access Key ID, Secret Access Key, Region) in the platform settings.
+For agents using Claude Code or OpenCode with Amazon Bedrock, enter your Amazon Bedrock credentials (Access Key ID, Secret Access Key, Region) in the platform settings.
 
 You can also use [AWS IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html), IAM roles, or any method supported by the [AWS SDK credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html).
 
 ## AWS credentials for LLM features
 
-AIDLC Collaborative uses [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) to access Claude models. You need valid AWS credentials with Amazon Bedrock access in your environment.
+AIDLC Collaborative uses [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html) to access Claude models. You must have valid AWS credentials with Amazon Bedrock access in your environment.
 
-If you do not have AWS credentials, the platform still starts. You can browse the UI, create organizations and projects, and manage specs. The LLM chat and agent features fail with a connection error.
+If you don't have AWS credentials, the platform still starts. You can browse the UI, create organizations and projects, and manage specs. However, the large language model (LLM) chat and agent features return a connection error.


### PR DESCRIPTION
## Summary

- Adds 5 missing AWS services to the prerequisites permissions table that are provisioned by Terraform but were undocumented: SQS, CloudWatch Logs, Systems Manager Parameter Store, Elastic Load Balancing, and the REST/WebSocket distinction for API Gateway
- Fixes AWS Content Design System (CDS) style issues: proper service name prefixes, modal verbs, passive voice, heading case, and link formatting

## Changes

**Services table updates:**
| Service added | Terraform usage |
|---|---|
| Amazon SQS | Agent question answer queue (`modules/orchestration/questions.tf`) |
| Amazon CloudWatch Logs | Log groups for WebSocket, YJS, agents, Step Functions, API |
| AWS Systems Manager Parameter Store | CloudFront secret, Bedrock token, MCP config, Kiro key |
| Elastic Load Balancing | Internal ALB for YJS real-time server |
| API Gateway (REST and WebSocket) | Clarified both v1 REST and v2 WebSocket are used |

**CDS style fixes:**
- Added `Amazon` / `AWS` brand prefixes to all service names on first use
- Replaced `"You need"` modal verb with direct imperatives
- Fixed passive voice (`"Two options are supported"` → `"The platform supports two options"`)
- Used sentence case for subheadings (`"API Key"` → `"API key"`)
- Removed bold formatting from hyperlink text in tables
- Spelled out `LLM` acronym on first use in body text

Closes #118