### PR TITLE
chore: group dependabot PRs, add auto-merge and terraform CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,22 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'npm'
     directory: '/frontend'
     schedule:
       interval: 'weekly'
       day: 'monday'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'npm'
     directories:
@@ -19,15 +29,29 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'terraform'
     directory: '/terraform'
     schedule:
       interval: 'weekly'
       day: 'monday'
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
       day: 'monday'
+    groups:
+      all:
+        patterns:
+          - '*'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,35 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        id: metadata
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Approve PR
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+          && steps.metadata.outputs.directory != '/frontend'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge minor/patch updates (except frontend)
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+          && steps.metadata.outputs.directory != '/frontend'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - aidlc-v2
     paths:
       - 'frontend/**'
       - 'package.json'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - aidlc-v2
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,30 @@
+name: Terraform
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**'
+  push:
+    branches: [main, aidlc-v2]
+    paths:
+      - 'terraform/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+
+      - name: Terraform Format Check
+        working-directory: terraform
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        working-directory: terraform
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        working-directory: terraform
+        run: terraform validate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - aidlc-v2
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
*Description of changes:*

- Group minor/patch updates per ecosystem in dependabot.yml
- Add auto-merge workflow for non-major, non-frontend updates
- Add terraform fmt check + validate workflow
- Add aidlc-v2 branch to all CI workflow push triggers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
