### PR TITLE
refactor: centralise vitest config via a shared base

### DIFF
--- a/lambda/notify/package.json
+++ b/lambda/notify/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "vitest run --project=notify",
+    "test:watch": "vitest --project=notify",
     "build": "esbuild notify.js --bundle --platform=node --target=node24 --format=esm --external:@aws-sdk/* --outfile=.build/notify.mjs"
   }
 }

--- a/lambda/notify/vitest.config.js
+++ b/lambda/notify/vitest.config.js
@@ -1,8 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { mergeConfig, defineConfig } from 'vitest/config';
+import base from '../../vitest.config.base.js';
 
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.js'],
-    setupFiles: ['../../test/setup.js'],
-  },
-});
+export default mergeConfig(base, defineConfig({}));

--- a/lambda/notify/vitest.config.js
+++ b/lambda/notify/vitest.config.js
@@ -1,4 +1,0 @@
-import { mergeConfig, defineConfig } from 'vitest/config';
-import base from '../../vitest.config.base.js';
-
-export default mergeConfig(base, defineConfig({}));

--- a/lambda/ws-authorizer/package.json
+++ b/lambda/ws-authorizer/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "vitest run --project=ws-authorizer",
+    "test:watch": "vitest --project=ws-authorizer",
     "build": "esbuild index.js --bundle --platform=node --target=node24 --format=esm --external:@aws-sdk/* --outfile=.build/index.mjs"
   },
   "dependencies": {

--- a/lambda/ws-authorizer/vitest.config.js
+++ b/lambda/ws-authorizer/vitest.config.js
@@ -1,8 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { mergeConfig, defineConfig } from 'vitest/config';
+import base from '../../vitest.config.base.js';
 
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.js'],
-    setupFiles: ['../../test/setup.js'],
-  },
-});
+export default mergeConfig(base, defineConfig({}));

--- a/lambda/ws-authorizer/vitest.config.js
+++ b/lambda/ws-authorizer/vitest.config.js
@@ -1,4 +1,0 @@
-import { mergeConfig, defineConfig } from 'vitest/config';
-import base from '../../vitest.config.base.js';
-
-export default mergeConfig(base, defineConfig({}));

--- a/lambda/ws-message/package.json
+++ b/lambda/ws-message/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "vitest run --project=ws-message",
+    "test:watch": "vitest --project=ws-message",
     "build": "esbuild index.js --bundle --platform=node --target=node24 --format=esm --external:@aws-sdk/* --outfile=.build/index.mjs"
   }
 }

--- a/lambda/ws-message/vitest.config.js
+++ b/lambda/ws-message/vitest.config.js
@@ -1,8 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { mergeConfig, defineConfig } from 'vitest/config';
+import base from '../../vitest.config.base.js';
 
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.js'],
-    setupFiles: ['../../test/setup.js'],
-  },
-});
+export default mergeConfig(base, defineConfig({}));

--- a/lambda/ws-message/vitest.config.js
+++ b/lambda/ws-message/vitest.config.js
@@ -1,4 +1,0 @@
-import { mergeConfig, defineConfig } from 'vitest/config';
-import base from '../../vitest.config.base.js';
-
-export default mergeConfig(base, defineConfig({}));

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lambda/ws-message"
   ],
   "scripts": {
-    "test": "npm test --workspaces --if-present"
+    "test": "vitest run"
   },
   "devDependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3.1040.0",

--- a/vitest.config.base.js
+++ b/vitest.config.base.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.js'],
+    setupFiles: [fileURLToPath(new URL('./test/setup.js', import.meta.url))],
+  },
+});

--- a/vitest.config.base.js
+++ b/vitest.config.base.js
@@ -1,9 +1,0 @@
-import { defineConfig } from 'vitest/config';
-import { fileURLToPath } from 'node:url';
-
-export default defineConfig({
-  test: {
-    include: ['test/**/*.test.js'],
-    setupFiles: [fileURLToPath(new URL('./test/setup.js', import.meta.url))],
-  },
-});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    projects: ['lambda/*/vitest.config.js'],
+  },
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,22 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { readdirSync, existsSync } from 'node:fs';
+
+const lambdaRoot = new URL('./lambda/', import.meta.url);
+const lambdas = readdirSync(fileURLToPath(lambdaRoot))
+  .filter((name) => existsSync(new URL(`${name}/test`, lambdaRoot)));
+
+const setupFiles = [fileURLToPath(new URL('./test/setup.js', import.meta.url))];
 
 export default defineConfig({
   test: {
-    projects: ['lambda/*/vitest.config.js'],
+    projects: lambdas.map((name) => ({
+      test: {
+        name,
+        root: fileURLToPath(new URL(name, lambdaRoot)),
+        include: ['test/**/*.test.js'],
+        setupFiles,
+      },
+    })),
   },
 });


### PR DESCRIPTION
## Summary

Collapse all vitest config across the repo into a **single** root `vitest.config.js`.

- Shared test settings (`include`, `setupFiles`) and per-project definitions live in one file.
- Project list is **fs-derived**: scans `lambda/` for subdirectories containing a `test/` folder. Adding a new testable lambda needs zero config edits.
- All lambda suites run in one Vitest process in parallel (~600ms) instead of chained per-workspace runs (~1.9s), with a single unified reporter output.
- Each workspace's `"test"` script uses `--project=<name>` so `npm test -w lambda/<name>` and `cd lambda/<name> && npm test` both still work — vitest walks up to the root config, then the flag filters.

### Why

Three identical per-workspace vitest configs; any shared concern (globalSetup, coverage, reporters) would otherwise need N edits. Mirrors what npm workspaces already do for dependencies.

### Ergonomics preserved
- `npm test` at the root — all projects in parallel (what CI runs).
- `vitest run --project=notify` — filter to one project from root.
- `npm test -w lambda/notify` — per-workspace invocation via `--project` filter.
- `cd lambda/notify && npm test` — same path.

### Files removed
- `vitest.config.base.js`
- `lambda/notify/vitest.config.js`
- `lambda/ws-authorizer/vitest.config.js`
- `lambda/ws-message/vitest.config.js`

## Test plan
- [x] `npm test` at repo root — 42 tests across 3 suites pass in a single Vitest process.
- [x] `npm test -w lambda/notify` — per-workspace invocation from root filters correctly (7 tests).
- [x] `cd lambda/notify && npm test` — same behaviour from inside the workspace.
- [x] CI (`.github/workflows/test.yml`, which calls `npm test`) green on this branch.