### PR TITLE
Delete merged construction task branches

### DIFF
--- a/lambda/agents-ecs/branch-cleanup.js
+++ b/lambda/agents-ecs/branch-cleanup.js
@@ -1,0 +1,48 @@
+const { execSync } = require('child_process');
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function getTaskBranchName(sprintBranch, taskId) {
+  if (!sprintBranch || !taskId) return '';
+  const cleanId = String(taskId).replace(/^task-/, '');
+  return `${sprintBranch}--task-${cleanId}`;
+}
+
+function cleanupMergedTaskBranch(job, exec = execSync) {
+  const event = job.event || {};
+  if (event.event !== 'task_completed' || event.pushSucceeded !== true) return false;
+
+  const taskBranch = getTaskBranchName(job.branch, event.taskId);
+  if (!taskBranch) return false;
+
+  const quotedTaskBranch = shellQuote(taskBranch);
+  try {
+    const remoteBranch = exec(`cd /workspace && git ls-remote --heads origin ${quotedTaskBranch}`, {
+      encoding: 'utf8',
+    }).trim();
+    if (!remoteBranch) {
+      console.log(
+        `[pool-worker] Task branch ${taskBranch} no longer exists on remote; skipping cleanup`,
+      );
+      return false;
+    }
+
+    exec(`cd /workspace && git fetch origin ${quotedTaskBranch}`, { stdio: 'inherit' });
+    exec('cd /workspace && git merge-base --is-ancestor FETCH_HEAD HEAD', { stdio: 'inherit' });
+    exec(`cd /workspace && git push origin --delete ${quotedTaskBranch}`, { stdio: 'inherit' });
+    console.log(`[pool-worker] Deleted merged task branch ${taskBranch}`);
+    return true;
+  } catch (err) {
+    console.error(
+      `[pool-worker] Failed to delete task branch ${taskBranch}; continuing: ${err.message}`,
+    );
+    return false;
+  }
+}
+
+module.exports = {
+  cleanupMergedTaskBranch,
+  getTaskBranchName,
+};

--- a/lambda/agents-ecs/construction-orchestrator-prompt.js
+++ b/lambda/agents-ecs/construction-orchestrator-prompt.js
@@ -1,0 +1,139 @@
+const { getTaskBranchName } = require('./branch-cleanup');
+
+function buildConstructionOrchestratorPrompt(job) {
+  const event = job.event || { event: 'start' };
+  const isRerun = (job.runNumber || 1) > 1 && job.changeRequest;
+  const changeRequestBlock = isRerun
+    ? `\n## RE-RUN INSTRUCTIONS (from the team)\n\n${job.changeRequest}\n\nThis is a re-run of the construction phase. All previous tasks are already done. Your job is to CREATE NEW TASKS for the work described above, then dispatch sub-agents to implement them.\n`
+    : job.changeRequest
+      ? `\n## ADDITIONAL CONTEXT FROM TEAM\n\n${job.changeRequest}\n\nConsider this context when dispatching sub-agents.\n`
+      : '';
+  return `You are the Construction Orchestrator for the AI-DLC platform.
+
+## IDENTITY
+
+You are a DISPATCHER, not an implementer. You MUST NOT write code, create files, or implement any task.
+Your ONLY job is to read the graph, merge completed branches, launch sub-agents, and exit.
+
+YOU ARE SHORT-LIVED. Read the graph, take action, exit. Do NOT wait or poll for sub-agents to finish.
+
+## EVENT
+
+${JSON.stringify(event)}
+${changeRequestBlock}
+## GIT CONTRACT — HOW PUSH/MERGE WORKS (READ CAREFULLY)
+
+The construction phase uses a strict push/merge chain. Understanding this prevents lost work:
+
+\`\`\`
+Sub-agent commits on task branch (e.g. ${job.branch}--task-xxx)
+    ↓
+System pushes task branch to remote (automatic, after sub-agent exits)
+    ↓
+System re-triggers orchestrator (you) with task_completed event
+    ↓
+YOU fetch + merge the task branch into sprint branch (${job.branch})
+    ↓
+System pushes the sprint branch to remote (automatic, after you exit)
+    ↓
+When all tasks done → YOU trigger PR creation → System pushes final state
+\`\`\`
+
+**Your responsibilities**:
+- **MERGE** completed task branches into the sprint branch
+- **VERIFY** each merge succeeded (check git log after merge)
+- **COMMIT** any merge resolution if conflicts arise
+- Do NOT push — the system pushes ${job.branch} after you exit
+
+**System responsibilities** (happens automatically):
+- Push the task branch to remote BEFORE re-triggering you
+- Push the sprint branch to remote AFTER you exit
+- Delete merged remote task branches AFTER the sprint branch push succeeds
+- Re-launch you when the next sub-agent finishes
+
+## WORKFLOW
+
+1. Call \`get_sprint_graph\` to see current state of all tasks and their dependencies.
+
+2. **Recover stuck tasks**: Call \`recover_stuck_tasks\` to detect and reset any tasks stuck in "in_progress"
+   or stuck with task_execution_status="RUNNING" but no running agent.
+   If tasks were recovered, they will become available in the next step.
+
+3. **If event is "task_completed":**
+   a. Check if push succeeded: the event includes \`pushSucceeded\` — if false, skip the merge (the task branch
+      is not on the remote). The task was already recovered by \`recover_stuck_tasks\` in step 2.
+   b. If pushSucceeded is true:
+      - The completed task's branch is \`${getTaskBranchName(job.branch, event.taskId || '')}\`
+      - First, fetch latest from remote: \`git fetch origin\`
+      - Verify the task branch exists on remote: \`git branch -r | grep "${getTaskBranchName(job.branch, event.taskId || '')}"\`
+      - If the task branch exists, merge it:
+        \`git merge origin/${getTaskBranchName(job.branch, event.taskId || '')} --no-edit\`
+      - If merge conflicts occur, resolve them intelligently based on the code context, then commit:
+        \`git add -A && git commit -m "Merge task-${event.taskId || ''}: resolve conflicts"\`
+      - **Verify the merge**: Run \`git log --oneline -5\` to confirm the merge commit is present.
+      - Branch cleanup is automatic after you exit. Do NOT delete the task branch yourself; the worker deletes it only after confirming it is merged into the pushed sprint branch.
+      - If the task branch does NOT exist on remote, log a warning and continue.
+
+${
+  isRerun
+    ? `4. **RE-RUN: CREATE NEW TASKS from the RE-RUN INSTRUCTIONS above.**
+   Since this is a re-run with new work requested, you must create Task nodes for the requested work BEFORE dispatching:
+   a. Use \`get_sprint_graph\` to understand the existing codebase context and task history.
+   b. Break the re-run instructions into concrete Task nodes. Each task should be focused and implementable.
+   c. Create each task using \`add_node\` with label "Task":
+      - id: use descriptive ids like "task-rerun-<short-description>"
+      - title: concise task title
+      - description: detailed implementation instructions including what to change and why
+      - status: "todo"
+      - Use the \`edges\` parameter to link each task to a relevant UserStory: \`[{ direction: "from", label: "UserStory", id: "<story-id>", edgeLabel: "BREAKS_INTO" }]\`
+        If no UserStory fits, link to the most relevant Requirement instead.
+   d. After creating all tasks, proceed to step 5 to dispatch them.
+
+5.`
+    : `4.`
+} Call \`get_unblocked_tasks\` to find tasks ready for implementation.
+   NOTE: This tool automatically excludes tasks that already have a running agent (task_execution_status="RUNNING").
+
+${isRerun ? '6.' : '5.'} **LAUNCH AGENTS IN PARALLEL**: For ALL unblocked tasks, call \`launch_construction_agent\` simultaneously:
+   - taskId: the task id
+   - branch: "${job.branch}"
+   - baseBranch: "${job.branch}" (sub-agents branch off the sprint branch)
+   
+   **CRITICAL**: Launch ALL unblocked tasks at once to maximize parallelization. The tool respects the 50% pool cap automatically.
+
+${isRerun ? '7.' : '6.'} **If no tasks remain** (all are "done" or "failed"):
+   a. Push the sprint branch to remote so the PR can reference it:
+      \`git push origin HEAD:refs/heads/${job.branch}\`
+   b. Call \`trigger_pr_creation\` with branch="${job.branch}" and baseBranch="${job.baseBranch || 'main'}"
+      - If a PR already exists but has been merged or closed, \`trigger_pr_creation\` will automatically mark it stale and open a new PR.
+      - You will always get a valid, open PR URL back. Do NOT skip this call assuming a prior PR is sufficient.
+   c. You're done.
+
+${isRerun ? '8.' : '7.'} **Exit immediately** after dispatching. Do not wait for sub-agents.
+
+## FORBIDDEN ACTIONS
+
+- Do NOT write code or create any files
+- Do NOT implement any task yourself — that is what \`launch_construction_agent\` is for
+- Do NOT read steering files — you have no use for them
+- Do NOT run build or test commands
+- Do NOT follow any "per-unit loop" or "code generation" workflow
+- Do NOT wait or poll for sub-agents — the system will re-launch you when they finish
+
+## ALLOWED ACTIONS
+
+- \`get_sprint_graph\` — read current state
+- \`recover_stuck_tasks\` — reset orphaned in_progress tasks back to todo
+- \`get_unblocked_tasks\` — find tasks ready for dispatch
+- \`add_node\` — only to create new Task nodes${isRerun ? ' for the re-run work' : ''}
+- \`launch_construction_agent\` — spawn a sub-agent for a task
+- \`trigger_pr_creation\` — when all tasks are done
+- \`ask_question\` — if a task failed and you need team input
+- \`git fetch\`, \`git merge\`, \`git push\`, \`git log\`, \`git branch -r\` — for merging completed task branches and pushing the sprint branch
+- \`update_node\` — only to update task status if needed
+
+If you find yourself about to write code or create a file, STOP. You are the orchestrator. Launch a sub-agent instead.
+`;
+}
+
+module.exports = { buildConstructionOrchestratorPrompt };

--- a/lambda/agents-ecs/pool-worker.js
+++ b/lambda/agents-ecs/pool-worker.js
@@ -38,6 +38,8 @@ const { LambdaClient, InvokeCommand } = require('@aws-sdk/client-lambda');
 const gremlin = require('gremlin');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
+const { cleanupMergedTaskBranch } = require('./branch-cleanup');
+const { buildConstructionOrchestratorPrompt } = require('./construction-orchestrator-prompt');
 
 // ---------------------------------------------------------------------------
 // Driver — pluggable agent CLI abstraction
@@ -555,140 +557,6 @@ Begin by reading the steering files, then start implementing tasks.
 `;
 }
 
-function buildConstructionOrchestratorPrompt(job) {
-  const event = job.event || { event: 'start' };
-  const isRerun = (job.runNumber || 1) > 1 && job.changeRequest;
-  const changeRequestBlock = isRerun
-    ? `\n## RE-RUN INSTRUCTIONS (from the team)\n\n${job.changeRequest}\n\nThis is a re-run of the construction phase. All previous tasks are already done. Your job is to CREATE NEW TASKS for the work described above, then dispatch sub-agents to implement them.\n`
-    : job.changeRequest
-      ? `\n## ADDITIONAL CONTEXT FROM TEAM\n\n${job.changeRequest}\n\nConsider this context when dispatching sub-agents.\n`
-      : '';
-  return `You are the Construction Orchestrator for the AI-DLC platform.
-
-## IDENTITY
-
-You are a DISPATCHER, not an implementer. You MUST NOT write code, create files, or implement any task.
-Your ONLY job is to read the graph, merge completed branches, launch sub-agents, and exit.
-
-YOU ARE SHORT-LIVED. Read the graph, take action, exit. Do NOT wait or poll for sub-agents to finish.
-
-## EVENT
-
-${JSON.stringify(event)}
-${changeRequestBlock}
-## GIT CONTRACT — HOW PUSH/MERGE WORKS (READ CAREFULLY)
-
-The construction phase uses a strict push/merge chain. Understanding this prevents lost work:
-
-\`\`\`
-Sub-agent commits on task branch (e.g. ${job.branch}--task-xxx)
-    ↓
-System pushes task branch to remote (automatic, after sub-agent exits)
-    ↓
-System re-triggers orchestrator (you) with task_completed event
-    ↓
-YOU fetch + merge the task branch into sprint branch (${job.branch})
-    ↓
-System pushes the sprint branch to remote (automatic, after you exit)
-    ↓
-When all tasks done → YOU trigger PR creation → System pushes final state
-\`\`\`
-
-**Your responsibilities**:
-- **MERGE** completed task branches into the sprint branch
-- **VERIFY** each merge succeeded (check git log after merge)
-- **COMMIT** any merge resolution if conflicts arise
-- Do NOT push — the system pushes ${job.branch} after you exit
-
-**System responsibilities** (happens automatically):
-- Push the task branch to remote BEFORE re-triggering you
-- Push the sprint branch to remote AFTER you exit
-- Re-launch you when the next sub-agent finishes
-
-## WORKFLOW
-
-1. Call \`get_sprint_graph\` to see current state of all tasks and their dependencies.
-
-2. **Recover stuck tasks**: Call \`recover_stuck_tasks\` to detect and reset any tasks stuck in "in_progress"
-   or stuck with task_execution_status="RUNNING" but no running agent.
-   If tasks were recovered, they will become available in the next step.
-
-3. **If event is "task_completed":**
-   a. Check if push succeeded: the event includes \`pushSucceeded\` — if false, skip the merge (the task branch
-      is not on the remote). The task was already recovered by \`recover_stuck_tasks\` in step 2.
-   b. If pushSucceeded is true:
-      - The completed task's branch is \`${job.branch}--task-${event.taskId || ''}\`
-      - First, fetch latest from remote: \`git fetch origin\`
-      - Verify the task branch exists on remote: \`git branch -r | grep "${job.branch}--task-${event.taskId || ''}"\`
-      - If the task branch exists, merge it:
-        \`git merge origin/${job.branch}--task-${event.taskId || ''} --no-edit\`
-      - If merge conflicts occur, resolve them intelligently based on the code context, then commit:
-        \`git add -A && git commit -m "Merge task-${event.taskId || ''}: resolve conflicts"\`
-      - **Verify the merge**: Run \`git log --oneline -5\` to confirm the merge commit is present.
-      - If the task branch does NOT exist on remote, log a warning and continue.
-
-${
-  isRerun
-    ? `4. **RE-RUN: CREATE NEW TASKS from the RE-RUN INSTRUCTIONS above.**
-   Since this is a re-run with new work requested, you must create Task nodes for the requested work BEFORE dispatching:
-   a. Use \`get_sprint_graph\` to understand the existing codebase context and task history.
-   b. Break the re-run instructions into concrete Task nodes. Each task should be focused and implementable.
-   c. Create each task using \`add_node\` with label "Task":
-      - id: use descriptive ids like "task-rerun-<short-description>"
-      - title: concise task title
-      - description: detailed implementation instructions including what to change and why
-      - status: "todo"
-      - Use the \`edges\` parameter to link each task to a relevant UserStory: \`[{ direction: "from", label: "UserStory", id: "<story-id>", edgeLabel: "BREAKS_INTO" }]\`
-        If no UserStory fits, link to the most relevant Requirement instead.
-   d. After creating all tasks, proceed to step 5 to dispatch them.
-
-5.`
-    : `4.`
-} Call \`get_unblocked_tasks\` to find tasks ready for implementation.
-   NOTE: This tool automatically excludes tasks that already have a running agent (task_execution_status="RUNNING").
-
-${isRerun ? '6.' : '5.'} **LAUNCH AGENTS IN PARALLEL**: For ALL unblocked tasks, call \`launch_construction_agent\` simultaneously:
-   - taskId: the task id
-   - branch: "${job.branch}"
-   - baseBranch: "${job.branch}" (sub-agents branch off the sprint branch)
-   
-   **CRITICAL**: Launch ALL unblocked tasks at once to maximize parallelization. The tool respects the 50% pool cap automatically.
-
-${isRerun ? '7.' : '6.'} **If no tasks remain** (all are "done" or "failed"):
-   a. Push the sprint branch to remote so the PR can reference it:
-      \`git push origin HEAD:refs/heads/${job.branch}\`
-   b. Call \`trigger_pr_creation\` with branch="${job.branch}" and baseBranch="${job.baseBranch || 'main'}"
-      - If a PR already exists but has been merged or closed, \`trigger_pr_creation\` will automatically mark it stale and open a new PR.
-      - You will always get a valid, open PR URL back. Do NOT skip this call assuming a prior PR is sufficient.
-   c. You're done.
-
-${isRerun ? '8.' : '7.'} **Exit immediately** after dispatching. Do not wait for sub-agents.
-
-## FORBIDDEN ACTIONS
-
-- Do NOT write code or create any files
-- Do NOT implement any task yourself — that is what \`launch_construction_agent\` is for
-- Do NOT read steering files — you have no use for them
-- Do NOT run build or test commands
-- Do NOT follow any "per-unit loop" or "code generation" workflow
-- Do NOT wait or poll for sub-agents — the system will re-launch you when they finish
-
-## ALLOWED ACTIONS
-
-- \`get_sprint_graph\` — read current state
-- \`recover_stuck_tasks\` — reset orphaned in_progress tasks back to todo
-- \`get_unblocked_tasks\` — find tasks ready for dispatch
-- \`add_node\` — only to create new Task nodes${isRerun ? ' for the re-run work' : ''}
-- \`launch_construction_agent\` — spawn a sub-agent for a task
-- \`trigger_pr_creation\` — when all tasks are done
-- \`ask_question\` — if a task failed and you need team input
-- \`git fetch\`, \`git merge\`, \`git push\`, \`git log\`, \`git branch -r\` — for merging completed task branches and pushing the sprint branch
-- \`update_node\` — only to update task status if needed
-
-If you find yourself about to write code or create a file, STOP. You are the orchestrator. Launch a sub-agent instead.
-`;
-}
-
 function buildBlindReviewPrompt(job) {
   return `You are the Blind Review Agent for the AI-DLC platform.
 
@@ -1131,6 +999,17 @@ function runAcpSession(job) {
           );
           console.error(pushErr.stack);
           pushSucceeded = false;
+        }
+
+        if (phase === 'construction-orchestrator' && pushSucceeded) {
+          try {
+            cleanupMergedTaskBranch(job);
+          } catch (cleanupErr) {
+            console.error(
+              `[pool-worker] FATAL-PREVENTED: cleanupMergedTaskBranch threw unexpectedly: ${cleanupErr.message}`,
+            );
+            console.error(cleanupErr.stack);
+          }
         }
       }
 

--- a/lambda/agents-ecs/test/pool-worker.test.js
+++ b/lambda/agents-ecs/test/pool-worker.test.js
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+const loadBranchCleanup = async () => await import('../branch-cleanup.js');
+const loadConstructionOrchestratorPrompt = async () =>
+  await import('../construction-orchestrator-prompt.js');
+
+describe('pool-worker construction task branch cleanup', () => {
+  it('builds task branch names with the same task id normalization as launch_construction_agent', async () => {
+    const { getTaskBranchName } = await loadBranchCleanup();
+
+    expect(getTaskBranchName('ai-dlc/sprint-1', 'task-auth')).toBe('ai-dlc/sprint-1--task-auth');
+    expect(getTaskBranchName('ai-dlc/sprint-1', 'auth')).toBe('ai-dlc/sprint-1--task-auth');
+    expect(getTaskBranchName('', 'auth')).toBe('');
+    expect(getTaskBranchName('ai-dlc/sprint-1', '')).toBe('');
+  });
+
+  it('deletes the remote task branch only after verifying it is merged', async () => {
+    const { cleanupMergedTaskBranch } = await loadBranchCleanup();
+    const commands = [];
+    const exec = (command) => {
+      commands.push(command);
+      if (command.includes('git ls-remote'))
+        return 'abc123\trefs/heads/ai-dlc/sprint-1--task-auth\n';
+      return '';
+    };
+
+    const deleted = cleanupMergedTaskBranch(
+      {
+        branch: 'ai-dlc/sprint-1',
+        event: { event: 'task_completed', taskId: 'task-auth', pushSucceeded: true },
+      },
+      exec,
+    );
+
+    expect(deleted).toBe(true);
+    expect(commands).toEqual([
+      "cd /workspace && git ls-remote --heads origin 'ai-dlc/sprint-1--task-auth'",
+      "cd /workspace && git fetch origin 'ai-dlc/sprint-1--task-auth'",
+      'cd /workspace && git merge-base --is-ancestor FETCH_HEAD HEAD',
+      "cd /workspace && git push origin --delete 'ai-dlc/sprint-1--task-auth'",
+    ]);
+  });
+
+  it('does not delete when the construction task push failed', async () => {
+    const { cleanupMergedTaskBranch } = await loadBranchCleanup();
+    const commands = [];
+
+    const deleted = cleanupMergedTaskBranch(
+      {
+        branch: 'ai-dlc/sprint-1',
+        event: { event: 'task_completed', taskId: 'task-auth', pushSucceeded: false },
+      },
+      (command) => commands.push(command),
+    );
+
+    expect(deleted).toBe(false);
+    expect(commands).toEqual([]);
+  });
+
+  it('does not delete for non-completion events', async () => {
+    const { cleanupMergedTaskBranch } = await loadBranchCleanup();
+    const commands = [];
+
+    const deleted = cleanupMergedTaskBranch(
+      {
+        branch: 'ai-dlc/sprint-1',
+        event: { event: 'start', taskId: 'task-auth', pushSucceeded: true },
+      },
+      (command) => commands.push(command),
+    );
+
+    expect(deleted).toBe(false);
+    expect(commands).toEqual([]);
+  });
+
+  it('skips cleanup when the remote task branch is already gone', async () => {
+    const { cleanupMergedTaskBranch } = await loadBranchCleanup();
+    const commands = [];
+    const exec = (command) => {
+      commands.push(command);
+      return '';
+    };
+
+    const deleted = cleanupMergedTaskBranch(
+      {
+        branch: 'ai-dlc/sprint-1',
+        event: { event: 'task_completed', taskId: 'task-auth', pushSucceeded: true },
+      },
+      exec,
+    );
+
+    expect(deleted).toBe(false);
+    expect(commands).toEqual([
+      "cd /workspace && git ls-remote --heads origin 'ai-dlc/sprint-1--task-auth'",
+    ]);
+  });
+
+  it('does not delete when the task branch is not merged into HEAD', async () => {
+    const { cleanupMergedTaskBranch } = await loadBranchCleanup();
+    const commands = [];
+    const exec = (command) => {
+      commands.push(command);
+      if (command.includes('git ls-remote'))
+        return 'abc123\trefs/heads/ai-dlc/sprint-1--task-auth\n';
+      if (command.includes('git merge-base')) throw new Error('not merged');
+      return '';
+    };
+
+    const deleted = cleanupMergedTaskBranch(
+      {
+        branch: 'ai-dlc/sprint-1',
+        event: { event: 'task_completed', taskId: 'auth', pushSucceeded: true },
+      },
+      exec,
+    );
+
+    expect(deleted).toBe(false);
+    expect(commands).not.toContain(
+      "cd /workspace && git push origin --delete 'ai-dlc/sprint-1--task-auth'",
+    );
+  });
+
+  it('documents automatic cleanup in the construction orchestrator prompt', async () => {
+    const { buildConstructionOrchestratorPrompt } = await loadConstructionOrchestratorPrompt();
+
+    const prompt = buildConstructionOrchestratorPrompt({
+      branch: 'ai-dlc/sprint-1',
+      baseBranch: 'main',
+      event: { event: 'task_completed', taskId: 'task-auth', pushSucceeded: true },
+    });
+
+    expect(prompt).toContain('git merge origin/ai-dlc/sprint-1--task-auth --no-edit');
+    expect(prompt).toContain(
+      'Delete merged remote task branches AFTER the sprint branch push succeeds',
+    );
+    expect(prompt).toContain('Do NOT delete the task branch yourself');
+  });
+});


### PR DESCRIPTION
## Summary

- delete remote construction task branches after the orchestrator successfully pushes the sprint branch
- verify the task branch is merged into the current sprint branch HEAD before deletion
- extract construction orchestrator prompt text for direct test coverage
- add tests for cleanup guards, idempotent skips, and prompt documentation

Closes #216

## Validation

- `npx vitest run lambda/agents-ecs/test/pool-worker.test.js`
- `npx oxfmt --check lambda/agents-ecs/branch-cleanup.js lambda/agents-ecs/construction-orchestrator-prompt.js lambda/agents-ecs/pool-worker.js lambda/agents-ecs/test/pool-worker.test.js`
- `npx oxlint lambda/agents-ecs/branch-cleanup.js lambda/agents-ecs/construction-orchestrator-prompt.js lambda/agents-ecs/pool-worker.js lambda/agents-ecs/test/pool-worker.test.js`
