### PR TITLE
fix(agents): preserve pre-assigned job on cold-start worker

### DIFF
--- a/lambda/agents-ecs/pool-worker.js
+++ b/lambda/agents-ecs/pool-worker.js
@@ -1064,8 +1064,27 @@ async function main() {
 
   console.log(`[pool-worker] Worker ${env.workerId} ready. Available CLIs: [${_availableClis.join(', ')}]`);
 
-  // Register as idle — advertises availableClis to the job dispatcher.
-  await setIdle();
+  // If the dispatcher pre-assigned a job to this worker (cold-start path where
+  // findIdleWorkers returned 0), the DDB row already has status='assigned' and
+  // a baked-in job. Honour that instead of overwriting it with setIdle, which
+  // would erase the job and leave the dispatcher with no worker for it.
+  const existing = await ddb.send(new GetCommand({
+    TableName: env.poolTable,
+    Key: { workerId: env.workerId },
+  }));
+  if (existing.Item?.status === 'assigned' && existing.Item.job) {
+    console.log(`[pool-worker] Found pre-assigned job on startup: ${existing.Item.job.executionId} — advertising clis without clearing job`);
+    // Advertise availableClis/version but preserve assigned status + job.
+    await ddb.send(new UpdateCommand({
+      TableName: env.poolTable,
+      Key: { workerId: env.workerId },
+      UpdateExpression: 'SET lastHeartbeat = :t, version = :v, availableClis = :clis, cliAuthErrors = :errs',
+      ExpressionAttributeValues: { ':t': Date.now(), ':v': env.version, ':clis': _availableClis, ':errs': _cliAuthErrors },
+    }));
+  } else {
+    // Register as idle — advertises availableClis to the job dispatcher.
+    await setIdle();
+  }
 
   // Heartbeat loop
   const heartbeat = setInterval(async () => {


### PR DESCRIPTION
## Summary
- Fixes a cold-start race in the agent pool dispatcher: when no idle workers exist, the freshly-launched ECS worker called `setIdle()` on startup, overwriting the dispatcher's pre-assigned job with `status='idle'` and `REMOVE job`. The job was orphaned and the user-facing request hung until the 45-minute stale-busy timeout.
- The worker now reads its own DDB row at startup. If `status='assigned'` and a `job` is present, it preserves them and only advertises `availableClis`/`version`/`lastHeartbeat`. Otherwise it goes idle as before.

## Diagnosis
Repro path:
1. Pool table empty (e.g. after pool drain or cold environment).
2. User dispatches an agent → `agents` lambda's `findIdleWorkers` returns `[]`.
3. Lambda calls `launchPoolWorker(wid)` and writes `status='assigned', job=<job>` to the worker's row.
4. ECS container boots (~50s), authenticates CLIs, and calls `setIdle()` → row overwritten to `status='idle'`, `job` removed.
5. Worker poll loop sees `status='idle'` (its own write) — never picks up the job.
6. UI hangs; request only fails after the stale-busy threshold (`STALE_BUSY_MS = 30 * 60 * 1000`) cleans things up.

The bug is dormant when the pool is pre-warmed (dispatch finds an idle worker and uses it directly), which is why it had not been caught until the pool was empty in our dev environment.

## Test plan
- [x] Drain pool, dispatch a new agent in dev — verify the freshly-launched worker logs `Found pre-assigned job on startup: <executionId>` and immediately picks up the job (`Got job: <executionId>`).
- [x] Verify a non-dispatch worker (launched via warm-pool path with no pre-assigned job) still calls `setIdle()` and goes idle correctly.