### PR TITLE
fix(agents): harden review stale-marking, PR pr_state, validation & PARTIAL

### DIFF
--- a/lambda/agents-ecs/mcp-server-graph/index.js
+++ b/lambda/agents-ecs/mcp-server-graph/index.js
@@ -56,8 +56,23 @@ const env = {
   })(),
 };
 
-// --- Neptune helpers (persistent connection with auto-reconnect) ---
+// Parse a GitHub repository identifier in "owner/repo" form into its parts.
+// Multiple call sites .split('/') and destructure [owner, repo] before building
+// api.github.com URLs; a malformed value (empty, no slash, extra segments) would
+// otherwise produce an undefined owner/repo and a silently-wrong request. Throw a
+// clear error instead so the failure is attributable.
+function parseOwnerRepo(s) {
+  if (typeof s !== 'string') {
+    throw new Error(`Invalid repository identifier: expected "owner/repo", got ${typeof s}`);
+  }
+  const parts = s.split('/');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`Invalid repository identifier "${s}": expected "owner/repo"`);
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
 
+// --- Neptune helpers (persistent connection with auto-reconnect) ---
 let _conn = null;
 let _g = null;
 
@@ -468,6 +483,20 @@ Use this to update status, description, title, or any mutable property.`,
   async ({ label, id, properties }) => {
     try {
       if (properties.id || properties.label) return err('Cannot change id or label');
+
+      // Whitelist guard: a Review's machine verdict drives downstream styling and
+      // gating, so reject any value outside the known set rather than letting an
+      // agent write a free-form status the frontend/validation can't interpret.
+      // Mirrors VALID_STATUSES in the reviews lambda.
+      if (label === 'Review' && properties.status !== undefined) {
+        const VALID_REVIEW_STATUSES = ['PENDING', 'PASSED', 'FAILED', 'PARTIAL'];
+        if (!VALID_REVIEW_STATUSES.includes(properties.status)) {
+          return err(
+            `Invalid Review status "${properties.status}". Must be one of: ${VALID_REVIEW_STATUSES.join(', ')}`,
+          );
+        }
+      }
+
       return await withGraph(async (g) => {
         const exists = await g.V().has(label, 'id', id).hasNext();
         if (!exists) return err(`${label} with id "${id}" not found`);
@@ -1158,7 +1187,7 @@ In multi-repo projects, creates one PR per repository and groups them in a PRGro
           for (const pr of existingGroup.prs) {
             try {
               const repoUrl = pr.repository || env.gitRepo;
-              const [owner, repo] = repoUrl.split('/');
+              const { owner, repo } = parseOwnerRepo(repoUrl);
               const ghRes = await fetch(
                 `https://api.github.com/repos/${owner}/${repo}/pulls/${pr.pr_number}`,
                 {
@@ -1215,6 +1244,16 @@ In multi-repo projects, creates one PR per repository and groups them in a PRGro
               .has('PRGroup', 'id', existingGroup.group.id)
               .property(cardinality.single, 'stale', 'true')
               .property(cardinality.single, 'stale_at', new Date().toISOString())
+              .next();
+            // Clear the denormalized PR copy on the Sprint vertex so it can't keep
+            // pointing at a now-stale/closed PR after the re-run (mirrors the
+            // single-repo stale path below). Fresh values are written when the new
+            // PRGroup's PRs are persisted further down.
+            await g
+              .V()
+              .has('Sprint', 'id', env.sprintId)
+              .property(cardinality.single, 'pr_url', '')
+              .property(cardinality.single, 'pr_number', '')
               .next();
           }).catch(() => {});
         }
@@ -1277,6 +1316,7 @@ In multi-repo projects, creates one PR per repository and groups them in a PRGro
               .property(cardinality.single, 'branch', branch)
               .property(cardinality.single, 'base_branch', baseBranch || 'main')
               .property(cardinality.single, 'repository', pr.repository)
+              .property(cardinality.single, 'pr_state', 'open')
               .next();
 
             // Link Sprint --HAS_PR--> PullRequest
@@ -1389,7 +1429,7 @@ In multi-repo projects, creates one PR per repository and groups them in a PRGro
         // Verify the PR is still open on GitHub — it may have been merged/closed since we stored it
         let prIsOpen = true;
         try {
-          const [owner, repo] = env.gitRepo.split('/');
+          const { owner, repo } = parseOwnerRepo(env.gitRepo);
           const ghRes = await fetch(
             `https://api.github.com/repos/${owner}/${repo}/pulls/${existingPr.prNumber}`,
             {
@@ -1492,6 +1532,7 @@ In multi-repo projects, creates one PR per repository and groups them in a PRGro
               .property(cardinality.single, 'pr_number', String(resp.prNumber))
               .property(cardinality.single, 'branch', branch)
               .property(cardinality.single, 'base_branch', baseBranch || 'main')
+              .property(cardinality.single, 'pr_state', 'open')
               .next();
 
             // Link Sprint --HAS_PR--> PullRequest (only if edge doesn't already exist)
@@ -1598,7 +1639,7 @@ If repository is omitted, posts to the primary PR (stored on the Sprint vertex).
         prNumber = sprintData.prNumber;
       }
 
-      const [owner, repo] = targetRepo.split('/');
+      const { owner, repo } = parseOwnerRepo(targetRepo);
       const response = await fetch(
         `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/comments`,
         {

--- a/lambda/agents-ecs/mcp-server-graph/index.js
+++ b/lambda/agents-ecs/mcp-server-graph/index.js
@@ -487,7 +487,8 @@ Use this to update status, description, title, or any mutable property.`,
       // Whitelist guard: a Review's machine verdict drives downstream styling and
       // gating, so reject any value outside the known set rather than letting an
       // agent write a free-form status the frontend/validation can't interpret.
-      // Mirrors VALID_STATUSES in the reviews lambda.
+      // Canonical list: lambda/shared/review-statuses.js (used by reviews lambda).
+      // Inlined here because the ECS container build doesn't include lambda/shared — update both.
       if (label === 'Review' && properties.status !== undefined) {
         const VALID_REVIEW_STATUSES = ['PENDING', 'PASSED', 'FAILED', 'PARTIAL'];
         if (!VALID_REVIEW_STATUSES.includes(properties.status)) {
@@ -1268,7 +1269,8 @@ In multi-repo projects, creates one PR per repository and groups them in a PRGro
                   projectId: env.projectId,
                   branch,
                   baseBranch,
-                  title: title || `Construction: ${env.sprintId} (${repo.url.split('/')[1]})`,
+                  title:
+                    title || `Construction: ${env.sprintId} (${parseOwnerRepo(repo.url).repo})`,
                   gitToken: env.gitToken,
                   gitRepo: repo.url,
                   executionId: process.env.EXECUTION_ID || '',
@@ -1688,7 +1690,7 @@ Use this to understand reviewer feedback before making modifications.`,
 
       if (!sprintData?.prNumber) return err('No PR found for this sprint');
 
-      const [owner, repo] = env.gitRepo.split('/');
+      const { owner, repo } = parseOwnerRepo(env.gitRepo);
       const headers = {
         Authorization: `token ${env.gitToken}`,
         Accept: 'application/vnd.github.v3+json',

--- a/lambda/agents-ecs/pool-worker.js
+++ b/lambda/agents-ecs/pool-worker.js
@@ -483,11 +483,14 @@ function cloneAndSetupBranch(job, repoUrl, targetDir) {
       );
     }
 
-    // Configure git
-    execSync(`cd "${targetDir}" && git config user.email "ai-dlc@example.com"`, {
+    // Configure git. Identity is overridable via env (set by the task def);
+    // falls back to a neutral default so commits always have an author.
+    const gitEmail = process.env.GIT_AUTHOR_EMAIL || 'ai-dlc@example.com';
+    const gitName = process.env.GIT_AUTHOR_NAME || 'AI-DLC Agent';
+    execSync(`cd "${targetDir}" && git config user.email "${gitEmail}"`, {
       stdio: 'inherit',
     });
-    execSync(`cd "${targetDir}" && git config user.name "AI-DLC Agent"`, { stdio: 'inherit' });
+    execSync(`cd "${targetDir}" && git config user.name "${gitName}"`, { stdio: 'inherit' });
 
     // For construction (sub-agents + orchestrator) and review phases, checkout/create the working branch
     const needsBranch = [
@@ -903,12 +906,19 @@ Perform a BUSINESS CODE REVIEW cross-referencing the implementation against requ
 \`\`\`
 ## Business Review
 
-**Verdict**: PASS | FAIL | PARTIAL
+**Verdict**: PASSED | FAILED | PARTIAL
 
 **Requirements Coverage**:
-| Requirement | Status | Notes |
-|---|---|---|
-| <req title> | ✅ Met / ⚠️ Partial / ❌ Missing | <brief note> |
+| Requirement | Repository | Status | Notes |
+|---|---|---|---|
+| <req title> | <owner/repo, or "all"> | ✅ Met / ⚠️ Partial / ❌ Missing | <brief note> |
+
+**Per-Repo Status** (multi-repo sprints — one line per repository):
+- <owner/repo>: ✅ PASSED / ⚠️ PARTIAL / ❌ FAILED — <brief note>
+
+NOTE: the machine **Verdict**/\`status\` above is sprint-wide (one aggregate verdict
+per sprint). When repos diverge (e.g. infra PASSED but ui FAILED), reflect that here
+in the per-repo breakdown and set the aggregate Verdict to PARTIAL.
 
 **Key Issues**:
 - 🔴 CRITICAL: …
@@ -940,10 +950,10 @@ Risk score guidance:
 
 > Reviewed by the AI-DLC Business Review Agent (with requirements context)
 
-**Verdict**: PASS | FAIL | PARTIAL
+**Verdict**: PASSED | FAILED | PARTIAL
 
 **Requirements Coverage**:
-<requirements table>
+<requirements table (include the Repository column)>
 
 **Key Issues**:
 <bullet list of critical/warning items only, or "None found">
@@ -1224,7 +1234,6 @@ function runAcpSession(job) {
       GIT_TOKEN: job.gitToken || '',
       GIT_REPO: job.gitRepo || '',
       GIT_REPOS: JSON.stringify(job.gitRepos || []),
-      WORKSPACE_LAYOUT: job.gitRepos && job.gitRepos.length > 1 ? 'multi' : 'single',
       RUN_NUMBER: String(job.runNumber || 1),
     };
 

--- a/lambda/agents/index.js
+++ b/lambda/agents/index.js
@@ -46,31 +46,10 @@ const STALE_BUSY_MS = 30 * 60 * 1000; // 30 minutes — sub-agents should not ru
 // pool-worker, which interpolates them into shell `git` commands. The projects
 // lambda validates on write, but legacy/pre-existing `git_repo` values were
 // stored without validation, so we MUST re-validate here on the read path.
+// Validators live in shared/ so the agents and projects lambdas can't drift.
 // ---------------------------------------------------------------------------
 
-// Reject anything that could break out of a double-quoted shell string. Mirrors
-// SHELL_SAFE_REPO_PATTERN in the projects lambda; we additionally reject ".."
-// path traversal (the multi-repo path interpolates url into /workspace/${url}).
-const SHELL_SAFE_REPO_PATTERN = /^[A-Za-z0-9._@:/-]+$/;
-// Git refs: letters, digits, ., _, /, - only. No leading dash (arg injection),
-// no ".." and no "@{" (git revision syntax).
-const GIT_REF_PATTERN = /^[A-Za-z0-9._/-]+$/;
-
-const isSafeRepo = (v) =>
-  typeof v === 'string' &&
-  v.length > 0 &&
-  v.length <= 200 &&
-  SHELL_SAFE_REPO_PATTERN.test(v) &&
-  !v.includes('..');
-
-const isSafeRef = (v) =>
-  typeof v === 'string' &&
-  v.length > 0 &&
-  v.length <= 200 &&
-  GIT_REF_PATTERN.test(v) &&
-  !v.startsWith('-') &&
-  !v.includes('..') &&
-  !v.includes('@{');
+const { isSafeRepo, isSafeRef } = require('./shared/repo-validation');
 
 const getConnection = async () => {
   const host = process.env.NEPTUNE_ENDPOINT;

--- a/lambda/agents/index.js
+++ b/lambda/agents/index.js
@@ -30,6 +30,7 @@ const ssm = new SSMClient({ region: process.env.AWS_REGION || 'us-east-1' });
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const { cardinality } = gremlin.process;
+const __ = gremlin.process.statics;
 
 const POOL_TABLE = process.env.POOL_TABLE || '';
 const POOL_SIZE = parseInt(process.env.POOL_SIZE || '5', 10);
@@ -39,6 +40,37 @@ const POOL_VERSION = process.env.POOL_VERSION || 'unknown';
 const STALE_STARTING_MS = 5 * 60 * 1000; // 5 minutes
 const STALE_IDLE_MS = 3 * 60 * 1000; // 3 minutes
 const STALE_BUSY_MS = 30 * 60 * 1000; // 30 minutes — sub-agents should not run this long
+
+// ---------------------------------------------------------------------------
+// Repo / branch validation — authoritative gate before values reach the
+// pool-worker, which interpolates them into shell `git` commands. The projects
+// lambda validates on write, but legacy/pre-existing `git_repo` values were
+// stored without validation, so we MUST re-validate here on the read path.
+// ---------------------------------------------------------------------------
+
+// Reject anything that could break out of a double-quoted shell string. Mirrors
+// SHELL_SAFE_REPO_PATTERN in the projects lambda; we additionally reject ".."
+// path traversal (the multi-repo path interpolates url into /workspace/${url}).
+const SHELL_SAFE_REPO_PATTERN = /^[A-Za-z0-9._@:/-]+$/;
+// Git refs: letters, digits, ., _, /, - only. No leading dash (arg injection),
+// no ".." and no "@{" (git revision syntax).
+const GIT_REF_PATTERN = /^[A-Za-z0-9._/-]+$/;
+
+const isSafeRepo = (v) =>
+  typeof v === 'string' &&
+  v.length > 0 &&
+  v.length <= 200 &&
+  SHELL_SAFE_REPO_PATTERN.test(v) &&
+  !v.includes('..');
+
+const isSafeRef = (v) =>
+  typeof v === 'string' &&
+  v.length > 0 &&
+  v.length <= 200 &&
+  GIT_REF_PATTERN.test(v) &&
+  !v.startsWith('-') &&
+  !v.includes('..') &&
+  !v.includes('@{');
 
 const getConnection = async () => {
   const host = process.env.NEPTUNE_ENDPOINT;
@@ -724,6 +756,29 @@ exports.handler = async (event) => {
         });
       }
 
+      // SECURITY: re-validate every repo URL and git ref before they reach the
+      // pool-worker, which interpolates them into shell `git` commands. Legacy
+      // `git_repo` values may predate the projects-lambda write-time validation,
+      // so this read-path gate is authoritative against command injection.
+      for (const url of [gitRepo, ...gitRepos.map((r) => r.url)].filter(Boolean)) {
+        if (!isSafeRepo(url)) {
+          console.error(`[agents] Rejecting job: unsafe repository url ${JSON.stringify(url)}`);
+          return response(400, {
+            error: 'Invalid repository',
+            message: 'A linked repository URL contains unsafe characters and cannot be cloned.',
+          });
+        }
+      }
+      for (const ref of [input.branch, input.baseBranch].filter(Boolean)) {
+        if (!isSafeRef(ref)) {
+          console.error(`[agents] Rejecting job: unsafe git ref ${JSON.stringify(ref)}`);
+          return response(400, {
+            error: 'Invalid branch',
+            message: 'The branch name contains characters that are not allowed.',
+          });
+        }
+      }
+
       const job = {
         executionId,
         projectId,
@@ -872,7 +927,13 @@ exports.handler = async (event) => {
                   .property(cardinality.single, 'stale_at', new Date().toISOString())
                   .toList();
               } catch (staleErr) {
-                console.error('Failed to mark Review nodes as stale:', staleErr.message);
+                // Non-fatal: construction proceeds even if stale-marking fails, but
+                // log distinctly so a silent regression (e.g. a missing `__` import)
+                // surfaces in CloudWatch instead of leaving reviews permanently un-stale.
+                console.error(
+                  `[stale-review] Failed to mark Review nodes stale for sprint ${input.sprintId}:`,
+                  staleErr,
+                );
               }
             }
 

--- a/lambda/create-pr/create-pr.js
+++ b/lambda/create-pr/create-pr.js
@@ -151,7 +151,11 @@ exports.handler = async (event) => {
 
   try {
     // Get project details from Neptune via GitHub Lambda
-    const [owner, repo] = gitRepo.split('/');
+    const parts = gitRepo.split('/');
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      return { statusCode: 400, body: `Invalid gitRepo "${gitRepo}": expected "owner/repo"` };
+    }
+    const [owner, repo] = parts;
 
     // Create PR using GitHub API
     const prTitle = `AI-DLC: ${branch}`;
@@ -193,40 +197,56 @@ exports.handler = async (event) => {
       // 422 means a PR already exists for this branch — look it up and return it
       if (response.status === 422) {
         console.log(`PR already exists for branch ${branch}, fetching existing PR...`);
-        const listRes = await fetch(
-          `https://api.github.com/repos/${owner}/${repo}/pulls?head=${owner}:${branch}&state=open`,
-          { headers: ghHeaders },
-        );
-        if (listRes.ok) {
-          const prs = await listRes.json();
-          if (prs.length > 0) {
-            console.log('Found existing PR:', prs[0].html_url);
-            await cleanupConstructionTaskBranches({ owner, repo, branch, ghHeaders });
-            return {
-              statusCode: 200,
-              prUrl: prs[0].html_url,
-              prNumber: prs[0].number,
-              existing: true,
-            };
+        // The head filter `${owner}:${branch}` assumes the PR's head branch lives
+        // in the SAME owner as the base repo. That holds for our same-repo flow but
+        // is brittle for fork/org-mismatch setups (head would be `forkOwner:branch`).
+        // So we try the precise head filter first, then fall back to listing PRs and
+        // matching on the branch ref (head.ref) regardless of head owner.
+        const findByBranch = async (state) => {
+          // Precise: owner-qualified head filter.
+          const headRes = await fetch(
+            `https://api.github.com/repos/${owner}/${repo}/pulls?head=${owner}:${branch}&state=${state}`,
+            { headers: ghHeaders },
+          );
+          if (headRes.ok) {
+            const headPrs = await headRes.json();
+            if (headPrs.length > 0) return headPrs[0];
           }
+          // Fallback: list PRs and match on the branch ref (handles fork/org mismatch).
+          const listRes = await fetch(
+            `https://api.github.com/repos/${owner}/${repo}/pulls?state=${state}&per_page=100`,
+            { headers: ghHeaders },
+          );
+          if (listRes.ok) {
+            const prs = await listRes.json();
+            const match = prs.find((p) => p.head?.ref === branch);
+            if (match) return match;
+          }
+          return null;
+        };
+
+        const openPr = await findByBranch('open');
+        if (openPr) {
+          console.log('Found existing PR:', openPr.html_url);
+          await cleanupConstructionTaskBranches({ owner, repo, branch, ghHeaders });
+          return {
+            statusCode: 200,
+            prUrl: openPr.html_url,
+            prNumber: openPr.number,
+            existing: true,
+          };
         }
-        // PR is closed/merged — check closed PRs too
-        const closedRes = await fetch(
-          `https://api.github.com/repos/${owner}/${repo}/pulls?head=${owner}:${branch}&state=all`,
-          { headers: ghHeaders },
-        );
-        if (closedRes.ok) {
-          const allPrs = await closedRes.json();
-          if (allPrs.length > 0) {
-            console.log('Found existing (closed) PR:', allPrs[0].html_url);
-            await cleanupConstructionTaskBranches({ owner, repo, branch, ghHeaders });
-            return {
-              statusCode: 200,
-              prUrl: allPrs[0].html_url,
-              prNumber: allPrs[0].number,
-              existing: true,
-            };
-          }
+        // PR is closed/merged — check all states too
+        const anyPr = await findByBranch('all');
+        if (anyPr) {
+          console.log('Found existing (closed) PR:', anyPr.html_url);
+          await cleanupConstructionTaskBranches({ owner, repo, branch, ghHeaders });
+          return {
+            statusCode: 200,
+            prUrl: anyPr.html_url,
+            prNumber: anyPr.number,
+            existing: true,
+          };
         }
       }
       console.error('GitHub API error:', errorText);

--- a/lambda/create-pr/test/create-pr.test.js
+++ b/lambda/create-pr/test/create-pr.test.js
@@ -155,3 +155,139 @@ describe('create-pr construction branch cleanup', () => {
     }
   });
 });
+
+describe('create-pr handler — gitRepo validation', () => {
+  it('returns 400 when gitRepo is missing a slash', async () => {
+    const { handler } = await loadCreatePr();
+    const result = await handler({
+      projectId: 'p1',
+      branch: 'ai-dlc/sprint-1',
+      baseBranch: 'main',
+      gitRepo: 'no-slash-here',
+      gitToken: 'token',
+      executionId: 'e1',
+    });
+    expect(result.statusCode).toBe(400);
+    expect(result.body).toMatch(/expected "owner\/repo"/);
+  });
+
+  it('returns 400 when gitRepo has too many segments', async () => {
+    const { handler } = await loadCreatePr();
+    const result = await handler({
+      projectId: 'p1',
+      branch: 'ai-dlc/sprint-1',
+      baseBranch: 'main',
+      gitRepo: 'owner/repo/extra',
+      gitToken: 'token',
+      executionId: 'e1',
+    });
+    expect(result.statusCode).toBe(400);
+    expect(result.body).toMatch(/expected "owner\/repo"/);
+  });
+
+  it('returns 400 when gitRepo is empty', async () => {
+    const { handler } = await loadCreatePr();
+    const result = await handler({
+      projectId: 'p1',
+      branch: 'ai-dlc/sprint-1',
+      baseBranch: 'main',
+      gitRepo: '',
+      gitToken: 'token',
+      executionId: 'e1',
+    });
+    expect(result.statusCode).toBe(400);
+  });
+});
+
+describe('create-pr handler — findByBranch fallback (PR already exists)', () => {
+  const makeExistingPrFetch = ({ preciseFinds = true, matchingPr = null } = {}) =>
+    vi.fn(async (url) => {
+      if (url.includes('/git/matching-refs/')) return { ok: true, json: async () => [] }; // no task branches
+      // First PR creation attempt — 422 (already exists)
+      if (url.endsWith('/pulls') && !url.includes('?'))
+        return { ok: false, status: 422, text: async () => 'Unprocessable' };
+      // Precise head-qualified lookup
+      if (url.includes('?head=') && url.includes(':')) {
+        const prs = preciseFinds
+          ? [
+              {
+                html_url: 'https://github.com/owner/repo/pull/3',
+                number: 3,
+                head: { ref: 'feat/x' },
+              },
+            ]
+          : [];
+        return { ok: true, json: async () => prs };
+      }
+      // Fallback list lookup
+      const prs = matchingPr ? [matchingPr] : [];
+      return { ok: true, json: async () => prs };
+    });
+
+  it('returns the existing open PR when the precise head-qualified lookup finds it', async () => {
+    const { handler } = await loadCreatePr();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = makeExistingPrFetch({ preciseFinds: true });
+    try {
+      const result = await handler({
+        projectId: 'p1',
+        branch: 'feat/x',
+        baseBranch: 'main',
+        gitRepo: 'owner/repo',
+        gitToken: 'token',
+        executionId: 'e1',
+      });
+      expect(result).toMatchObject({ statusCode: 200, prNumber: 3, existing: true });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('falls back to listing PRs when head-qualified lookup returns empty (fork/org mismatch)', async () => {
+    // Simulates a fork where the PR head is forkOwner:feat/x — the precise
+    // owner:branch filter returns nothing, so we fall through to the full list.
+    const { handler } = await loadCreatePr();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = makeExistingPrFetch({
+      preciseFinds: false,
+      matchingPr: {
+        html_url: 'https://github.com/owner/repo/pull/9',
+        number: 9,
+        head: { ref: 'feat/x' },
+      },
+    });
+    try {
+      const result = await handler({
+        projectId: 'p1',
+        branch: 'feat/x',
+        baseBranch: 'main',
+        gitRepo: 'owner/repo',
+        gitToken: 'token',
+        executionId: 'e1',
+      });
+      expect(result).toMatchObject({ statusCode: 200, prNumber: 9, existing: true });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns 500 when neither lookup finds the PR', async () => {
+    const { handler } = await loadCreatePr();
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = makeExistingPrFetch({ preciseFinds: false, matchingPr: null });
+    try {
+      const result = await handler({
+        projectId: 'p1',
+        branch: 'feat/x',
+        baseBranch: 'main',
+        gitRepo: 'owner/repo',
+        gitToken: 'token',
+        executionId: 'e1',
+      });
+      // Neither open nor any state found — falls through to the throw at line 253
+      expect(result.statusCode).toBe(500);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/lambda/projects/index.js
+++ b/lambda/projects/index.js
@@ -141,16 +141,9 @@ const REPO_URL_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,38}\/[a-zA-Z0-9][a-zA-Z0-9.
 // The legacy `gitRepo` field is historically a freeform string (bare names,
 // SSH URLs). We can't tighten it to owner/repo without breaking that contract,
 // but it still gets interpolated into `git clone "https://.../${url}.git"` in
-// the pool-worker. This whitelist rejects exactly the characters that can break
-// out of that double-quoted shell string ("  `  $  \  whitespace), closing the
-// injection vector while preserving freeform values.
-const SHELL_SAFE_REPO_PATTERN = /^[A-Za-z0-9._@:/-]+$/;
-
-// Shell-safe AND traversal-safe. Rejects "..", which the raw pattern would
-// otherwise allow (e.g. "../../foo"), keeping the value safe for both the
-// clone URL and the multi-repo "/workspace/${url}" directory interpolation.
-const isShellSafeRepo = (v) =>
-  typeof v === 'string' && v.length > 0 && SHELL_SAFE_REPO_PATTERN.test(v) && !v.includes('..');
+// the pool-worker. The shell/traversal-safe guard lives in shared/ so it can't
+// drift from the agents lambda's read-path copy (esbuild bundles ../shared).
+const { isSafeRepo } = require('../shared/repo-validation');
 
 // Canonical repository role + provider vocabularies. Keep in sync with
 // `RepoRole` and `ProjectRepo.provider` in frontend/src/services/projects.ts.
@@ -201,7 +194,7 @@ const ensureLegacyRepoMigrated = async (g, projectId, legacyGitRepo) => {
   // Legacy git_repo is freeform, so we only enforce shell-safety here (not strict
   // owner/repo). Skip (don't throw) on a dangerous value — this runs on read paths
   // and must not break GETs of old projects.
-  if (!isShellSafeRepo(legacyGitRepo)) {
+  if (!isSafeRepo(legacyGitRepo)) {
     console.error(
       `[projects] Skipping migration of unsafe git_repo value for ${projectId}: ${JSON.stringify(legacyGitRepo)}`,
     );
@@ -827,7 +820,7 @@ export const handler = async (event) => {
           const repoInputError = validateRepoRoleAndProvider(repo);
           if (repoInputError) return response(400, { error: repoInputError });
         }
-        if (legacyGitRepo && !isShellSafeRepo(legacyGitRepo)) {
+        if (legacyGitRepo && !isSafeRepo(legacyGitRepo)) {
           return response(400, { error: `Invalid gitRepo "${legacyGitRepo}".` });
         }
 
@@ -941,7 +934,7 @@ export const handler = async (event) => {
         if (data.gitRepo !== undefined) {
           // SECURITY: same execSync sink as POST. The legacy gitRepo is freeform
           // but must be shell-safe so it can't break out of the git clone command.
-          if (data.gitRepo && !isShellSafeRepo(data.gitRepo)) {
+          if (data.gitRepo && !isSafeRepo(data.gitRepo)) {
             return response(400, { error: `Invalid gitRepo "${data.gitRepo}".` });
           }
           await g

--- a/lambda/reviews/index.js
+++ b/lambda/reviews/index.js
@@ -23,7 +23,7 @@ const getConnection = async () => {
 // FAILED") cannot be expressed in the machine status; the human-readable per-repo
 // breakdown lives in `full_review` (see pool-worker.js buildFullReviewPrompt).
 // Splitting the model into per-repo Review nodes is deferred.
-const VALID_STATUSES = ['PENDING', 'PASSED', 'FAILED', 'PARTIAL'];
+const { VALID_REVIEW_STATUSES: VALID_STATUSES } = require('./shared/review-statuses');
 
 const mapReview = (v) => ({
   id: v.get('id')?.[0] || '',
@@ -77,7 +77,9 @@ exports.handler = async (event) => {
           .toList();
         if (allReviews.length === 0) return res(200, null);
         const activeReview = allReviews.find((v) => v.get('stale')?.[0] !== 'true');
-        return res(200, mapReview(activeReview || allReviews[allReviews.length - 1]));
+        // All stale: return the most recent. With Order.desc on stale_at the newest
+        // is at index 0 (allReviews[length-1] would be the oldest).
+        return res(200, mapReview(activeReview || allReviews[0]));
       }
 
       case 'POST': {

--- a/lambda/reviews/index.js
+++ b/lambda/reviews/index.js
@@ -7,6 +7,7 @@ const { buildResponse } = require('./shared/response');
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
 const { cardinality } = gremlin.process;
+const { order: Order } = gremlin.process;
 
 const getConnection = async () => {
   const host = process.env.NEPTUNE_ENDPOINT;
@@ -16,6 +17,12 @@ const getConnection = async () => {
   return new DriverRemoteConnection(connInfo.url, { headers: connInfo.headers });
 };
 
+// NOTE (known design constraint, tracked): the review verdict is sprint-wide —
+// exactly one active Review per Sprint — so a single `status` aggregates quality
+// across ALL repos in a multi-repo sprint. Per-repo verdicts ("infra PASSED, ui
+// FAILED") cannot be expressed in the machine status; the human-readable per-repo
+// breakdown lives in `full_review` (see pool-worker.js buildFullReviewPrompt).
+// Splitting the model into per-repo Review nodes is deferred.
 const VALID_STATUSES = ['PENDING', 'PASSED', 'FAILED', 'PARTIAL'];
 
 const mapReview = (v) => ({
@@ -48,12 +55,24 @@ exports.handler = async (event) => {
 
     switch (httpMethod) {
       case 'GET': {
-        // Return the active (non-stale) review. If all are stale, return the most recent one.
+        // Return the active (non-stale) review. If all are stale, return the most
+        // recent one. valueMap().toList() order is NOT guaranteed by the graph
+        // engine, so order by stale_at desc. The active review has no stale_at, so
+        // coalesce to '' keeps it in the list (order().by(missingKey) would
+        // otherwise drop it); it is selected by the .find() below regardless.
         const allReviews = await g
           .V()
           .has('Sprint', 'id', sprintId)
           .out('HAS_REVIEW')
           .hasLabel('Review')
+          .order()
+          .by(
+            gremlin.process.statics.coalesce(
+              gremlin.process.statics.values('stale_at'),
+              gremlin.process.statics.constant(''),
+            ),
+            Order.desc,
+          )
           .valueMap()
           .toList();
         if (allReviews.length === 0) return res(200, null);

--- a/lambda/shared/repo-validation.js
+++ b/lambda/shared/repo-validation.js
@@ -1,0 +1,41 @@
+// Shared shell-injection guards for repo identifiers and git refs.
+//
+// These values are interpolated into double-quoted shell `git` commands (clone
+// URLs) and into "/workspace/${url}" directory paths by the pool-worker, so this
+// is the authoritative injection gate. It lived in two copies (agents + projects
+// lambdas) that had already drifted (one capped length, the other didn't); keeping
+// a single definition here prevents a future hardening fix from being applied to
+// one lambda but not the other.
+//
+// Consumed by:
+//   - lambda/agents/index.js   via require('./shared/repo-validation')  (raw-zip, runtime ./shared)
+//   - lambda/projects/index.js via require('../shared/repo-validation') (esbuild bundles ../shared)
+
+// Reject anything that could break out of a double-quoted shell string
+// ("  `  $  \  whitespace). Freeform values (bare names, SSH URLs) still pass.
+const SHELL_SAFE_REPO_PATTERN = /^[A-Za-z0-9._@:/-]+$/;
+
+// Git refs: letters, digits, ., _, /, - only. No leading dash (arg injection),
+// no ".." and no "@{" (git revision syntax).
+const GIT_REF_PATTERN = /^[A-Za-z0-9._/-]+$/;
+
+// Shell-safe AND traversal-safe repo identifier. Rejects "..", which the raw
+// pattern would otherwise allow (e.g. "../../foo"), keeping the value safe for
+// both the clone URL and the "/workspace/${url}" directory interpolation.
+const isSafeRepo = (v) =>
+  typeof v === 'string' &&
+  v.length > 0 &&
+  v.length <= 200 &&
+  SHELL_SAFE_REPO_PATTERN.test(v) &&
+  !v.includes('..');
+
+const isSafeRef = (v) =>
+  typeof v === 'string' &&
+  v.length > 0 &&
+  v.length <= 200 &&
+  GIT_REF_PATTERN.test(v) &&
+  !v.startsWith('-') &&
+  !v.includes('..') &&
+  !v.includes('@{');
+
+module.exports = { SHELL_SAFE_REPO_PATTERN, GIT_REF_PATTERN, isSafeRepo, isSafeRef };

--- a/lambda/shared/review-statuses.js
+++ b/lambda/shared/review-statuses.js
@@ -1,0 +1,9 @@
+// Canonical set of valid Review status values.
+//
+// The ECS container (mcp-server-graph) inlines a copy of this list because it
+// can't import from lambda/shared/ at runtime (Dockerfile only copies
+// lambda/agents-ecs/*). Update BOTH when adding a new status.
+// Consumed by lambda/reviews/index.js and lambda/agents-ecs/mcp-server-graph/index.js.
+const VALID_REVIEW_STATUSES = ['PENDING', 'PASSED', 'FAILED', 'PARTIAL'];
+
+module.exports = { VALID_REVIEW_STATUSES };

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -347,6 +347,10 @@ module "agents" {
   # Bedrock model pinning for claude and opencode drivers.
   bedrock_model = var.bedrock_model
 
+  # Git identity for agent-created commits (overridable per deployment).
+  git_author_name  = var.git_author_name
+  git_author_email = var.git_author_email
+
   tags = {
     Environment = var.environment
     Project     = var.project_name

--- a/terraform/modules/compute/agents/main.tf
+++ b/terraform/modules/compute/agents/main.tf
@@ -342,6 +342,9 @@ resource "aws_ecs_task_definition" "agent" {
       { name = "BEDROCK_BEARER_TOKEN_SSM_PATH", value = aws_ssm_parameter.bedrock_bearer_token.name },
       { name = "MCP_SERVERS_SSM_PATH", value = aws_ssm_parameter.mcp_servers.name },
       { name = "KIRO_API_KEY_SSM_PATH", value = aws_ssm_parameter.kiro_api_key.name },
+      # Git identity for commits the agents create (overridable per deployment).
+      { name = "GIT_AUTHOR_NAME", value = var.git_author_name },
+      { name = "GIT_AUTHOR_EMAIL", value = var.git_author_email },
     ]
     logConfiguration = {
       logDriver = "awslogs"

--- a/terraform/modules/compute/agents/variables.tf
+++ b/terraform/modules/compute/agents/variables.tf
@@ -200,3 +200,15 @@ variable "bedrock_small_fast_model" {
   type        = string
   default     = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
 }
+
+variable "git_author_name" {
+  description = "Git author name used by agents for commits they create (pool-worker reads GIT_AUTHOR_NAME)"
+  type        = string
+  default     = "AI-DLC Agent"
+}
+
+variable "git_author_email" {
+  description = "Git author email used by agents for commits they create (pool-worker reads GIT_AUTHOR_EMAIL)"
+  type        = string
+  default     = "ai-dlc@example.com"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -21,3 +21,15 @@ variable "bedrock_model" {
   type        = string
   default     = "us.anthropic.claude-sonnet-4-6"
 }
+
+variable "git_author_name" {
+  description = "Git author name used by agents for commits they create"
+  type        = string
+  default     = "AI-DLC Agent"
+}
+
+variable "git_author_email" {
+  description = "Git author email used by agents for commits they create"
+  type        = string
+  default     = "ai-dlc@example.com"
+}


### PR DESCRIPTION
Stacked on #236 (review) → #183 (multi-repo base). **Draft — pending rebase onto current `main` + reconciliation with #215/#205/#226** (overlaps in pool-worker / mcp-server-graph / reviews).

- agents: define missing `__` (gremlin.process.statics) so review nodes are marked stale on construction re-run
- mcp-server-graph: `pr_state='open'` at PR creation (multi & single repo); clear sprint pr fields on stale; `parseOwnerRepo` validation; whitelist `Review.status`
- reviews: accept PARTIAL; deterministic order-by
- create-pr: robust 422 existing-PR lookup + owner/repo validation
- pool-worker: per-repo coverage in full_review