### PR TITLE
fix(github-lambda): bundle via esbuild + inline resolveGitToken

### DIFF
--- a/lambda/github/index.js
+++ b/lambda/github/index.js
@@ -6,14 +6,37 @@ import {
   DeleteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
-import { SSMClient, PutParameterCommand, DeleteParameterCommand } from '@aws-sdk/client-ssm';
+import {
+  SSMClient,
+  PutParameterCommand,
+  DeleteParameterCommand,
+  GetParameterCommand,
+} from '@aws-sdk/client-ssm';
 import crypto from 'crypto';
 import { buildResponse } from '../shared/response.js';
-import { resolveGitToken } from '../shared/git-token.js';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const secrets = new SecretsManagerClient({});
 const ssm = new SSMClient({});
+
+const GIT_TOKEN_PARAM_PATTERN = /^\/[\w-]+\/[\w-]+\/[\w-]+\/[\w-]+$/;
+
+// Inlined from shared/git-token.js — esbuild cannot bundle the CJS module
+// because it does `require('@aws-sdk/client-ssm')` which becomes a dynamic
+// require not supported in the ESM runtime. Mirrors the pattern adopted by
+// lambda/github-issues (see PR #180).
+const resolveGitToken = async (ssmClient, item) => {
+  if (item?.parameterName) {
+    if (!GIT_TOKEN_PARAM_PATTERN.test(item.parameterName)) {
+      throw new Error('Invalid SSM parameter name format');
+    }
+    const param = await ssmClient.send(
+      new GetParameterCommand({ Name: item.parameterName, WithDecryption: true }),
+    );
+    return JSON.parse(param.Parameter.Value).accessToken;
+  }
+  throw new Error('No SSM parameter name set');
+};
 
 class OAuthNotConfiguredError extends Error {
   constructor() {

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -668,17 +668,16 @@ module "github_lambda" {
 
   function_name = "${var.project_name}-github-${var.environment}"
   handler       = "index.handler"
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs24.x"
   timeout       = 30
 
   source_path = [
     {
-      path             = "${path.module}/../../../../lambda/github"
-      npm_requirements = true
-    },
-    {
-      path          = "${path.module}/../../../../lambda/shared"
-      prefix_in_zip = "shared"
+      path = "${path.module}/../../../../lambda/github"
+      commands = [
+        "cd ../.. && npm run build -w github-lambda",
+        ":zip lambda/github/.build",
+      ]
     }
   ]
 


### PR DESCRIPTION
## Problem

Two layered runtime regressions blocked `/api/github/*` endpoints in deployed environments:

1. **PR #176** ("Migrate lambda/github to ESM") changed `require('./shared/...')` to `import '../shared/response.js'`, but the Terraform packaging copied `shared/` at the same level as `index.js` in the zip. At runtime, the ESM resolver dereferenced `'../shared/response.js'` to `/var/shared/response.js` — one level above `/var/task/`, which doesn't exist. Every cold start threw `ERR_MODULE_NOT_FOUND`.

2. `shared/git-token.js` is CommonJS and uses `require('@aws-sdk/client-ssm')` at the module top level. Even after fixing the path, esbuild bundles a CJS shim that the Node.js ESM runtime rejects with `Dynamic require of "@aws-sdk/client-ssm" is not supported`.

## Solution

Apply the same packaging pattern adopted for `lambda/github-issues` in #180:

- **`terraform/modules/api/lambda/main.tf`**: replace `npm_requirements + prefix_in_zip='shared'` with the `commands + :zip` esbuild build pattern; bump runtime to `nodejs24.x` to match the workspace `--target=node24`.
- **`lambda/github/index.js`**: inline `resolveGitToken` locally (mirroring the pattern adopted by `lambda/github-issues`). `shared/response.js` continues to be imported from shared since it has no top-level `require` of an external package and esbuild can statically bundle it.

## Validation

- ✅ All 153 unit tests pass (7 test files)
- ✅ TypeScript clean
- ✅ Terraform validate clean
- ✅ Manual test on staging: `aws lambda invoke` returns `statusCode: 200` with valid JSON `{"connected": false}`
- ✅ `/api/github/status` returns proper JSON 401 (was returning HTML 200 before)

## Why inline `resolveGitToken` rather than refactor `shared/`

10+ other CJS lambdas import `shared/response` and `shared/git-token`. Migrating shared/ to ESM would force a coordinated rewrite of all of them, well beyond the scope of this fix. Inlining mirrors the pragmatic precedent set by #180.

Closes the regression introduced in #176.
