### PR TITLE
fix(questions): broadcast question.answered to other collaborators

### DIFF
--- a/frontend/src/hooks/useSprintEvents.ts
+++ b/frontend/src/hooks/useSprintEvents.ts
@@ -8,7 +8,8 @@ export type SprintEventType =
   | 'sprint.phaseChanged'
   | 'agent.question'
   | 'agent.artifacts'
-  | 'agent.completed';
+  | 'agent.completed'
+  | 'question.answered';
 
 interface SprintEvent {
   action: SprintEventType;
@@ -39,6 +40,7 @@ export function useSprintEvents(sprintId: string, onEvent: (event: SprintEvent) 
       'agent.question',
       'agent.artifacts',
       'agent.completed',
+      'question.answered',
     ];
 
     const unsubs = events.map((eventType) =>

--- a/frontend/src/pages/ConstructionPage.tsx
+++ b/frontend/src/pages/ConstructionPage.tsx
@@ -253,9 +253,7 @@ export default function ConstructionPage() {
     try {
       await questionsService.update(sprintId, questionId, { structuredAnswer: answer });
       realtimeService.send('broadcastToDocument', {
-        documentId: `sprint:${sprintId}`,
-        action: 'question.answered',
-        data: { questionId, answer },
+        data: { action: 'question.answered', sprintId, questionId },
       });
       timelineEventsService
         .create(sprintId, { type: 'question_answered', title: 'Answered agent question', userName })

--- a/frontend/src/pages/InceptionPage.tsx
+++ b/frontend/src/pages/InceptionPage.tsx
@@ -347,9 +347,7 @@ export default function InceptionPage() {
     try {
       await questionsService.update(sprintId, questionId, { structuredAnswer: answer });
       realtimeService.send('broadcastToDocument', {
-        documentId: `sprint:${sprintId}`,
-        action: 'question.answered',
-        data: { questionId, answer },
+        data: { action: 'question.answered', sprintId, questionId },
       });
       timelineEventsService
         .create(sprintId, {

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -248,9 +248,7 @@ export default function ReviewPage() {
     try {
       await questionsService.update(sprintId, questionId, { structuredAnswer: answer });
       realtimeService.send('broadcastToDocument', {
-        documentId: `sprint:${sprintId}`,
-        action: 'question.answered',
-        data: { questionId, answer },
+        data: { action: 'question.answered', sprintId, questionId },
       });
       await reload();
     } catch (err) {


### PR DESCRIPTION
## Summary

- Fixes #168 — when one collaborator submits an answer to a question, the question now disappears from other collaborators' browsers immediately (instead of staying open until the next poll cycle).
- The realtime broadcast was silently dropped because the call site put `action: 'question.answered'` at the same nesting level as the outer `action: 'broadcastToDocument'` — the spread inside `realtimeService.send` overwrote the routing action, so `ws-message` never broadcast it.
- Even if the broadcast had fired, `useSprintEvents` didn't subscribe to `question.answered`.

## Changes

- `frontend/src/pages/{Inception,Construction,Review}Page.tsx` — restructure the broadcast payload so the inner event sits inside `data`:
  ```ts
  realtimeService.send('broadcastToDocument', {
    data: { action: 'question.answered', sprintId, questionId },
  });
  ```
- `frontend/src/hooks/useSprintEvents.ts` — add `'question.answered'` to `SprintEventType` and the subscribed event list.

## Test plan

- [ ] `tsc --noEmit` passes.
- [ ] `npm run lint` (oxlint) passes with no new warnings (45 warnings, 0 errors — same as baseline).
- [ ] Manual: open the same sprint in two browser sessions; have User A answer a pending question; verify User B's question disappears immediately (no 10–60 s wait for the poll).
- [ ] Verify on Inception, Construction, and Review pages.