### PR TITLE
ci: add frontend build workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,46 @@
+name: Frontend Build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/frontend.yml"
+  pull_request:
+    paths:
+      - "frontend/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/frontend.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/frontend.yml` running `npm run build` (tsc + vite) on Node 24
- Triggers on pushes/PRs that touch `frontend/**` or the root `package.json`/`package-lock.json` (covers future dependabot PRs once frontend moves to root workspaces)
- Concurrency group cancels superseded runs
- Fixes `__dirname` → `import.meta.dirname` in `vite.config.ts` (package is `"type": "module"`, CJS global was incorrect). This also gives a frontend-touching change to verify the workflow triggers on this PR.

## Test plan
- [x] `Frontend Build` workflow runs on this PR
- [x] Build succeeds on Node 24