### PR TITLE
fix(terraform): declare s3 backend so -backend-config takes effect

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,6 +10,7 @@ terraform {
       version = "~> 3.0"
     }
   }
+  backend "s3" {}
 }
 
 provider "aws" {


### PR DESCRIPTION
  The root terraform block was missing `backend "s3" {}`, so Terraform
  silently fell back to the local backend and the per-environment
  `.s3.tfbackend` files passed via `terraform init -backend-config=...`
  in bootstrap.sh and destroy.sh were ignored.

  Closes #127

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
