### PR TITLE
Fix agent startup hangs from broken MCP servers

### DIFF
--- a/frontend/src/components/settings/McpServersSection.tsx
+++ b/frontend/src/components/settings/McpServersSection.tsx
@@ -85,6 +85,13 @@ export function McpServersSection({
       </CardHeader>
       <CardContent className="space-y-3">
         <p className="text-xs text-muted-foreground">{description}</p>
+        {canEdit && (
+          <p className="text-[11px] text-muted-foreground">
+            Stdio MCP servers can use these agent image commands: <code>node</code>,{' '}
+            <code>npx</code>, <code>uv</code>, <code>uvx</code>, <code>python</code>,{' '}
+            <code>python3</code>. Use an absolute path for any other executable.
+          </p>
+        )}
         <Textarea
           value={value}
           onChange={(e) => {
@@ -97,7 +104,7 @@ export function McpServersSection({
           )}
           spellCheck={false}
           disabled={!canEdit}
-          placeholder='[{"name":"my-tool","command":"npx","args":["-y","my-mcp-server"]}]'
+          placeholder='[{"name":"my-tool","command":"npx","args":["-y","my-mcp-server"],"env":[]}]'
         />
         {error && (
           <p className="text-[11px] text-destructive flex items-start gap-1">

--- a/frontend/src/hooks/useAgentStatus.ts
+++ b/frontend/src/hooks/useAgentStatus.ts
@@ -53,6 +53,13 @@ class SeqDeduplicator {
   }
 }
 
+function formatAgentErrorMessage(message?: string) {
+  return `\n\n### Agent failed\n\n${
+    message ||
+    'The agent failed before it could complete. Please check the agent settings and try again.'
+  }\n`;
+}
+
 export function useAgentStatus({
   executionArn,
   executionId,
@@ -143,6 +150,15 @@ export function useAgentStatus({
           streamBuffer.current = execStatus.outputText;
           setStreamingText(execStatus.outputText);
           setCompletedOutput(execStatus.outputText);
+        } else if (
+          execStatus.status === 'FAILED' &&
+          execStatus.errorMessage &&
+          !streamBuffer.current
+        ) {
+          const text = formatAgentErrorMessage(execStatus.errorMessage);
+          streamBuffer.current = text;
+          setStreamingText(text);
+          setCompletedOutput(text);
         }
       }
       if (questionsRes) setQuestions(questionsRes.questions || []);
@@ -225,8 +241,14 @@ export function useAgentStatus({
       realtimeService.on('agent.artifacts', () => {
         setArtifactsUpdated((prev) => prev + 1);
       }),
-      realtimeService.on('agent.error', () => {
+      realtimeService.on('agent.error', (data) => {
+        if (data.agentTaskId) return;
         setStatus((prev) => (prev ? { ...prev, status: 'FAILED' } : prev));
+        const message = data.error || data.message;
+        if (message && !streamBuffer.current.includes(message)) {
+          streamBuffer.current += formatAgentErrorMessage(message);
+          setStreamingText(streamBuffer.current);
+        }
         // Still save whatever we got as completed output
         if (streamBuffer.current) {
           setCompletedOutput(streamBuffer.current);

--- a/frontend/src/hooks/useConstructionStatus.ts
+++ b/frontend/src/hooks/useConstructionStatus.ts
@@ -46,6 +46,13 @@ class SeqDeduplicator {
   }
 }
 
+function formatAgentErrorMessage(message?: string) {
+  return `\n\n### Agent failed\n\n${
+    message ||
+    'The agent failed before it could complete. Please check the agent settings and try again.'
+  }\n`;
+}
+
 export function useConstructionStatus({
   projectId,
   sprintId,
@@ -215,6 +222,33 @@ export function useConstructionStatus({
         }
       }),
       realtimeService.on('agent.completed', () => {
+        refreshTasks();
+        refreshOrchestrator();
+      }),
+      realtimeService.on('agent.error', (data) => {
+        const taskId = data.agentTaskId || 'orchestrator';
+        const message = data.error || data.message;
+        const text = formatAgentErrorMessage(message);
+        if (!streamBuffers.current[taskId]?.includes(message || text)) {
+          streamBuffers.current[taskId] = (streamBuffers.current[taskId] || '') + text;
+        }
+
+        if (taskId === 'orchestrator' || !data.agentTaskId) {
+          setOrchestratorStream((prev) => ({
+            ...prev,
+            text: streamBuffers.current[taskId],
+            activeToolCall: null,
+          }));
+        } else {
+          setTaskStreams((prev) => ({
+            ...prev,
+            [taskId]: {
+              text: streamBuffers.current[taskId],
+              activeToolCall: null,
+              toolCalls: prev[taskId]?.toolCalls || [],
+            },
+          }));
+        }
         refreshTasks();
         refreshOrchestrator();
       }),

--- a/frontend/src/hooks/useReviewAgents.ts
+++ b/frontend/src/hooks/useReviewAgents.ts
@@ -58,6 +58,13 @@ class SeqDeduplicator {
   }
 }
 
+function formatAgentErrorMessage(message?: string) {
+  return `\n\n### Agent failed\n\n${
+    message ||
+    'The agent failed before it could complete. Please check the agent settings and try again.'
+  }\n`;
+}
+
 export function useReviewAgents({ projectId, sprintId }: UseReviewAgentsOptions) {
   const [blindAgent, setBlindAgent] = useState<AgentState>(initialAgentState);
   const [fullAgent, setFullAgent] = useState<AgentState>(initialAgentState);
@@ -348,13 +355,37 @@ export function useReviewAgents({ projectId, sprintId }: UseReviewAgentsOptions)
         const type = resolveAgentType(data);
         if (!type) return;
 
+        const message = data.error || data.message;
+        if (message) {
+          const text = formatAgentErrorMessage(message);
+          if (type === 'review-blind' && !blindBuffer.current.includes(message)) {
+            blindBuffer.current += text;
+          } else if (type === 'review-full' && !fullBuffer.current.includes(message)) {
+            fullBuffer.current += text;
+          } else if (type === 'review-modify' && !modifyBuffer.current.includes(message)) {
+            modifyBuffer.current += text;
+          }
+        }
+
         const setter =
           type === 'review-blind'
             ? setBlindAgent
             : type === 'review-full'
               ? setFullAgent
               : setModifyAgent;
-        setter((prev) => ({ ...prev, status: 'FAILED', activeToolCall: null }));
+        const buffer =
+          type === 'review-blind'
+            ? blindBuffer.current
+            : type === 'review-full'
+              ? fullBuffer.current
+              : modifyBuffer.current;
+        setter((prev) => ({
+          ...prev,
+          status: 'FAILED',
+          activeToolCall: null,
+          streamingText: buffer,
+          completedOutput: buffer,
+        }));
       }),
 
       realtimeService.on('agent.started', (data) => {

--- a/frontend/src/services/agents.ts
+++ b/frontend/src/services/agents.ts
@@ -8,6 +8,7 @@ export interface AgentExecution {
   status?: 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'TIMED_OUT' | 'ABORTED';
   output?: string;
   outputText?: string;
+  errorMessage?: string;
 }
 
 export interface AgentQuestion {

--- a/lambda/.dockerignore
+++ b/lambda/.dockerignore
@@ -1,0 +1,11 @@
+# Keep Lambda Docker build contexts small and stable.
+node_modules
+**/node_modules
+package-lock.json
+**/package-lock.json
+.git
+.gitignore
+test
+**/test
+*.test.js
+.dockerignore

--- a/lambda/agents-ecs/Dockerfile
+++ b/lambda/agents-ecs/Dockerfile
@@ -46,28 +46,29 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && chmod -R a+rX "$UV_PYTHON_INSTALL_DIR"
 
 # Embed AI-DLC workflow rules
-COPY aidlc-rules /opt/aidlc-rules
+COPY agents-ecs/aidlc-rules /opt/aidlc-rules
 
 # Install MCP server
-COPY mcp-server-graph/package.json mcp-server-graph/index.js /opt/mcp-server-graph/
+COPY agents-ecs/mcp-server-graph/package.json agents-ecs/mcp-server-graph/index.js /opt/mcp-server-graph/
 RUN cd /opt/mcp-server-graph && npm install --production
 
 # Install ACP client (includes drivers)
-COPY package.json /opt/acp-client/package.json
+COPY agents-ecs/package.json /opt/acp-client/package.json
 RUN cd /opt/acp-client && npm install --production
 
 ARG IMAGE_TAG=latest
 ENV IMAGE_TAG=${IMAGE_TAG}
 
-COPY acp-client.js pool-worker.js branch-cleanup.js construction-orchestrator-prompt.js /opt/acp-client/
-COPY drivers/ /opt/acp-client/drivers/
+COPY agents-ecs/acp-client.js agents-ecs/pool-worker.js agents-ecs/branch-cleanup.js agents-ecs/construction-orchestrator-prompt.js /opt/acp-client/
+COPY agents-ecs/drivers/ /opt/acp-client/drivers/
+COPY shared/mcp-validator.js /opt/shared/mcp-validator.js
 
 RUN mkdir -p /workspace \
     && chown -R node:node /workspace /opt/aidlc-rules /opt/mcp-server-graph /opt/acp-client /opt/kiro
 
 WORKDIR /workspace
 
-COPY --chown=node:node entrypoint.sh /entrypoint.sh
+COPY --chown=node:node agents-ecs/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 USER node

--- a/lambda/agents-ecs/acp-client.js
+++ b/lambda/agents-ecs/acp-client.js
@@ -20,6 +20,7 @@ const { getDriver } = require('./drivers');
 const AGENT_CLI = process.env.AGENT_CLI || 'kiro';
 const driver = getDriver(AGENT_CLI);
 const ACP_VERBOSE = process.env.ACP_VERBOSE === 'true';
+const DEFAULT_REQUEST_TIMEOUT_MS = parseInt(process.env.ACP_REQUEST_TIMEOUT_MS || '120000', 10);
 
 // ---------------------------------------------------------------------------
 // MCP servers — merged from global (SSM), project (Neptune), task (Neptune)
@@ -141,11 +142,28 @@ const env = {
   region: process.env.AWS_REGION || 'us-east-1',
 };
 
+function toNeptuneSignerCredentials(credentials, region) {
+  return {
+    accessKeyId: credentials.accessKeyId,
+    accessKey: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    secretKey: credentials.secretAccessKey,
+    sessionToken: credentials.sessionToken,
+    region,
+  };
+}
+
 const getConnection = async () => {
   if (!env.neptuneEndpoint) return null;
   const credentials = await fromNodeProviderChain()();
-  credentials.region = env.region;
-  const connInfo = getUrlAndHeaders(env.neptuneEndpoint, '8182', credentials, '/gremlin', 'wss');
+  const signerCredentials = toNeptuneSignerCredentials(credentials, env.region);
+  const connInfo = getUrlAndHeaders(
+    env.neptuneEndpoint,
+    '8182',
+    signerCredentials,
+    '/gremlin',
+    'wss',
+  );
   return new DriverRemoteConnection(connInfo.url, { headers: connInfo.headers });
 };
 
@@ -176,11 +194,36 @@ function send(method, params) {
   return id;
 }
 
-function request(method, params) {
+function request(method, params, options = {}) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   return new Promise((resolve, reject) => {
     const id = send(method, params);
-    pending.set(id, { resolve, reject });
+    const timer =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            pending.delete(id);
+            reject(new Error(`${method} timed out after ${timeoutMs}ms`));
+          }, timeoutMs)
+        : null;
+    pending.set(id, { method, resolve, reject, timer });
   });
+}
+
+function settlePending(id, settle, value) {
+  const entry = pending.get(id);
+  if (!entry) return false;
+  pending.delete(id);
+  if (entry.timer) clearTimeout(entry.timer);
+  entry[settle](value);
+  return true;
+}
+
+function rejectAllPending(err) {
+  for (const [id, entry] of pending) {
+    pending.delete(id);
+    if (entry.timer) clearTimeout(entry.timer);
+    entry.reject(err);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -308,7 +351,6 @@ async function saveStatus(status) {
     console.log(`[acp] Status already saved, skipping duplicate saveStatus('${status}')`);
     return;
   }
-  statusSaved = true;
   try {
     await ddb.send(
       new PutCommand({
@@ -326,9 +368,16 @@ async function saveStatus(status) {
         },
       }),
     );
+    statusSaved = true;
+    console.log(`[acp] Wrote AgentOutputs status '${status}' for ${env.executionId}`);
+  } catch (err) {
+    console.error('[acp] Failed to write AgentOutputs status:', err.message);
+    return;
+  }
 
-    // Update Sprint vertex with completion status
-    if (env.sprintId) {
+  // Update Sprint vertex with completion status
+  if (env.sprintId) {
+    try {
       await withNeptune(async (g) => {
         const { cardinality } = gremlin.process;
         const agentStatus = status === 'completed' ? 'completed' : 'failed';
@@ -339,12 +388,17 @@ async function saveStatus(status) {
           .property(cardinality.single, 'agent_completed_at', new Date().toISOString())
           .next();
       });
+      console.log(`[acp] Updated Sprint ${env.sprintId} status to '${status}'`);
+    } catch (err) {
+      console.error('[acp] Failed to update Sprint status in Neptune:', err.message);
     }
+  }
 
-    // Clear task_execution_status on the Task vertex so the orchestrator knows this agent is done.
-    // Without this, task_execution_status stays "RUNNING" forever and the orchestrator
-    // thinks an agent is still working on the task.
-    if (env.agentTaskId) {
+  // Clear task_execution_status on the Task vertex so the orchestrator knows this agent is done.
+  // Without this, task_execution_status stays "RUNNING" forever and the orchestrator
+  // thinks an agent is still working on the task.
+  if (env.agentTaskId) {
+    try {
       await withNeptune(async (g) => {
         const { cardinality } = gremlin.process;
         const execStatus = status === 'completed' ? 'COMPLETED' : 'FAILED';
@@ -355,9 +409,9 @@ async function saveStatus(status) {
           .next();
         console.log(`[acp] Updated task ${env.agentTaskId} task_execution_status to ${execStatus}`);
       });
+    } catch (err) {
+      console.error('[acp] Failed to update Task status in Neptune:', err.message);
     }
-  } catch (err) {
-    console.error('Failed to save status:', err.message);
   }
 }
 
@@ -373,12 +427,12 @@ function handleMessage(msg) {
 
   // Response to a request we sent
   if (msg.id !== undefined && pending.has(msg.id)) {
-    const { resolve, reject } = pending.get(msg.id);
-    pending.delete(msg.id);
     if (msg.error) {
       console.error('[acp] Error response details:', JSON.stringify(msg.error));
-      reject(new Error(msg.error.message));
-    } else resolve(msg.result);
+      settlePending(msg.id, 'reject', new Error(msg.error.message));
+    } else {
+      settlePending(msg.id, 'resolve', msg.result);
+    }
     return;
   }
 
@@ -633,6 +687,7 @@ async function runAcpMode() {
     if (stderrChunks.length === 0) {
       console.error(`[acp] ${acpBin} exited (code=${code}) with no stderr output`);
     }
+    rejectAllPending(new Error(`${acpBin} exited before responding`));
     // Only save status here if the prompt flow hasn't already handled it.
     // The statusSaved guard inside saveStatus() prevents double-writes.
     if (!statusSaved) {
@@ -644,11 +699,15 @@ async function runAcpMode() {
 
   // 1. Initialize
   console.log('[acp] Initializing...');
-  const initResult = await request('initialize', {
-    protocolVersion: 1,
-    clientCapabilities: {},
-    clientInfo: { name: 'ai-dlc-agent', version: '1.0.0' },
-  });
+  const initResult = await request(
+    'initialize',
+    {
+      protocolVersion: 1,
+      clientCapabilities: {},
+      clientInfo: { name: 'ai-dlc-agent', version: '1.0.0' },
+    },
+    { timeoutMs: 60000 },
+  );
   console.log('[acp] Initialized:', initResult.agentInfo?.name, initResult.agentInfo?.version);
   console.log('[acp] Agent capabilities:', JSON.stringify(initResult.agentCapabilities || {}));
 
@@ -706,6 +765,12 @@ async function runAcpMode() {
     ...extras,
   ];
   console.log(`[acp] Starting session with ${mcpServers.length} MCP server(s)`);
+  console.log(
+    '[acp] MCP servers:',
+    mcpServers
+      .map((server) => `${server.name || '(unnamed)'}:${server.command || '(no command)'}`)
+      .join(', '),
+  );
   // Redacted dump of the payload we're about to send. Header/env values are
   // replaced with their length so secrets don't end up in CloudWatch.
   console.log(
@@ -720,14 +785,18 @@ async function runAcpMode() {
         headers: Array.isArray(s.headers)
           ? s.headers.map((h) => ({ name: h.name, value: `<${(h.value || '').length} chars>` }))
           : s.headers,
-      })),
-    }),
+        })),
+      }),
   );
 
-  const session = await request('session/new', {
-    cwd: '/workspace',
-    mcpServers,
-  });
+  const session = await request(
+    'session/new',
+    {
+      cwd: '/workspace',
+      mcpServers,
+    },
+    { timeoutMs: parseInt(process.env.ACP_SESSION_NEW_TIMEOUT_MS || '180000', 10) },
+  );
   const sessionId = session.sessionId;
   console.log('[acp] Session created:', sessionId);
 
@@ -741,7 +810,11 @@ async function runAcpMode() {
   const hasBypassMode = availableModes.some((m) => m.id === 'bypassPermissions');
   if (hasBypassMode) {
     try {
-      await request('session/set_mode', { sessionId, modeId: 'bypassPermissions' });
+      await request(
+        'session/set_mode',
+        { sessionId, modeId: 'bypassPermissions' },
+        { timeoutMs: 30000 },
+      );
       console.log('[acp] Session mode set to bypassPermissions');
     } catch (modeErr) {
       // Non-fatal — we still have the session/request_permission handler as fallback
@@ -760,10 +833,14 @@ async function runAcpMode() {
   console.log('[acp] Sending prompt...');
   let promptSucceeded = false;
   try {
-    await request('session/prompt', {
-      sessionId,
-      prompt: [{ type: 'text', text: env.prompt }],
-    });
+    await request(
+      'session/prompt',
+      {
+        sessionId,
+        prompt: [{ type: 'text', text: env.prompt }],
+      },
+      { timeoutMs: 0 },
+    );
     console.log('[acp] Prompt completed');
     // Flush any buffered text chunks before saving/broadcasting completion
     flushChunksSync();

--- a/lambda/agents-ecs/acp-client.js
+++ b/lambda/agents-ecs/acp-client.js
@@ -13,6 +13,7 @@ const { SSMClient, GetParameterCommand } = require('@aws-sdk/client-ssm');
 const gremlin = require('gremlin');
 const { fromNodeProviderChain } = require('@aws-sdk/credential-providers');
 const { getUrlAndHeaders } = require('gremlin-aws-sigv4/lib/utils');
+const { parseMcpServersJson: parseSharedMcpServersJson } = require('../shared/mcp-validator');
 
 // ---------------------------------------------------------------------------
 // Driver — pluggable agent CLI abstraction
@@ -63,41 +64,6 @@ function redactMcpServerForLog(server) {
   };
 }
 
-function validateMcpServer(server, index) {
-  if (!server || typeof server !== 'object' || Array.isArray(server)) {
-    throw new Error(`MCP server at index ${index} must be an object`);
-  }
-  if (typeof server.name !== 'string' || server.name.length === 0) {
-    throw new Error(`MCP server at index ${index} must include a string name`);
-  }
-  const type = server.type || 'stdio';
-  if (!['stdio', 'http', 'sse'].includes(type)) {
-    throw new Error(`MCP server ${server.name} type must be stdio, http, or sse`);
-  }
-  if (type === 'stdio') {
-    if (!server.command || typeof server.command !== 'string') {
-      throw new Error(`MCP server ${server.name} must include a string command`);
-    }
-    if (server.args === undefined) server.args = [];
-    if (!Array.isArray(server.args)) {
-      throw new Error(`MCP server ${server.name} args must be an array`);
-    }
-    if (server.args.some((arg) => typeof arg !== 'string')) {
-      throw new Error(`MCP server ${server.name} args must contain only strings`);
-    }
-  }
-  if (type === 'http' || type === 'sse') {
-    if (!server.url || typeof server.url !== 'string') {
-      throw new Error(`MCP server ${server.name} must include a string url`);
-    }
-    if (server.headers === undefined) server.headers = [];
-    if (!Array.isArray(server.headers)) {
-      throw new Error(`MCP server ${server.name} headers must be an array`);
-    }
-  }
-  return server;
-}
-
 function commandExists(command) {
   if (command.includes('/')) {
     try {
@@ -116,8 +82,7 @@ function commandExists(command) {
 
 function filterRunnableMcpServers(servers, { requiredNames = new Set() } = {}) {
   const runnable = [];
-  for (let i = 0; i < servers.length; i += 1) {
-    const server = validateMcpServer(servers[i], i);
+  for (const server of servers) {
     if ((server.type || 'stdio') !== 'stdio') {
       runnable.push(server);
       continue;
@@ -140,11 +105,13 @@ function filterRunnableMcpServers(servers, { requiredNames = new Set() } = {}) {
 }
 
 function parseMcpServersJson(raw, source) {
-  const parsed = JSON.parse(raw || '[]');
-  if (!Array.isArray(parsed)) {
-    throw new Error(`${source} MCP servers setting must be a JSON array`);
-  }
-  return parsed.map(validateMcpServer);
+  const validation = parseSharedMcpServersJson(raw || '[]');
+  if (validation.valid) return validation.value;
+
+  const details = validation.issues
+    .map((issue) => `${issue.path ? `${issue.path}: ` : ''}${issue.message}`)
+    .join('; ');
+  throw new Error(`${source} MCP servers setting is invalid: ${details}`);
 }
 
 /**

--- a/lambda/agents-ecs/acp-client.js
+++ b/lambda/agents-ecs/acp-client.js
@@ -1,6 +1,7 @@
 // ACP client wrapper - spawns the active agent CLI in ACP mode and communicates
 // via JSON-RPC 2.0 over stdio. The CLI is selected via AGENT_CLI env var (default: kiro).
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
+const fs = require('fs');
 const readline = require('readline');
 const { DynamoDBClient, QueryCommand: DDBQueryCommand } = require('@aws-sdk/client-dynamodb');
 const { DynamoDBDocumentClient, PutCommand } = require('@aws-sdk/lib-dynamodb');
@@ -28,6 +29,94 @@ const DEFAULT_REQUEST_TIMEOUT_MS = parseInt(process.env.ACP_REQUEST_TIMEOUT_MS |
 // Cached after first load to avoid redundant lookups within the same session.
 let mergedMcpServers = null;
 
+function mcpServerLabel(server) {
+  return `${server?.name || '(unnamed)'}:${server?.command || server?.url || '(no command)'}`;
+}
+
+function validateMcpServer(server, index) {
+  if (!server || typeof server !== 'object' || Array.isArray(server)) {
+    throw new Error(`MCP server at index ${index} must be an object`);
+  }
+  if (typeof server.name !== 'string' || server.name.length === 0) {
+    throw new Error(`MCP server at index ${index} must include a string name`);
+  }
+  const type = server.type || 'stdio';
+  if (!['stdio', 'http', 'sse'].includes(type)) {
+    throw new Error(`MCP server ${server.name} type must be stdio, http, or sse`);
+  }
+  if (type === 'stdio') {
+    if (!server.command || typeof server.command !== 'string') {
+      throw new Error(`MCP server ${server.name} must include a string command`);
+    }
+    if (server.args === undefined) server.args = [];
+    if (!Array.isArray(server.args)) {
+      throw new Error(`MCP server ${server.name} args must be an array`);
+    }
+    if (server.args.some((arg) => typeof arg !== 'string')) {
+      throw new Error(`MCP server ${server.name} args must contain only strings`);
+    }
+  }
+  if (type === 'http' || type === 'sse') {
+    if (!server.url || typeof server.url !== 'string') {
+      throw new Error(`MCP server ${server.name} must include a string url`);
+    }
+    if (server.headers === undefined) server.headers = [];
+    if (!Array.isArray(server.headers)) {
+      throw new Error(`MCP server ${server.name} headers must be an array`);
+    }
+  }
+  return server;
+}
+
+function commandExists(command) {
+  if (command.includes('/')) {
+    try {
+      fs.accessSync(command, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return (
+    spawnSync('/bin/sh', ['-c', 'command -v "$1" >/dev/null 2>&1', 'sh', command], {
+      stdio: 'ignore',
+    }).status === 0
+  );
+}
+
+function filterRunnableMcpServers(servers, { requiredNames = new Set() } = {}) {
+  const runnable = [];
+  for (let i = 0; i < servers.length; i += 1) {
+    const server = validateMcpServer(servers[i], i);
+    if ((server.type || 'stdio') !== 'stdio') {
+      runnable.push(server);
+      continue;
+    }
+    if (commandExists(server.command)) {
+      runnable.push(server);
+      continue;
+    }
+
+    const label = mcpServerLabel(server);
+    const message = `MCP server ${label} command not found on PATH: ${server.command}`;
+    if (requiredNames.has(server.name)) {
+      throw new Error(message);
+    }
+    reportAgentWarning(
+      `Skipping optional ${message}. The agent will continue without this tool server.`,
+    );
+  }
+  return runnable;
+}
+
+function parseMcpServersJson(raw, source) {
+  const parsed = JSON.parse(raw || '[]');
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${source} MCP servers setting must be a JSON array`);
+  }
+  return parsed.map(validateMcpServer);
+}
+
 /**
  * Load and merge MCP server definitions from all three scopes:
  *   Global  — SSM Parameter Store (environment-wide, managed via Admin UI)
@@ -50,7 +139,7 @@ async function loadMergedMcpServers(projectId, taskId) {
         new GetParameterCommand({ Name: ssmPath, WithDecryption: false }),
       );
       const raw = result.Parameter?.Value || '[]';
-      globalServers = JSON.parse(raw);
+      globalServers = parseMcpServersJson(raw, 'global');
     } catch (err) {
       console.error('[acp] Failed to load global MCP servers from SSM:', err.message);
     }
@@ -81,7 +170,7 @@ async function loadMergedMcpServers(projectId, taskId) {
               : (projectResult.value['mcp_servers'] || [])[0];
           if (raw) {
             try {
-              projectServers = JSON.parse(raw);
+              projectServers = parseMcpServersJson(raw, 'project');
             } catch {
               console.error('[acp] Could not parse project mcp_servers:', raw);
             }
@@ -97,7 +186,7 @@ async function loadMergedMcpServers(projectId, taskId) {
                 : (taskResult.value['mcp_servers'] || [])[0];
             if (raw) {
               try {
-                taskServers = JSON.parse(raw);
+                taskServers = parseMcpServersJson(raw, 'task');
               } catch {
                 console.error('[acp] Could not parse task mcp_servers:', raw);
               }
@@ -183,6 +272,7 @@ const pending = new Map();
 let agentProc; // the spawned ACP subprocess (was 'kiro')
 // Accumulate the full agent output text so we can persist it on completion
 let fullOutputBuffer = '';
+let lastErrorMessage = '';
 // Track whether we've already persisted a final status to avoid double-saves
 // (the prompt catch block and the kiro exit handler can both fire)
 let statusSaved = false;
@@ -224,6 +314,54 @@ function rejectAllPending(err) {
     if (entry.timer) clearTimeout(entry.timer);
     entry.reject(err);
   }
+}
+
+function friendlyAgentError(err) {
+  const raw = err && err.message ? err.message : String(err || 'Unknown error');
+  if (/command not found on PATH/i.test(raw)) {
+    const match = raw.match(/MCP server ([^:]+:[^ ]+) command not found on PATH: (.+)$/i);
+    if (match) {
+      return `An MCP server could not start because the required command \`${match[2]}\` is not installed in the agent image. The server was ${match[1]}.`;
+    }
+    return 'An MCP server could not start because one of its required commands is not installed in the agent image.';
+  }
+  if (/session\/new timed out/i.test(raw)) {
+    return 'The agent could not finish starting its tool session. One of the configured MCP servers may be hanging during startup.';
+  }
+  if (/initialize timed out/i.test(raw)) {
+    return 'The agent CLI did not finish initialization in time. Please retry, or check the agent credentials and runtime logs.';
+  }
+  if (/spawn .*ENOENT/i.test(raw) || /exited before responding/i.test(raw)) {
+    return 'The agent CLI failed to start inside the worker image. Please check that the selected agent CLI is installed and healthy.';
+  }
+  if (/No KIRO_API_KEY|whoami failed|API key/i.test(raw)) {
+    return 'The agent could not authenticate. Please check the configured agent API key in Admin settings.';
+  }
+  return 'The agent failed before it could complete. Please retry after checking the agent configuration and MCP server settings.';
+}
+
+function appendAgentSystemMessage(kind, message) {
+  const heading = kind === 'error' ? 'Agent failed' : 'Agent startup warning';
+  const text = `\n\n### ${heading}\n\n${message}\n`;
+  fullOutputBuffer += text;
+  bufferChunk(text);
+}
+
+function reportAgentWarning(message) {
+  console.warn(`[acp] ${message}`);
+  appendAgentSystemMessage('warning', message);
+  broadcastEvent('agent.warning', { message });
+}
+
+function reportAgentError(err) {
+  const raw = err && err.message ? err.message : String(err || 'Unknown error');
+  const message = friendlyAgentError(err);
+  lastErrorMessage = message;
+  console.error('[acp] User-visible agent error:', message);
+  console.error('[acp] Raw agent error:', raw);
+  appendAgentSystemMessage('error', message);
+  flushChunksSync();
+  broadcastEvent('agent.error', { error: message, rawError: raw });
 }
 
 // ---------------------------------------------------------------------------
@@ -276,7 +414,13 @@ function broadcastEvent(type, data) {
     try {
       const connectionIds = await getConnections();
       if (connectionIds.length === 0) return;
-      const payload = JSON.stringify({ type, agentTaskId: env.agentTaskId || undefined, ...data });
+      const payload = JSON.stringify({
+        type,
+        executionId: env.executionId,
+        agentType: env.agentType,
+        agentTaskId: env.agentTaskId || undefined,
+        ...data,
+      });
       await Promise.all(
         connectionIds.map((connId) =>
           broadcastWsClient
@@ -361,6 +505,7 @@ async function saveStatus(status) {
           projectId: env.projectId,
           sprintId: env.sprintId || undefined,
           status,
+          errorMessage: lastErrorMessage || undefined,
           // Persist the full accumulated agent output so it can be fetched later
           outputText: fullOutputBuffer || undefined,
           completedAt: new Date().toISOString(),
@@ -754,7 +899,7 @@ async function runAcpMode() {
     }
   }
 
-  const mcpServers = [
+  const configuredMcpServers = [
     {
       name: 'graph',
       command: 'node',
@@ -764,13 +909,11 @@ async function runAcpMode() {
     // Additional MCP servers from Secrets Manager (zero or more)
     ...extras,
   ];
+  const mcpServers = filterRunnableMcpServers(configuredMcpServers, {
+    requiredNames: new Set(['graph']),
+  });
   console.log(`[acp] Starting session with ${mcpServers.length} MCP server(s)`);
-  console.log(
-    '[acp] MCP servers:',
-    mcpServers
-      .map((server) => `${server.name || '(unnamed)'}:${server.command || '(no command)'}`)
-      .join(', '),
-  );
+  console.log('[acp] MCP servers:', mcpServers.map(mcpServerLabel).join(', '));
   // Redacted dump of the payload we're about to send. Header/env values are
   // replaced with their length so secrets don't end up in CloudWatch.
   console.log(
@@ -785,8 +928,8 @@ async function runAcpMode() {
         headers: Array.isArray(s.headers)
           ? s.headers.map((h) => ({ name: h.name, value: `<${(h.value || '').length} chars>` }))
           : s.headers,
-        })),
-      }),
+      })),
+    }),
   );
 
   const session = await request(
@@ -855,15 +998,8 @@ async function runAcpMode() {
     await broadcastQueue;
     promptSucceeded = true;
   } catch (err) {
-    console.error('[acp] Prompt failed:', err.message);
-    flushChunksSync();
+    reportAgentError(err);
     await saveStatus('failed');
-    await broadcastQueue;
-    broadcastEvent('agent.error', {
-      error: err.message,
-      executionId: env.executionId,
-      agentType: env.agentType,
-    });
     await broadcastQueue;
   }
 
@@ -874,6 +1010,8 @@ async function runAcpMode() {
 
 main().catch(async (err) => {
   console.error('[acp] Fatal error:', err);
+  reportAgentError(err);
   await saveStatus('failed');
+  await broadcastQueue;
   process.exit(1);
 });

--- a/lambda/agents-ecs/acp-client.js
+++ b/lambda/agents-ecs/acp-client.js
@@ -22,6 +22,7 @@ const AGENT_CLI = process.env.AGENT_CLI || 'kiro';
 const driver = getDriver(AGENT_CLI);
 const ACP_VERBOSE = process.env.ACP_VERBOSE === 'true';
 const DEFAULT_REQUEST_TIMEOUT_MS = parseInt(process.env.ACP_REQUEST_TIMEOUT_MS || '120000', 10);
+const REDACTED = '<redacted>';
 
 // ---------------------------------------------------------------------------
 // MCP servers — merged from global (SSM), project (Neptune), task (Neptune)
@@ -31,6 +32,35 @@ let mergedMcpServers = null;
 
 function mcpServerLabel(server) {
   return `${server?.name || '(unnamed)'}:${server?.command || server?.url || '(no command)'}`;
+}
+
+function redactUrl(value) {
+  if (typeof value !== 'string') return value;
+  try {
+    const url = new URL(value);
+    if (url.username) url.username = REDACTED;
+    if (url.password) url.password = REDACTED;
+    url.search = url.search ? '?<redacted>' : '';
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+function redactMcpServerForLog(server) {
+  return {
+    type: server.type || 'stdio',
+    name: server.name || '(unnamed)',
+    command: server.command || undefined,
+    url: server.url ? redactUrl(server.url) : undefined,
+    args: Array.isArray(server.args) ? `<${server.args.length} arg(s)>` : server.args,
+    env: Array.isArray(server.env)
+      ? server.env.map((e) => ({ name: e.name, value: `<${(e.value || '').length} chars>` }))
+      : server.env,
+    headers: Array.isArray(server.headers)
+      ? server.headers.map((h) => ({ name: h.name, value: `<${(h.value || '').length} chars>` }))
+      : server.headers,
+  };
 }
 
 function validateMcpServer(server, index) {
@@ -152,8 +182,14 @@ async function loadMergedMcpServers(projectId, taskId) {
   if (neptuneEndpoint && projectId && projectId !== 'unknown') {
     try {
       const credentials = await fromNodeProviderChain()();
-      credentials.region = env.region;
-      const connInfo = getUrlAndHeaders(neptuneEndpoint, '8182', credentials, '/gremlin', 'wss');
+      const signerCredentials = toNeptuneSignerCredentials(credentials, env.region);
+      const connInfo = getUrlAndHeaders(
+        neptuneEndpoint,
+        '8182',
+        signerCredentials,
+        '/gremlin',
+        'wss',
+      );
       const conn = new DriverRemoteConnection(connInfo.url, { headers: connInfo.headers });
       const g = traversal().withRemote(conn);
       try {
@@ -273,6 +309,7 @@ let agentProc; // the spawned ACP subprocess (was 'kiro')
 // Accumulate the full agent output text so we can persist it on completion
 let fullOutputBuffer = '';
 let lastErrorMessage = '';
+let promptSucceeded = false;
 // Track whether we've already persisted a final status to avoid double-saves
 // (the prompt catch block and the kiro exit handler can both fire)
 let statusSaved = false;
@@ -361,7 +398,7 @@ function reportAgentError(err) {
   console.error('[acp] Raw agent error:', raw);
   appendAgentSystemMessage('error', message);
   flushChunksSync();
-  broadcastEvent('agent.error', { error: message, rawError: raw });
+  broadcastEvent('agent.error', { error: message });
 }
 
 // ---------------------------------------------------------------------------
@@ -832,11 +869,14 @@ async function runAcpMode() {
     if (stderrChunks.length === 0) {
       console.error(`[acp] ${acpBin} exited (code=${code}) with no stderr output`);
     }
+    const hadPendingRequests = pending.size > 0;
     rejectAllPending(new Error(`${acpBin} exited before responding`));
     // Only save status here if the prompt flow hasn't already handled it.
     // The statusSaved guard inside saveStatus() prevents double-writes.
     if (!statusSaved) {
-      await saveStatus(code === 0 ? 'completed' : 'failed');
+      await saveStatus(
+        code === 0 && promptSucceeded && !hadPendingRequests ? 'completed' : 'failed',
+      );
     }
     // Don't call process.exit() here — let the main() flow handle exit
     // to avoid racing with the prompt catch block.
@@ -920,15 +960,7 @@ async function runAcpMode() {
     '[acp] session/new payload (redacted):',
     JSON.stringify({
       cwd: '/workspace',
-      mcpServers: mcpServers.map((s) => ({
-        ...s,
-        env: Array.isArray(s.env)
-          ? s.env.map((e) => ({ name: e.name, value: `<${(e.value || '').length} chars>` }))
-          : s.env,
-        headers: Array.isArray(s.headers)
-          ? s.headers.map((h) => ({ name: h.name, value: `<${(h.value || '').length} chars>` }))
-          : s.headers,
-      })),
+      mcpServers: mcpServers.map(redactMcpServerForLog),
     }),
   );
 
@@ -974,7 +1006,6 @@ async function runAcpMode() {
 
   // 3. Send prompt
   console.log('[acp] Sending prompt...');
-  let promptSucceeded = false;
   try {
     await request(
       'session/prompt',

--- a/lambda/agents-ecs/mcp-server-graph/index.js
+++ b/lambda/agents-ecs/mcp-server-graph/index.js
@@ -36,6 +36,17 @@ console.error = (...args) => {
   } catch {}
 };
 
+function toNeptuneSignerCredentials(credentials, region) {
+  return {
+    accessKeyId: credentials.accessKeyId,
+    accessKey: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    secretKey: credentials.secretAccessKey,
+    sessionToken: credentials.sessionToken,
+    region,
+  };
+}
+
 const env = {
   neptuneEndpoint: process.env.NEPTUNE_ENDPOINT,
   projectId: process.env.PROJECT_ID,
@@ -56,8 +67,8 @@ let _g = null;
 
 async function getConnection() {
   const creds = await fromNodeProviderChain()();
-  creds.region = env.region;
-  const info = getUrlAndHeaders(env.neptuneEndpoint, '8182', creds, '/gremlin', 'wss');
+  const signerCreds = toNeptuneSignerCredentials(creds, env.region);
+  const info = getUrlAndHeaders(env.neptuneEndpoint, '8182', signerCreds, '/gremlin', 'wss');
   return new DriverRemoteConnection(info.url, { headers: info.headers });
 }
 

--- a/lambda/agents-ecs/pool-worker.js
+++ b/lambda/agents-ecs/pool-worker.js
@@ -76,6 +76,17 @@ const env = {
 const POLL_INTERVAL = 3000;
 const HEARTBEAT_INTERVAL = 30000;
 
+function toNeptuneSignerCredentials(credentials, region) {
+  return {
+    accessKeyId: credentials.accessKeyId,
+    accessKey: credentials.accessKeyId,
+    secretAccessKey: credentials.secretAccessKey,
+    secretKey: credentials.secretAccessKey,
+    sessionToken: credentials.sessionToken,
+    region,
+  };
+}
+
 // Mark this worker as idle, advertising which CLIs it has authenticated.
 async function setIdle() {
   await ddb.send(
@@ -126,7 +137,7 @@ async function saveStatus(executionId, agentType, projectId, status) {
         },
       }),
     )
-    .catch((e) => console.error('Failed to save status:', e.message));
+    .catch((e) => console.error('[pool-worker] Failed to write AgentOutputs status:', e.message));
 }
 
 // Update the AgentRun node in Neptune on job completion/failure.
@@ -137,8 +148,8 @@ async function updateAgentRunStatus(job, status) {
   if (!neptuneEndpoint) return;
   try {
     const creds = await fromNodeProviderChain()();
-    creds.region = env.region;
-    const info = getUrlAndHeaders(neptuneEndpoint, '8182', creds, '/gremlin', 'wss');
+    const signerCreds = toNeptuneSignerCredentials(creds, env.region);
+    const info = getUrlAndHeaders(neptuneEndpoint, '8182', signerCreds, '/gremlin', 'wss');
     const conn = new gremlin.driver.DriverRemoteConnection(info.url, { headers: info.headers });
     const g = gremlin.process.AnonymousTraversalSource.traversal().withRemote(conn);
     const { cardinality } = gremlin.process;

--- a/lambda/agents-ecs/pool-worker.js
+++ b/lambda/agents-ecs/pool-worker.js
@@ -31,7 +31,6 @@ const {
   DynamoDBDocumentClient,
   GetCommand,
   UpdateCommand,
-  PutCommand,
   DeleteCommand,
 } = require('@aws-sdk/lib-dynamodb');
 const { LambdaClient, InvokeCommand } = require('@aws-sdk/client-lambda');
@@ -126,14 +125,17 @@ async function saveStatus(executionId, agentType, projectId, status) {
   if (!env.agentOutputsTable) return;
   await ddb
     .send(
-      new PutCommand({
+      new UpdateCommand({
         TableName: env.agentOutputsTable,
-        Item: {
-          executionId,
-          agentType,
-          projectId,
-          status,
-          expiresAt: Math.floor(Date.now() / 1000) + 86400,
+        Key: { executionId },
+        UpdateExpression:
+          'SET agentType = if_not_exists(agentType, :agentType), projectId = if_not_exists(projectId, :projectId), #status = :status, expiresAt = if_not_exists(expiresAt, :expiresAt)',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: {
+          ':agentType': agentType,
+          ':projectId': projectId,
+          ':status': status,
+          ':expiresAt': Math.floor(Date.now() / 1000) + 86400,
         },
       }),
     )

--- a/lambda/agents-ecs/test/pool-worker.test.js
+++ b/lambda/agents-ecs/test/pool-worker.test.js
@@ -6,10 +6,19 @@ const loadConstructionOrchestratorPrompt = async () =>
   await import('../construction-orchestrator-prompt.js');
 
 const dockerfile = readFileSync(new URL('../Dockerfile', import.meta.url), 'utf8');
+const acpClient = readFileSync(new URL('../acp-client.js', import.meta.url), 'utf8');
 const poolWorker = readFileSync(new URL('../pool-worker.js', import.meta.url), 'utf8');
 
 const dockerfileCopiesPath = (requiredPath) => {
   const relativePath = requiredPath.slice('./'.length);
+  const pathWithExtension = `agents-ecs/${relativePath}.js`;
+  return dockerfile
+    .split('\n')
+    .some((line) => line.startsWith('COPY ') && line.includes(`${pathWithExtension} `));
+};
+
+const dockerfileCopiesSharedPath = (requiredPath) => {
+  const relativePath = requiredPath.slice('../'.length);
   const pathWithExtension = `${relativePath}.js`;
   return dockerfile
     .split('\n')
@@ -28,7 +37,18 @@ describe('pool-worker construction task branch cleanup', () => {
     expect(localRequires.filter((requiredPath) => !dockerfileCopiesPath(requiredPath))).toEqual([
       './drivers',
     ]);
-    expect(dockerfile).toContain('COPY drivers/ /opt/acp-client/drivers/');
+    expect(dockerfile).toContain('COPY agents-ecs/drivers/ /opt/acp-client/drivers/');
+  });
+
+  it('packages shared MCP validator used by the ACP client into the ECS image', () => {
+    const sharedRequires = [
+      ...acpClient.matchAll(/require\('(?<path>\.\.\/shared\/[\w-]+)'\)/g),
+    ].map((match) => match.groups.path);
+
+    expect(sharedRequires).toContain('../shared/mcp-validator');
+    expect(
+      sharedRequires.filter((requiredPath) => !dockerfileCopiesSharedPath(requiredPath)),
+    ).toEqual([]);
   });
 
   it('builds task branch names with the same task id normalization as launch_construction_agent', async () => {

--- a/lambda/agents/index.js
+++ b/lambda/agents/index.js
@@ -1165,7 +1165,12 @@ exports.handler = async (event) => {
         if (outputItem) {
           const s = outputItem.status;
           const mapped = s === 'completed' ? 'SUCCEEDED' : s === 'failed' ? 'FAILED' : 'RUNNING';
-          return response(200, { status: mapped, executionArn: taskId });
+          return response(200, {
+            status: mapped,
+            executionArn: taskId,
+            outputText: outputItem.outputText,
+            errorMessage: outputItem.errorMessage,
+          });
         }
       }
       const taskStatus = await getTaskStatus(taskId);

--- a/lambda/shared/mcp-validator.js
+++ b/lambda/shared/mcp-validator.js
@@ -15,7 +15,7 @@ const ALLOWED_TYPES = new Set(['stdio', 'http', 'sse']);
 const STDIO_ALLOWED_KEYS = new Set(['type', 'name', 'command', 'args', 'env']);
 const HTTP_ALLOWED_KEYS = new Set(['type', 'name', 'url', 'headers']);
 const NAME_VALUE_KEYS = new Set(['name', 'value']);
-const KNOWN_AGENT_IMAGE_COMMANDS = new Set(['node', 'npx', 'uv', 'uvx', 'python', 'python3']);
+const KNOWN_AGENT_IMAGE_MCP_COMMANDS = new Set(['node', 'npx', 'uv', 'uvx', 'python', 'python3']);
 
 // Validate a single {name, value} pair (used for env entries and HTTP headers).
 function validateNameValuePair(item, path, issues, kind) {
@@ -62,11 +62,11 @@ function validateStdio(server, path, issues) {
       path: `${path}.command`,
       message: 'Required non-empty string (path to the MCP server executable).',
     });
-  } else if (!server.command.includes('/') && !KNOWN_AGENT_IMAGE_COMMANDS.has(server.command)) {
+  } else if (!server.command.includes('/') && !KNOWN_AGENT_IMAGE_MCP_COMMANDS.has(server.command)) {
     issues.push({
       path: `${path}.command`,
       message: `Unknown executable "${server.command}". Use an absolute path or one of: ${[
-        ...KNOWN_AGENT_IMAGE_COMMANDS,
+        ...KNOWN_AGENT_IMAGE_MCP_COMMANDS,
       ].join(', ')}.`,
     });
   }
@@ -225,7 +225,7 @@ function parseMcpServersJson(jsonString) {
 }
 
 module.exports = {
-  KNOWN_AGENT_IMAGE_COMMANDS,
+  KNOWN_AGENT_IMAGE_MCP_COMMANDS,
   parseMcpServersJson,
   validateMcpServers,
   validateMcpServersJson,

--- a/lambda/shared/mcp-validator.js
+++ b/lambda/shared/mcp-validator.js
@@ -15,6 +15,7 @@ const ALLOWED_TYPES = new Set(['stdio', 'http', 'sse']);
 const STDIO_ALLOWED_KEYS = new Set(['type', 'name', 'command', 'args', 'env']);
 const HTTP_ALLOWED_KEYS = new Set(['type', 'name', 'url', 'headers']);
 const NAME_VALUE_KEYS = new Set(['name', 'value']);
+const KNOWN_AGENT_IMAGE_COMMANDS = new Set(['node', 'npx', 'uv', 'uvx', 'python', 'python3']);
 
 // Validate a single {name, value} pair (used for env entries and HTTP headers).
 function validateNameValuePair(item, path, issues, kind) {
@@ -60,6 +61,13 @@ function validateStdio(server, path, issues) {
     issues.push({
       path: `${path}.command`,
       message: 'Required non-empty string (path to the MCP server executable).',
+    });
+  } else if (!server.command.includes('/') && !KNOWN_AGENT_IMAGE_COMMANDS.has(server.command)) {
+    issues.push({
+      path: `${path}.command`,
+      message: `Unknown executable "${server.command}". Use an absolute path or one of: ${[
+        ...KNOWN_AGENT_IMAGE_COMMANDS,
+      ].join(', ')}.`,
     });
   }
   if (!Array.isArray(server.args)) {
@@ -193,7 +201,32 @@ function validateMcpServersJson(jsonString) {
   return validateMcpServers(parsed);
 }
 
+/**
+ * Parse and validate the raw JSON string, returning the parsed server array on
+ * success. Runtime callers use this to avoid duplicating the validator rules.
+ */
+function parseMcpServersJson(jsonString) {
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonString || '[]');
+  } catch (err) {
+    return {
+      valid: false,
+      value: [],
+      issues: [{ path: '', message: `Invalid JSON: ${err.message}.` }],
+    };
+  }
+
+  const validation = validateMcpServers(parsed);
+  return {
+    ...validation,
+    value: validation.valid ? parsed : [],
+  };
+}
+
 module.exports = {
+  KNOWN_AGENT_IMAGE_COMMANDS,
+  parseMcpServersJson,
   validateMcpServers,
   validateMcpServersJson,
 };

--- a/lambda/shared/test/mcp-validator.test.js
+++ b/lambda/shared/test/mcp-validator.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { validateMcpServers, validateMcpServersJson } from '../mcp-validator.js';
+import {
+  KNOWN_AGENT_IMAGE_COMMANDS,
+  parseMcpServersJson,
+  validateMcpServers,
+  validateMcpServersJson,
+} from '../mcp-validator.js';
 
 describe('validateMcpServers', () => {
   describe('top-level', () => {
@@ -23,8 +28,8 @@ describe('validateMcpServers', () => {
 
     it('reports duplicate server names', () => {
       const r = validateMcpServers([
-        { name: 'dup', command: 'a', args: [] },
-        { name: 'dup', command: 'b', args: [] },
+        { name: 'dup', command: 'node', args: [] },
+        { name: 'dup', command: 'npx', args: [] },
       ]);
       expect(r.valid).toBe(false);
       expect(r.issues).toEqual([
@@ -47,6 +52,26 @@ describe('validateMcpServers', () => {
           { type: 'stdio', name: 'fs', command: '/usr/bin/mcp-fs', args: ['--root', '/'] },
         ]),
       ).toEqual({ valid: true, issues: [] });
+    });
+
+    it('accepts known agent image commands', () => {
+      const servers = [...KNOWN_AGENT_IMAGE_COMMANDS].map((command) => ({
+        name: command,
+        command,
+        args: [],
+      }));
+
+      expect(validateMcpServers(servers)).toEqual({ valid: true, issues: [] });
+    });
+
+    it('rejects unknown bare commands at configuration time', () => {
+      const r = validateMcpServers([{ name: 'typo', command: 'uvxx', args: [] }]);
+
+      expect(r.valid).toBe(false);
+      expect(r.issues).toContainEqual({
+        path: '[0].command',
+        message: expect.stringContaining('Unknown executable "uvxx"'),
+      });
     });
 
     it('accepts env entries as array of {name, value}', () => {
@@ -315,6 +340,26 @@ describe('validateMcpServersJson', () => {
   it('forwards schema issues from the parsed payload', () => {
     const r = validateMcpServersJson(JSON.stringify([{ name: 'x' }]));
     expect(r.valid).toBe(false);
+    expect(r.issues.some((i) => i.path === '[0].command')).toBe(true);
+  });
+});
+
+describe('parseMcpServersJson', () => {
+  it('returns parsed value for valid JSON', () => {
+    const servers = [{ name: 'x', command: 'node', args: ['server.js'] }];
+
+    expect(parseMcpServersJson(JSON.stringify(servers))).toEqual({
+      valid: true,
+      issues: [],
+      value: servers,
+    });
+  });
+
+  it('returns no parsed value when validation fails', () => {
+    const r = parseMcpServersJson(JSON.stringify([{ name: 'x' }]));
+
+    expect(r.valid).toBe(false);
+    expect(r.value).toEqual([]);
     expect(r.issues.some((i) => i.path === '[0].command')).toBe(true);
   });
 });

--- a/lambda/shared/test/mcp-validator.test.js
+++ b/lambda/shared/test/mcp-validator.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
-  KNOWN_AGENT_IMAGE_COMMANDS,
+  KNOWN_AGENT_IMAGE_MCP_COMMANDS,
   parseMcpServersJson,
   validateMcpServers,
   validateMcpServersJson,
@@ -55,7 +55,7 @@ describe('validateMcpServers', () => {
     });
 
     it('accepts known agent image commands', () => {
-      const servers = [...KNOWN_AGENT_IMAGE_COMMANDS].map((command) => ({
+      const servers = [...KNOWN_AGENT_IMAGE_MCP_COMMANDS].map((command) => ({
         name: command,
         command,
         args: [],

--- a/terraform/modules/compute/agents/main.tf
+++ b/terraform/modules/compute/agents/main.tf
@@ -56,9 +56,9 @@ resource "aws_ecr_lifecycle_policy" "agents" {
 
 # Calculate hash of all source files for change detection
 locals {
-  agents_source_path = abspath("${path.module}/../../../../lambda/agents-ecs")
+  agents_source_path = abspath("${path.module}/../../../../lambda")
 
-  path_include = ["**"]
+  path_include = ["agents-ecs/**", "shared/mcp-validator.js"]
   path_exclude = ["**/node_modules/**", "**/.git/**"]
 
   agents_files_include = setunion([for f in local.path_include : fileset(local.agents_source_path, f)]...)
@@ -84,7 +84,7 @@ module "agents_docker_build" {
   use_image_tag    = true
   image_tag        = local.agents_image_tag
   source_path      = local.agents_source_path
-  docker_file_path = "${local.agents_source_path}/Dockerfile"
+  docker_file_path = "${local.agents_source_path}/agents-ecs/Dockerfile"
   platform         = "linux/amd64"
 
   build_args = {


### PR DESCRIPTION
## Summary

- Add bounded ACP request timeouts for startup/session setup while leaving long-running prompts unbounded.
- Validate and preflight merged MCP server config so optional stdio MCP servers with missing commands are skipped instead of hanging startup.
- Surface friendly agent startup/execution failures through WebSocket events, persisted AgentOutputs, and existing UI stream panels.
- Harden diagnostics by redacting MCP args/URL secrets and avoiding raw error broadcasts.
- Normalize Neptune signer credentials in agent-side graph paths.

## Issue

Refs #219

Broken MCP server configuration could make agents appear to hang during startup, especially when a server required an executable such as `uv` that was not present in the worker image, or when ACP `session/new` waited indefinitely for MCP startup. The previous behavior left the failure mostly in logs and did not give users an actionable UI message.

## Testing

- `npm test` - 19 files, 393 tests passed
- `npm run format:check` - passed
- `npm run lint` - no errors, existing warnings only
