### PR TITLE
feat(review): surface all PRs in multi-repo review with per-PR tabs

### DIFF
--- a/frontend/src/components/layout/PipelineView.tsx
+++ b/frontend/src/components/layout/PipelineView.tsx
@@ -470,12 +470,15 @@ function QuickAction({
   }
 
   if (sprint.prUrl) {
+    // sprint.prUrl is only the FIRST PR (denormalized copy). In multi-repo sprints
+    // there can be several PRs, so opening this single URL is misleading. Navigate
+    // to the review page instead, where the multi-PR box lists every repo's PR.
     return (
       <Button
         variant="outline"
         size="sm"
         className="w-full h-7 text-xs gap-1.5"
-        onClick={() => window.open(sprint.prUrl!, '_blank')}
+        onClick={() => navigate(`/project/${projectId}/sprint/${sprintId}/review`)}
       >
         <Zap className="h-3 w-3" />
         View Pull Request

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
+import { cn } from '@/lib/utils';
+
+const ToggleGroup = React.forwardRef<
+  React.ComponentRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn('inline-flex items-center gap-1', className)}
+    {...props}
+  />
+));
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
+
+const ToggleGroupItem = React.forwardRef<
+  React.ComponentRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <ToggleGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md border bg-background px-3 py-1 text-sm font-medium ring-offset-background transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground',
+      className,
+    )}
+    {...props}
+  />
+));
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
+
+export { ToggleGroup, ToggleGroupItem };

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -8,7 +8,7 @@ import { projectsService, type Project } from '@/services/projects';
 import { reviewsService } from '@/services/reviews';
 import { questionsService } from '@/services/questions';
 import { githubService, type PRComment } from '@/services/github';
-import { sprintGraphService } from '@/services/sprintGraph';
+import { sprintGraphService, extractPrs, type PrInfo } from '@/services/sprintGraph';
 import { realtimeService } from '@/services/realtime';
 import { sprintsService } from '@/services/sprints';
 import { agentsService } from '@/services/agents';
@@ -48,6 +48,7 @@ import {
   XCircle,
   Code2,
   GitBranch,
+  GitPullRequest,
   Link,
   AlertTriangle,
   ShieldAlert,
@@ -144,6 +145,8 @@ export default function ReviewPage() {
   } = useSprint();
 
   const [project, setProject] = useState<Project | null>(null);
+  const [prs, setPrs] = useState<PrInfo[]>([]);
+  const [selectedPrId, setSelectedPrId] = useState<string>('');
   const [prComments, setPrComments] = useState<PRComment[]>([]);
   const [prBranch, setPrBranch] = useState('');
   const [prBaseBranch, setPrBaseBranch] = useState('main');
@@ -199,13 +202,13 @@ export default function ReviewPage() {
       sprintGraphService
         .get(sprintId)
         .then((graph) => {
-          const prNode = graph.nodes.find((n) => n.type === 'PullRequest');
-          if (prNode) {
-            setPrBranch((prNode as Record<string, string>).branch || '');
-            setPrBaseBranch((prNode as Record<string, string>).base_branch || 'main');
-          }
+          const found = extractPrs(graph);
+          setPrs(found);
+          setSelectedPrId((prev) =>
+            prev && found.some((p) => p.id === prev) ? prev : (found[0]?.id ?? ''),
+          );
           // Fall back to sprint branch if no PR node yet
-          else if (sprint?.branch) {
+          if (found.length === 0 && sprint?.branch) {
             setPrBranch(sprint.branch);
             setPrBaseBranch(sprint.baseBranch || 'main');
           }
@@ -214,16 +217,59 @@ export default function ReviewPage() {
     }
   }, [sprintId, sprint?.branch, sprint?.baseBranch]);
 
-  // Load PR comments
+  // Selected PR drives the View/checkout/comments below. Falls back to the
+  // single PR copied onto the sprint vertex for backward compatibility.
+  const selectedPr = prs.find((p) => p.id === selectedPrId) ?? prs[0] ?? null;
+  const activePrUrl = selectedPr?.prUrl || sprint?.prUrl || '';
+  const activePrNumber = selectedPr?.prNumber || sprint?.prNumber || '';
+  const activeRepo = selectedPr?.repository || project?.gitRepo || '';
+  const selectedBranch = selectedPr?.branch || '';
+  const selectedBaseBranch = selectedPr?.baseBranch || 'main';
+  const hasPr = prs.length > 0 || !!sprint?.prUrl;
+
+  const repoShort = (repo: string) => repo.split('/').pop() || repo || '';
+  const prTabLabel = (p: PrInfo) => `${repoShort(p.repository) || 'repo'} #${p.prNumber}`;
+  // open = emerald, merged = violet, closed = red, unknown = zinc
+  const stateDotClass = (state: string) =>
+    state === 'merged'
+      ? 'bg-violet-500'
+      : state === 'closed'
+        ? 'bg-red-500'
+        : state === 'open'
+          ? 'bg-emerald-500'
+          : 'bg-zinc-400';
+  const repoCount = new Set(prs.map((p) => p.repository)).size;
+  const prCount = prs.length || (sprint?.prUrl ? 1 : 0);
+  const viewPrLabel = selectedPr
+    ? `View ${repoShort(selectedPr.repository) ? `${repoShort(selectedPr.repository)} #${selectedPr.prNumber}` : `PR #${selectedPr.prNumber}`}`
+    : 'View PR';
+
+  // Keep the branch used by "Modify Code" aligned with the selected PR's repo.
   useEffect(() => {
-    if (!sprint?.prNumber || !project?.gitRepo) return;
-    const [owner, repo] = project.gitRepo.split('/');
-    if (owner && repo)
-      githubService
-        .getPRComments(owner, repo, parseInt(sprint.prNumber))
-        .then((res) => setPrComments(res.comments))
-        .catch(() => {});
-  }, [sprint?.prNumber, project?.gitRepo]);
+    if (!selectedBranch) return;
+    setPrBranch(selectedBranch);
+    setPrBaseBranch(selectedBaseBranch);
+  }, [selectedBranch, selectedBaseBranch]);
+
+  // Load PR comments for the selected PR
+  useEffect(() => {
+    if (!activePrNumber || !activeRepo) return;
+    const [owner, repo] = activeRepo.split('/');
+    if (!owner || !repo) return;
+    let cancelled = false;
+    // Clear previous PR's comments so a slow response can't show them under the
+    // newly selected PR, and guard against out-of-order resolution on fast switches.
+    setPrComments([]);
+    githubService
+      .getPRComments(owner, repo, parseInt(activePrNumber))
+      .then((res) => {
+        if (!cancelled) setPrComments(res.comments);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [activePrNumber, activeRepo]);
 
   const pendingQuestions = questions
     .filter((q) => !q.structuredAnswer)
@@ -297,15 +343,15 @@ export default function ReviewPage() {
   };
 
   const handleAddComment = async () => {
-    if (!newComment.trim() || !sprint?.prNumber || !project?.gitRepo) return;
+    if (!newComment.trim() || !activePrNumber || !activeRepo) return;
     setSubmittingComment(true);
     try {
-      const [owner, repo] = project.gitRepo.split('/');
-      await githubService.addPRComment(owner, repo, parseInt(sprint.prNumber), {
+      const [owner, repo] = activeRepo.split('/');
+      await githubService.addPRComment(owner, repo, parseInt(activePrNumber), {
         body: newComment,
       });
       setNewComment('');
-      const comments = await githubService.getPRComments(owner, repo, parseInt(sprint.prNumber));
+      const comments = await githubService.getPRComments(owner, repo, parseInt(activePrNumber));
       setPrComments(comments.comments);
     } catch (err) {
       alert('Failed to add comment: ' + (err instanceof Error ? err.message : 'Unknown error'));
@@ -376,7 +422,11 @@ export default function ReviewPage() {
                   onAutoSave={async (draft) => {
                     questionsService
                       .update(sprintId, pq.id, { draftAnswer: draft })
-                      .catch(() => {});
+                      .catch((err) => {
+                        // Don't block the page if the graph fetch fails, but surface it — a
+                        // silent swallow hid PR-loading failures (no PRs shown, no error).
+                        console.error('Failed to load sprint graph for PRs:', err);
+                      });
                   }}
                   onFocus={() => setActivity('question', pq.id)}
                   onBlur={() => setActivity('idle')}
@@ -423,13 +473,64 @@ export default function ReviewPage() {
             </Card>
           )}
 
-          {/* Review controls */}
+          {/* Pull requests — groups everything scoped to a single PR/repo:
+              the repo tabs, the View PR link, and the local checkout command. */}
+          {activePrUrl && (
+            <div className="rounded-lg border bg-muted/30 p-3 space-y-3">
+              <div className="flex items-center gap-2 flex-wrap">
+                <GitPullRequest className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">Pull requests</span>
+                <Badge variant="secondary" className="h-5 px-1.5">
+                  {prCount}
+                </Badge>
+                {repoCount > 1 && (
+                  <span className="text-xs text-muted-foreground">
+                    across {repoCount} repositories
+                  </span>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5 ml-auto"
+                  title={activeRepo ? `Open ${activeRepo} #${activePrNumber}` : 'Open pull request'}
+                  onClick={() => window.open(activePrUrl, '_blank')}
+                >
+                  <ExternalLink className="h-3.5 w-3.5" /> {viewPrLabel}
+                </Button>
+              </div>
+              {prs.length > 1 && (
+                <Tabs value={selectedPrId} onValueChange={setSelectedPrId}>
+                  <TabsList className="h-auto flex-wrap bg-background">
+                    {prs.map((p) => (
+                      <TabsTrigger
+                        key={p.id}
+                        value={p.id}
+                        className="gap-1.5 text-xs"
+                        title={p.repository}
+                      >
+                        <span className={`h-1.5 w-1.5 rounded-full ${stateDotClass(p.state)}`} />
+                        {prTabLabel(p)}
+                      </TabsTrigger>
+                    ))}
+                  </TabsList>
+                </Tabs>
+              )}
+              {activePrNumber && (
+                <PrCheckoutCommand
+                  prNumber={activePrNumber}
+                  branch={selectedPr?.branch || sprint?.branch}
+                  baseBranch={selectedPr?.baseBranch || sprint?.baseBranch}
+                  gitRepo={activeRepo || project?.gitRepo}
+                />
+              )}
+            </div>
+          )}
+
+          {/* Sprint-level actions */}
           <div className="flex items-center gap-3 flex-wrap">
             <Button
               onClick={handleKickOffReviews}
-              disabled={
-                isAnyRunning || !!launching || !sprint?.prUrl || sprint?.phase === 'COMPLETED'
-              }
+              disabled={isAnyRunning || !!launching || !hasPr || sprint?.phase === 'COMPLETED'}
               className="gap-2"
             >
               {launching ? (
@@ -442,22 +543,12 @@ export default function ReviewPage() {
             <Button
               onClick={() => setShowModifyModal(true)}
               disabled={
-                isAnyRunning || !sprint?.prUrl || !hasReviewResults || sprint?.phase === 'COMPLETED'
+                isAnyRunning || !hasPr || !hasReviewResults || sprint?.phase === 'COMPLETED'
               }
               className="gap-2"
             >
               <Wrench className="h-4 w-4" /> Fix Review Findings
             </Button>
-            {sprint?.prUrl && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5 ml-auto"
-                onClick={() => window.open(sprint.prUrl!, '_blank')}
-              >
-                <ExternalLink className="h-3.5 w-3.5" /> View PR
-              </Button>
-            )}
 
             {/* Review status */}
             {review &&
@@ -485,18 +576,8 @@ export default function ReviewPage() {
 
           {startError && <AgentStartErrorBanner error={startError} onDismiss={clearStartError} />}
 
-          {/* Local checkout command */}
-          {sprint?.prUrl && sprint?.prNumber && (
-            <PrCheckoutCommand
-              prNumber={sprint.prNumber}
-              branch={sprint.branch}
-              baseBranch={sprint.baseBranch}
-              gitRepo={project?.gitRepo}
-            />
-          )}
-
           {/* Missing PR warning */}
-          {!sprint?.prUrl && (
+          {!hasPr && (
             <Card className="border-amber-500/50 bg-amber-500/5">
               <CardContent className="p-4 space-y-3">
                 <p className="text-sm text-amber-600 dark:text-amber-400">

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -197,25 +198,35 @@ export default function ReviewPage() {
         .catch(() => {});
   }, [projectId]);
 
+  // Fetch the sprint graph (and its PRs) on sprintId only — a full graph refetch
+  // is expensive and must not be triggered by realtime branch/baseBranch updates.
   useEffect(() => {
-    if (sprintId) {
-      sprintGraphService
-        .get(sprintId)
-        .then((graph) => {
-          const found = extractPrs(graph);
-          setPrs(found);
-          setSelectedPrId((prev) =>
-            prev && found.some((p) => p.id === prev) ? prev : (found[0]?.id ?? ''),
-          );
-          // Fall back to sprint branch if no PR node yet
-          if (found.length === 0 && sprint?.branch) {
-            setPrBranch(sprint.branch);
-            setPrBaseBranch(sprint.baseBranch || 'main');
-          }
-        })
-        .catch(() => {});
+    if (!sprintId) return;
+    sprintGraphService
+      .get(sprintId)
+      .then((graph) => {
+        const found = extractPrs(graph);
+        setPrs(found);
+        setSelectedPrId((prev) =>
+          prev && found.some((p) => p.id === prev) ? prev : (found[0]?.id ?? ''),
+        );
+      })
+      .catch((err) => {
+        // Surface PR-loading failures instead of swallowing them — a silent catch
+        // previously hid them (no PRs shown, no error).
+        console.error('Failed to load sprint graph for PRs:', err);
+      });
+  }, [sprintId]);
+
+  // One-shot fallback: when the sprint has no PR node yet, use its own branch for
+  // the Modify Code flow. Kept in its own effect (guarded by prs.length === 0) so
+  // branch/baseBranch changes don't refetch the whole graph.
+  useEffect(() => {
+    if (prs.length === 0 && sprint?.branch) {
+      setPrBranch(sprint.branch);
+      setPrBaseBranch(sprint.baseBranch || 'main');
     }
-  }, [sprintId, sprint?.branch, sprint?.baseBranch]);
+  }, [prs.length, sprint?.branch, sprint?.baseBranch]);
 
   // Selected PR drives the View/checkout/comments below. Falls back to the
   // single PR copied onto the sprint vertex for backward compatibility.
@@ -423,9 +434,9 @@ export default function ReviewPage() {
                     questionsService
                       .update(sprintId, pq.id, { draftAnswer: draft })
                       .catch((err) => {
-                        // Don't block the page if the graph fetch fails, but surface it — a
-                        // silent swallow hid PR-loading failures (no PRs shown, no error).
-                        console.error('Failed to load sprint graph for PRs:', err);
+                        // Autosave is best-effort: don't block typing if it fails,
+                        // but log so a silently dropped draft is diagnosable.
+                        console.error('Failed to autosave question draft:', err);
                       });
                   }}
                   onFocus={() => setActivity('question', pq.id)}
@@ -499,21 +510,24 @@ export default function ReviewPage() {
                 </Button>
               </div>
               {prs.length > 1 && (
-                <Tabs value={selectedPrId} onValueChange={setSelectedPrId}>
-                  <TabsList className="h-auto flex-wrap bg-background">
-                    {prs.map((p) => (
-                      <TabsTrigger
-                        key={p.id}
-                        value={p.id}
-                        className="gap-1.5 text-xs"
-                        title={p.repository}
-                      >
-                        <span className={`h-1.5 w-1.5 rounded-full ${stateDotClass(p.state)}`} />
-                        {prTabLabel(p)}
-                      </TabsTrigger>
-                    ))}
-                  </TabsList>
-                </Tabs>
+                <ToggleGroup
+                  type="single"
+                  value={selectedPrId}
+                  onValueChange={(v) => v && setSelectedPrId(v)}
+                  className="flex-wrap justify-start"
+                >
+                  {prs.map((p) => (
+                    <ToggleGroupItem
+                      key={p.id}
+                      value={p.id}
+                      className="gap-1.5 text-xs"
+                      title={p.repository}
+                    >
+                      <span className={`h-1.5 w-1.5 rounded-full ${stateDotClass(p.state)}`} />
+                      {prTabLabel(p)}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
               )}
               {activePrNumber && (
                 <PrCheckoutCommand

--- a/frontend/src/services/sprintGraph.test.ts
+++ b/frontend/src/services/sprintGraph.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { extractPrs, type SprintGraph } from './sprintGraph';
+
+const prNode = (over: Record<string, unknown>) => ({
+  id: over.id ?? 'pr-1',
+  type: 'PullRequest',
+  label: 'PR',
+  pr_url: 'https://github.com/owner/repo/pull/1',
+  pr_number: '1',
+  repository: 'owner/repo',
+  branch: 'feat/x',
+  base_branch: 'main',
+  pr_state: 'open',
+  ...over,
+});
+
+const graph = (nodes: Record<string, unknown>[]): SprintGraph => ({
+  nodes: nodes as SprintGraph['nodes'],
+  edges: [],
+});
+
+describe('extractPrs', () => {
+  it('returns an empty array when there are no PullRequest nodes', () => {
+    expect(extractPrs(graph([{ id: 't1', type: 'Task', label: 'task' }]))).toEqual([]);
+  });
+
+  it('maps snake_case PR node fields to PrInfo', () => {
+    const [pr] = extractPrs(graph([prNode({})]));
+    expect(pr).toEqual({
+      id: 'pr-1',
+      prUrl: 'https://github.com/owner/repo/pull/1',
+      prNumber: '1',
+      repository: 'owner/repo',
+      branch: 'feat/x',
+      baseBranch: 'main',
+      state: 'open',
+    });
+  });
+
+  it('collects one PR per repo and sorts by repository', () => {
+    const prs = extractPrs(
+      graph([
+        prNode({ id: 'b', repository: 'owner/ui', pr_number: '2' }),
+        prNode({ id: 'a', repository: 'owner/infra', pr_number: '3' }),
+      ]),
+    );
+    expect(prs.map((p) => p.repository)).toEqual(['owner/infra', 'owner/ui']);
+  });
+
+  it('drops stale and url-less PRs', () => {
+    const prs = extractPrs(
+      graph([
+        prNode({ id: 'live', repository: 'owner/ui' }),
+        prNode({ id: 'stale', repository: 'owner/old', stale: true }),
+        prNode({ id: 'staleStr', repository: 'owner/old2', stale: 'true' }),
+        prNode({ id: 'empty', repository: 'owner/nourl', pr_url: '' }),
+      ]),
+    );
+    expect(prs.map((p) => p.id)).toEqual(['live']);
+  });
+
+  it('defaults baseBranch to main when missing', () => {
+    const [pr] = extractPrs(graph([prNode({ base_branch: undefined })]));
+    expect(pr.baseBranch).toBe('main');
+  });
+
+  it('keeps both PRs when two repos share the same PR number', () => {
+    const prs = extractPrs(
+      graph([
+        prNode({ id: 'ui', repository: 'owner/ui', pr_number: '5' }),
+        prNode({ id: 'infra', repository: 'owner/infra', pr_number: '5' }),
+      ]),
+    );
+    expect(prs).toHaveLength(2);
+    expect(new Set(prs.map((p) => p.id)).size).toBe(2);
+  });
+
+  it('tolerates a missing repository field without throwing', () => {
+    const [pr] = extractPrs(graph([prNode({ repository: undefined })]));
+    expect(pr.repository).toBe('');
+  });
+
+  it('falls back to empty state when pr_state is missing', () => {
+    // Documents the fallback: open PRs created before pr_state was persisted (or
+    // any PR missing the property) map to state '' so the UI renders the
+    // "unknown" (grey) dot rather than throwing.
+    const [pr] = extractPrs(graph([prNode({ pr_state: undefined })]));
+    expect(pr.state).toBe('');
+  });
+});

--- a/frontend/src/services/sprintGraph.test.ts
+++ b/frontend/src/services/sprintGraph.test.ts
@@ -47,7 +47,7 @@ describe('extractPrs', () => {
     expect(prs.map((p) => p.repository)).toEqual(['owner/infra', 'owner/ui']);
   });
 
-  it('drops stale and url-less PRs', () => {
+  it('drops superseded (stale, non-merged) and url-less PRs', () => {
     const prs = extractPrs(
       graph([
         prNode({ id: 'live', repository: 'owner/ui' }),
@@ -57,6 +57,20 @@ describe('extractPrs', () => {
       ]),
     );
     expect(prs.map((p) => p.id)).toEqual(['live']);
+  });
+
+  it('keeps merged PRs even though the backend marks them stale', () => {
+    // The backend sets stale=true *and* pr_state='merged' when a PR is merged on
+    // GitHub. Merged PRs should still surface on the review page (violet dot), so
+    // only superseded stale PRs are dropped.
+    const prs = extractPrs(
+      graph([
+        prNode({ id: 'live', repository: 'owner/ui' }),
+        prNode({ id: 'merged', repository: 'owner/api', stale: true, pr_state: 'merged' }),
+        prNode({ id: 'superseded', repository: 'owner/old', stale: true, pr_state: 'open' }),
+      ]),
+    );
+    expect(prs.map((p) => p.id)).toEqual(['merged', 'live']);
   });
 
   it('defaults baseBranch to main when missing', () => {

--- a/frontend/src/services/sprintGraph.ts
+++ b/frontend/src/services/sprintGraph.ts
@@ -21,3 +21,37 @@ export interface SprintGraph {
 export const sprintGraphService = {
   get: (sprintId: string) => api.get<SprintGraph>(`/sprints/${sprintId}/graph`),
 };
+
+export interface PrInfo {
+  id: string;
+  prUrl: string;
+  prNumber: string;
+  repository: string; // owner/repo
+  branch: string;
+  baseBranch: string;
+  state: string; // open | closed | merged | ''
+}
+
+// Collect every PullRequest node from a sprint graph (multi-repo = one per repo).
+// Stale PRs (superseded/merged) are filtered out; result is sorted by repository
+// for a stable tab order.
+export function extractPrs(graph: SprintGraph): PrInfo[] {
+  return graph.nodes
+    .filter((n) => n.type === 'PullRequest')
+    .map((n) => {
+      const r = n as Record<string, unknown>;
+      return {
+        id: String(n.id),
+        prUrl: String(r.pr_url ?? ''),
+        prNumber: String(r.pr_number ?? ''),
+        repository: String(r.repository ?? ''),
+        branch: String(r.branch ?? ''),
+        baseBranch: String(r.base_branch ?? 'main'),
+        state: String(r.pr_state ?? ''),
+        stale: r.stale === true || r.stale === 'true',
+      };
+    })
+    .filter((p) => !p.stale && p.prUrl)
+    .map(({ stale: _stale, ...p }) => p)
+    .sort((a, b) => a.repository.localeCompare(b.repository));
+}

--- a/frontend/src/services/sprintGraph.ts
+++ b/frontend/src/services/sprintGraph.ts
@@ -33,7 +33,8 @@ export interface PrInfo {
 }
 
 // Collect every PullRequest node from a sprint graph (multi-repo = one per repo).
-// Stale PRs (superseded/merged) are filtered out; result is sorted by repository
+// Superseded PRs (stale with no terminal state) are dropped, but merged PRs are kept
+// so they still surface (with a "merged" state dot); result is sorted by repository
 // for a stable tab order.
 export function extractPrs(graph: SprintGraph): PrInfo[] {
   return graph.nodes
@@ -51,7 +52,7 @@ export function extractPrs(graph: SprintGraph): PrInfo[] {
         stale: r.stale === true || r.stale === 'true',
       };
     })
-    .filter((p) => !p.stale && p.prUrl)
+    .filter((p) => (!p.stale || p.state === 'merged') && p.prUrl)
     .map(({ stale: _stale, ...p }) => p)
     .sort((a, b) => a.repository.localeCompare(b.repository));
 }

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -29,5 +29,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Stacked on #183 (multi-repo base) — review after #183.

Surfaces every `PullRequest` from the sprint graph (one per repo) on the review page: per-repo tabs with state dots, a labeled View PR button, and a scoped checkout command. Sprint actions and the review verdict sit below.

- `sprintGraph.extractPrs()` + `PrInfo` type (filters stale, sorts by repo, carries `pr_state`); unit tests
- `ReviewPage`: per-PR selection scopes View/checkout/comments; cancel-guarded comments fetch; NaN risk guard; `PARTIAL` verdict styling
- `PipelineView`: sidebar PR button navigates to the review page
- `reviews`/`ReviewEditor`: `PARTIAL` added to `ReviewStatus`