### PR TITLE
Block PRs when construction task branches are unmerged

### DIFF
--- a/lambda/agents-ecs/construction-orchestrator-prompt.js
+++ b/lambda/agents-ecs/construction-orchestrator-prompt.js
@@ -102,12 +102,19 @@ ${isRerun ? '6.' : '5.'} **LAUNCH AGENTS IN PARALLEL**: For ALL unblocked tasks,
    **CRITICAL**: Launch ALL unblocked tasks at once to maximize parallelization. The tool respects the 50% pool cap automatically.
 
 ${isRerun ? '7.' : '6.'} **If no tasks remain** (all are "done" or "failed"):
-   a. Push the sprint branch to remote so the PR can reference it:
+   a. Before creating a PR, validate that every remote task branch has landed in the sprint branch:
+      - Run \`git fetch origin\`
+      - List task branches with \`git branch -r --list "origin/${job.branch}--task-*"\`
+      - For each listed task branch, run \`git merge-base --is-ancestor origin/<task-branch> HEAD\`
+      - If any task branch is not an ancestor of HEAD, merge it with \`git merge origin/<task-branch> --no-edit\`, resolve conflicts if needed, and verify with \`git merge-base --is-ancestor origin/<task-branch> HEAD\`
+      - Do NOT call \`trigger_pr_creation\` while any task branch is unmerged.
+   b. Push the sprint branch to remote so the PR can reference it:
       \`git push origin HEAD:refs/heads/${job.branch}\`
-   b. Call \`trigger_pr_creation\` with branch="${job.branch}" and baseBranch="${job.baseBranch || 'main'}"
+   c. Call \`trigger_pr_creation\` with branch="${job.branch}" and baseBranch="${job.baseBranch || 'main'}"
       - If a PR already exists but has been merged or closed, \`trigger_pr_creation\` will automatically mark it stale and open a new PR.
+      - If \`trigger_pr_creation\` reports unmerged construction branches, fetch and merge those branches, push again, then retry PR creation.
       - You will always get a valid, open PR URL back. Do NOT skip this call assuming a prior PR is sufficient.
-   c. You're done.
+   d. You're done.
 
 ${isRerun ? '8.' : '7.'} **Exit immediately** after dispatching. Do not wait for sub-agents.
 

--- a/lambda/agents-ecs/mcp-server-graph/index.js
+++ b/lambda/agents-ecs/mcp-server-graph/index.js
@@ -1198,6 +1198,11 @@ Only call this when all tasks have status "done" and branches have been merged.`
         }),
       );
       const resp = JSON.parse(Buffer.from(result.Payload).toString());
+      if (resp.statusCode >= 400) {
+        return err(
+          resp.error || resp.body || `create-pr Lambda returned status ${resp.statusCode}`,
+        );
+      }
 
       // Persist PR data to Neptune: upsert a PullRequest node and link to Sprint
       if (resp.prUrl && resp.prNumber) {

--- a/lambda/agents-ecs/pool-worker.js
+++ b/lambda/agents-ecs/pool-worker.js
@@ -686,8 +686,9 @@ ${taskSection}
    a. Update task status to "in_progress"
    b. Implement the task following AI-DLC construction stages
    c. Write code files to /workspace
-   d. Update task status to "done" (or "failed" if issues arise)
-   e. Stage and commit: \`git add . && git commit -m "Implement <task-id>: <short description>"\`
+   d. Stage and commit: \`git add . && git commit -m "Implement <task-id>: <short description>"\`
+   e. Verify your commit exists with \`git log --oneline -3\`
+   f. Only after the commit is verified, update task status to "done" (or "failed" if issues arise)
 
 ## GIT CONTRACT — READ CAREFULLY
 

--- a/lambda/agents-ecs/test/pool-worker.test.js
+++ b/lambda/agents-ecs/test/pool-worker.test.js
@@ -159,6 +159,7 @@ describe('pool-worker construction task branch cleanup', () => {
     expect(prompt).toContain(
       'Delete merged remote task branches AFTER the sprint branch push succeeds',
     );
+    expect(prompt).toContain('Do NOT call `trigger_pr_creation` while any task branch is unmerged');
     expect(prompt).toContain('Do NOT delete the task branch yourself');
   });
 });

--- a/lambda/create-pr/create-pr.js
+++ b/lambda/create-pr/create-pr.js
@@ -1,3 +1,146 @@
+function encodeRefPath(ref) {
+  return ref.split('/').map(encodeURIComponent).join('/');
+}
+
+function getConstructionBranchCleanupPrefix(branch) {
+  return `refs/heads/${branch}--task-`;
+}
+
+function getBranchNameFromRef(refName) {
+  return refName.replace(/^refs\/heads\//, '');
+}
+
+async function listConstructionTaskRefs({ owner, repo, branch, ghHeaders, fetchImpl = fetch }) {
+  const refPrefix = getConstructionBranchCleanupPrefix(branch);
+  const matchingRefsPath = encodeRefPath(`heads/${branch}--task-`);
+  const refsRes = await fetchImpl(
+    `https://api.github.com/repos/${owner}/${repo}/git/matching-refs/${matchingRefsPath}`,
+    { headers: ghHeaders },
+  );
+
+  if (!refsRes.ok) {
+    const errorText = await refsRes.text();
+    throw new Error(`Failed to list construction task branches: ${errorText}`);
+  }
+
+  const refs = await refsRes.json();
+  return refs.filter((ref) => ref?.ref?.startsWith(refPrefix));
+}
+
+async function isBranchMergedInto({
+  owner,
+  repo,
+  sourceBranch,
+  targetBranch,
+  ghHeaders,
+  fetchImpl,
+}) {
+  const compareRes = await fetchImpl(
+    `https://api.github.com/repos/${owner}/${repo}/compare/${encodeURIComponent(sourceBranch)}...${encodeURIComponent(targetBranch)}`,
+    { headers: ghHeaders },
+  );
+  if (!compareRes.ok) {
+    const errorText = await compareRes.text();
+    throw new Error(`Failed to compare ${sourceBranch} against ${targetBranch}: ${errorText}`);
+  }
+
+  const comparison = await compareRes.json();
+  return comparison.status === 'identical' || comparison.status === 'ahead';
+}
+
+async function getUnmergedConstructionTaskBranches({
+  owner,
+  repo,
+  branch,
+  ghHeaders,
+  fetchImpl = fetch,
+}) {
+  const refs = await listConstructionTaskRefs({ owner, repo, branch, ghHeaders, fetchImpl });
+  const unmerged = [];
+
+  for (const ref of refs) {
+    const taskBranch = getBranchNameFromRef(ref.ref);
+    const merged = await isBranchMergedInto({
+      owner,
+      repo,
+      sourceBranch: taskBranch,
+      targetBranch: branch,
+      ghHeaders,
+      fetchImpl,
+    });
+    if (!merged) unmerged.push(taskBranch);
+  }
+
+  return unmerged;
+}
+
+async function cleanupConstructionTaskBranches({
+  owner,
+  repo,
+  branch,
+  ghHeaders,
+  fetchImpl = fetch,
+}) {
+  let refs;
+  try {
+    refs = await listConstructionTaskRefs({ owner, repo, branch, ghHeaders, fetchImpl });
+  } catch (err) {
+    console.error(err.message);
+    return { deleted: 0, failed: 1, skipped: 0 };
+  }
+
+  let deleted = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const ref of refs) {
+    const refName = ref.ref;
+    const taskBranch = getBranchNameFromRef(refName);
+    let merged = false;
+    try {
+      merged = await isBranchMergedInto({
+        owner,
+        repo,
+        sourceBranch: taskBranch,
+        targetBranch: branch,
+        ghHeaders,
+        fetchImpl,
+      });
+    } catch (err) {
+      failed += 1;
+      console.error(err.message);
+      continue;
+    }
+
+    if (!merged) {
+      skipped += 1;
+      console.error(`Skipping unmerged construction task branch ${taskBranch}`);
+      continue;
+    }
+
+    const deletePath = encodeRefPath(refName.replace(/^refs\//, ''));
+    const deleteRes = await fetchImpl(
+      `https://api.github.com/repos/${owner}/${repo}/git/refs/${deletePath}`,
+      { method: 'DELETE', headers: ghHeaders },
+    );
+
+    if (deleteRes.ok) {
+      deleted += 1;
+    } else {
+      failed += 1;
+      const errorText = await deleteRes.text();
+      console.error(`Failed to delete construction task branch ${refName}:`, errorText);
+    }
+  }
+
+  if (deleted || failed || skipped) {
+    console.log(
+      `Construction task branch cleanup complete: deleted=${deleted}, failed=${failed}, skipped=${skipped}`,
+    );
+  }
+  return { deleted, failed, skipped };
+}
+
 exports.handler = async (event) => {
   const { projectId, branch, baseBranch, gitRepo, gitToken, executionId } = event;
   console.log('Request:', JSON.stringify({ projectId, branch, baseBranch, gitRepo, executionId }));
@@ -19,6 +162,20 @@ exports.handler = async (event) => {
       Accept: 'application/vnd.github.v3+json',
       'Content-Type': 'application/json',
     };
+
+    const unmergedBranches = await getUnmergedConstructionTaskBranches({
+      owner,
+      repo,
+      branch,
+      ghHeaders,
+    });
+    if (unmergedBranches.length) {
+      return {
+        statusCode: 409,
+        error: `Cannot create PR: ${unmergedBranches.length} construction task branch(es) are not merged into ${branch}`,
+        unmergedBranches,
+      };
+    }
 
     const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls`, {
       method: 'POST',
@@ -44,6 +201,7 @@ exports.handler = async (event) => {
           const prs = await listRes.json();
           if (prs.length > 0) {
             console.log('Found existing PR:', prs[0].html_url);
+            await cleanupConstructionTaskBranches({ owner, repo, branch, ghHeaders });
             return {
               statusCode: 200,
               prUrl: prs[0].html_url,
@@ -61,6 +219,7 @@ exports.handler = async (event) => {
           const allPrs = await closedRes.json();
           if (allPrs.length > 0) {
             console.log('Found existing (closed) PR:', allPrs[0].html_url);
+            await cleanupConstructionTaskBranches({ owner, repo, branch, ghHeaders });
             return {
               statusCode: 200,
               prUrl: allPrs[0].html_url,
@@ -76,6 +235,7 @@ exports.handler = async (event) => {
 
     const pr = await response.json();
     console.log('PR created:', pr.html_url);
+    await cleanupConstructionTaskBranches({ owner, repo, branch, ghHeaders });
 
     return {
       statusCode: 200,
@@ -90,3 +250,7 @@ exports.handler = async (event) => {
     };
   }
 };
+
+exports.cleanupConstructionTaskBranches = cleanupConstructionTaskBranches;
+exports.getUnmergedConstructionTaskBranches = getUnmergedConstructionTaskBranches;
+exports.getConstructionBranchCleanupPrefix = getConstructionBranchCleanupPrefix;

--- a/lambda/create-pr/test/create-pr.test.js
+++ b/lambda/create-pr/test/create-pr.test.js
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const loadCreatePr = async () => await import('../create-pr.js');
+
+describe('create-pr construction branch cleanup', () => {
+  it('deletes only task branches for the branch used to create the PR', async () => {
+    const { cleanupConstructionTaskBranches } = await loadCreatePr();
+    const requests = [];
+    const fetchImpl = vi.fn(async (url, options = {}) => {
+      requests.push({ url, options });
+      if (url.includes('/git/matching-refs/')) {
+        return {
+          ok: true,
+          json: async () => [
+            { ref: 'refs/heads/ai-dlc/feature/dashboard-improvement-1780474313832' },
+            {
+              ref: 'refs/heads/ai-dlc/feature/dashboard-improvement-1780474313832--task-sse-backend',
+            },
+            {
+              ref: 'refs/heads/ai-dlc/feature/dashboard-improvement-1780474313832--task-sse-frontend',
+            },
+            { ref: 'refs/heads/ai-dlc/feature/other--task-unrelated' },
+          ],
+        };
+      }
+      if (url.includes('/compare/')) return { ok: true, json: async () => ({ status: 'ahead' }) };
+      return { ok: true, text: async () => '' };
+    });
+
+    const result = await cleanupConstructionTaskBranches({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'ai-dlc/feature/dashboard-improvement-1780474313832',
+      ghHeaders: { Authorization: 'token token' },
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ deleted: 2, failed: 0, skipped: 0 });
+    expect(requests.map((request) => request.url)).toEqual([
+      'https://api.github.com/repos/owner/repo/git/matching-refs/heads/ai-dlc/feature/dashboard-improvement-1780474313832--task-',
+      'https://api.github.com/repos/owner/repo/compare/ai-dlc%2Ffeature%2Fdashboard-improvement-1780474313832--task-sse-backend...ai-dlc%2Ffeature%2Fdashboard-improvement-1780474313832',
+      'https://api.github.com/repos/owner/repo/git/refs/heads/ai-dlc/feature/dashboard-improvement-1780474313832--task-sse-backend',
+      'https://api.github.com/repos/owner/repo/compare/ai-dlc%2Ffeature%2Fdashboard-improvement-1780474313832--task-sse-frontend...ai-dlc%2Ffeature%2Fdashboard-improvement-1780474313832',
+      'https://api.github.com/repos/owner/repo/git/refs/heads/ai-dlc/feature/dashboard-improvement-1780474313832--task-sse-frontend',
+    ]);
+    expect(requests.filter((request) => request.options.method === 'DELETE')).toHaveLength(2);
+  });
+
+  it('does not delete task branches that are not merged into the PR branch', async () => {
+    const { cleanupConstructionTaskBranches } = await loadCreatePr();
+    const requests = [];
+    const fetchImpl = vi.fn(async (url, options = {}) => {
+      requests.push({ url, options });
+      if (url.includes('/git/matching-refs/')) {
+        return {
+          ok: true,
+          json: async () => [{ ref: 'refs/heads/ai-dlc/sprint-1--task-api' }],
+        };
+      }
+      if (url.includes('/compare/'))
+        return { ok: true, json: async () => ({ status: 'diverged' }) };
+      return { ok: true, text: async () => '' };
+    });
+
+    const result = await cleanupConstructionTaskBranches({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'ai-dlc/sprint-1',
+      ghHeaders: { Authorization: 'token token' },
+      fetchImpl,
+    });
+
+    expect(result).toEqual({ deleted: 0, failed: 0, skipped: 1 });
+    expect(requests.some((request) => request.options.method === 'DELETE')).toBe(false);
+  });
+
+  it('runs cleanup after a PR is created', async () => {
+    const { handler } = await loadCreatePr();
+    const requests = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      requests.push({ url, options });
+      if (url.endsWith('/pulls')) {
+        return {
+          ok: true,
+          json: async () => ({ html_url: 'https://github.com/owner/repo/pull/7', number: 7 }),
+        };
+      }
+      if (url.includes('/git/matching-refs/')) {
+        return {
+          ok: true,
+          json: async () => [{ ref: 'refs/heads/ai-dlc/sprint-1--task-auth' }],
+        };
+      }
+      if (url.includes('/compare/')) return { ok: true, json: async () => ({ status: 'ahead' }) };
+      return { ok: true, text: async () => '' };
+    });
+
+    try {
+      const result = await handler({
+        projectId: 'project-1',
+        branch: 'ai-dlc/sprint-1',
+        baseBranch: 'main',
+        gitRepo: 'owner/repo',
+        gitToken: 'token',
+        executionId: 'exec-1',
+      });
+
+      expect(result).toMatchObject({
+        statusCode: 200,
+        prUrl: 'https://github.com/owner/repo/pull/7',
+        prNumber: 7,
+      });
+      expect(requests.map((request) => request.url)).toContain(
+        'https://api.github.com/repos/owner/repo/git/refs/heads/ai-dlc/sprint-1--task-auth',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('refuses to create a PR when completed task branches are not merged', async () => {
+    const { handler } = await loadCreatePr();
+    const requests = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      requests.push({ url, options });
+      if (url.includes('/git/matching-refs/')) {
+        return {
+          ok: true,
+          json: async () => [{ ref: 'refs/heads/ai-dlc/sprint-1--task-auth' }],
+        };
+      }
+      if (url.includes('/compare/')) return { ok: true, json: async () => ({ status: 'behind' }) };
+      return { ok: true, json: async () => ({}) };
+    });
+
+    try {
+      const result = await handler({
+        projectId: 'project-1',
+        branch: 'ai-dlc/sprint-1',
+        baseBranch: 'main',
+        gitRepo: 'owner/repo',
+        gitToken: 'token',
+        executionId: 'exec-1',
+      });
+
+      expect(result).toMatchObject({
+        statusCode: 409,
+        unmergedBranches: ['ai-dlc/sprint-1--task-auth'],
+      });
+      expect(requests.some((request) => request.url.endsWith('/pulls'))).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- extend #216 by validating construction task branches before PR creation
- refuse PR creation when `${sprintBranch}--task-*` branches are not merged into the sprint branch
- delete task branches only after verifying they are merged
- propagate create-pr Lambda failures through `trigger_pr_creation`
- update construction prompts so agents commit before marking tasks done and orchestrators verify all task branches before PR creation

## Validation

- `npx vitest run --project create-pr --project agents-ecs`
- `npx oxfmt --check lambda/create-pr/create-pr.js lambda/create-pr/test/create-pr.test.js lambda/agents-ecs/mcp-server-graph/index.js lambda/agents-ecs/pool-worker.js lambda/agents-ecs/construction-orchestrator-prompt.js lambda/agents-ecs/test/pool-worker.test.js`
- `npx oxlint lambda/create-pr/create-pr.js lambda/create-pr/test/create-pr.test.js lambda/agents-ecs/mcp-server-graph/index.js lambda/agents-ecs/pool-worker.js lambda/agents-ecs/construction-orchestrator-prompt.js lambda/agents-ecs/test/pool-worker.test.js`

Extends #216.
Closes #230.