### PR TITLE
chore: add jeromevdl as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @leandrodamascena @svozza @eipasteur @JWThewes
+* @leandrodamascena @svozza @eipasteur @JWThewes @jeromevdl


### PR DESCRIPTION
Adds @jeromevdl to the global CODEOWNERS entry so they are requested for review on all changes.