### PR TITLE
fix: enforce authorization on v1 history reads

### DIFF
--- a/lambda/agents/index.js
+++ b/lambda/agents/index.js
@@ -23,6 +23,7 @@ import {
   InvokeAgentRuntimeCommand,
 } from '@aws-sdk/client-bedrock-agentcore';
 import gremlin from 'gremlin';
+import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
@@ -34,6 +35,11 @@ import { listMcpSecrets, putMcpSecrets } from '../shared/mcp-secrets-store.js';
 import { fetchMembershipRole } from '../shared/trackers.js';
 import { listClaudeModels } from '../shared/bedrock-models.js';
 import { refreshPricing } from '../shared/model-pricing.js';
+import {
+  authorizeLegacyProjectRead,
+  authorizeLegacySprintRead,
+  fetchProjectIdForExecution,
+} from '../shared/legacy-authz.js';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const ssm = new SSMClient({ region: process.env.AWS_REGION || 'us-east-1' });
@@ -140,23 +146,65 @@ const fetchGlobalCustomMcpServers = async () => {
 
 const getConnection = async () => {
   const host = process.env.NEPTUNE_ENDPOINT;
-  const port = '8182';
+  const port = process.env.GREMLIN_PORT || '8182';
+  const protocol = process.env.GREMLIN_PROTOCOL || 'wss';
+  if (protocol !== 'wss') {
+    return new DriverRemoteConnection(`${protocol}://${host}:${port}/gremlin`);
+  }
   const region = process.env.AWS_REGION || 'us-east-1';
   const credentials = await fromNodeProviderChain()();
   credentials.region = region;
-  const connInfo = getUrlAndHeaders(host, port, credentials, '/gremlin', 'wss');
+  const connInfo = getUrlAndHeaders(host, port, credentials, '/gremlin', protocol);
   return new DriverRemoteConnection(connInfo.url, { headers: connInfo.headers });
 };
 
 async function withNeptune(fn) {
   const conn = await getConnection();
   try {
-    const g = traversal().withRemote(conn);
+    let g = traversal().withRemote(conn);
+    if (process.env.GREMLIN_PARTITION) {
+      g = g.withStrategies(
+        new PartitionStrategy({
+          partitionKey: '_partition',
+          writePartition: process.env.GREMLIN_PARTITION,
+          readPartitions: [process.env.GREMLIN_PARTITION],
+        }),
+      );
+    }
     return await fn(g);
   } finally {
     await conn.close();
   }
 }
+
+const authorizeExecutionRead = async (event, storedProjectId, executionIds) =>
+  withNeptune(async (g) => {
+    const projectId =
+      storedProjectId || (await fetchProjectIdForExecution(g, executionIds.filter(Boolean)));
+    if (!projectId) {
+      return { denied: true, statusCode: 404, error: 'Agent execution not found' };
+    }
+    return authorizeLegacyProjectRead(g, event, projectId);
+  });
+
+const PUBLIC_AGENT_QUESTION_FIELDS = [
+  'questionId',
+  'agentTaskId',
+  'questions',
+  'status',
+  'structuredAnswer',
+  'answeredBy',
+  'answeredByName',
+  'answeredAt',
+  'createdAt',
+];
+
+const publicAgentQuestion = (item) =>
+  Object.fromEntries(
+    PUBLIC_AGENT_QUESTION_FIELDS.filter((field) =>
+      Object.prototype.hasOwnProperty.call(item, field),
+    ).map((field) => [field, item[field]]),
+  );
 
 function modelPricingPath() {
   const prefix = process.env.AGENT_SETTINGS_SSM_PREFIX || '';
@@ -720,8 +768,12 @@ export const handler = async (event) => {
       const sprintId = event.queryStringParameters?.sprintId;
       if (!sprintId) return response(400, { error: 'sprintId query parameter required' });
       return await withNeptune(async (g) => {
+        const auth = await authorizeLegacySprintRead(g, event, sprintId, projectId);
+        if (auth.denied) return response(auth.statusCode, { error: auth.error });
         const tasks = await g
           .V()
+          .has('Project', 'id', projectId)
+          .out('HAS_SPRINT')
           .has('Sprint', 'id', sprintId)
           .out('CONTAINS')
           .hasLabel('Task')
@@ -756,11 +808,18 @@ export const handler = async (event) => {
       const sprintId = event.queryStringParameters?.sprintId;
 
       return await withNeptune(async (g) => {
-        // Use Sprint vertex if sprintId provided, otherwise fallback to Project
-        const vertexLabel = sprintId ? 'Sprint' : 'Project';
-        const vertexId = sprintId || projectId;
+        const auth = sprintId
+          ? await authorizeLegacySprintRead(g, event, sprintId, projectId)
+          : await authorizeLegacyProjectRead(g, event, projectId);
+        if (auth.denied) return response(auth.statusCode, { error: auth.error });
 
-        const result = await g.V().has(vertexLabel, 'id', vertexId).valueMap().next();
+        // Use Sprint vertex if sprintId provided, otherwise fallback to Project.
+        const scopedVertex = () =>
+          sprintId
+            ? g.V().has('Project', 'id', projectId).out('HAS_SPRINT').has('Sprint', 'id', sprintId)
+            : g.V().has('Project', 'id', projectId);
+
+        const result = await scopedVertex().valueMap().next();
         const v = result.value;
         if (!v) return response(200, { executionArn: null, executionId: null, status: null });
 
@@ -773,15 +832,15 @@ export const handler = async (event) => {
         // Helper to write terminal status to Sprint and AgentRun nodes
         const writeTerminalStatus = async (statusStr, execIdForRun) => {
           const completedAt = new Date().toISOString();
-          await g
-            .V()
-            .has(vertexLabel, 'id', vertexId)
+          await scopedVertex()
             .property(cardinality.single, 'current_agent_status', statusStr)
             .property(cardinality.single, 'agent_completed_at', completedAt)
             .next();
           if (execIdForRun) {
-            await g
-              .V()
+            const runs = sprintId
+              ? scopedVertex().out('HAS_AGENT_RUN')
+              : scopedVertex().out('HAS_SPRINT').out('HAS_AGENT_RUN');
+            await runs
               .hasLabel('AgentRun')
               .has('execution_id', execIdForRun)
               .property(cardinality.single, 'status', statusStr)
@@ -838,7 +897,16 @@ export const handler = async (event) => {
           ExpressionAttributeValues: { ':taskId': taskId },
         }),
       );
-      return response(200, { questions: result.Items });
+      const projectIds = [
+        ...new Set((result.Items || []).map((item) => item.projectId).filter(Boolean)),
+      ];
+      if (projectIds.length > 1) {
+        console.error(`[agents] Questions for execution ${taskId} span multiple projects`);
+        return response(500, { error: 'Internal server error' });
+      }
+      const auth = await authorizeExecutionRead(event, projectIds[0], [taskId]);
+      if (auth.denied) return response(auth.statusCode, { error: auth.error });
+      return response(200, { questions: (result.Items || []).map(publicAgentQuestion) });
     }
 
     // GET /agents/{taskId}
@@ -866,6 +934,12 @@ export const handler = async (event) => {
           );
         }
         const outputItem = outputQuery.Items?.[0];
+        const requestedExecutionId = event.queryStringParameters?.executionId;
+        const auth = await authorizeExecutionRead(event, outputItem?.projectId, [
+          taskId,
+          requestedExecutionId,
+        ]);
+        if (auth.denied) return response(auth.statusCode, { error: auth.error });
         if (outputItem) {
           const s = outputItem.status;
           const mapped = s === 'completed' ? 'SUCCEEDED' : s === 'failed' ? 'FAILED' : 'FAILED';
@@ -876,6 +950,12 @@ export const handler = async (event) => {
             errorMessage: outputItem.errorMessage,
           });
         }
+      } else {
+        const auth = await authorizeExecutionRead(event, null, [
+          taskId,
+          event.queryStringParameters?.executionId,
+        ]);
+        if (auth.denied) return response(auth.statusCode, { error: auth.error });
       }
       // No recorded output — the run predates output tracking or was lost with
       // the retired engine. Nothing can be running anymore.

--- a/lambda/agents/test/history-auth.test.js
+++ b/lambda/agents/test/history-auth.test.js
@@ -1,0 +1,254 @@
+import { beforeAll, beforeEach, afterAll, describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import gremlin from 'gremlin';
+import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+
+const PARTITION = `t-${randomUUID()}`;
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+let handler;
+let conn;
+let g;
+
+beforeAll(async () => {
+  vi.stubEnv('GREMLIN_PARTITION', PARTITION);
+  vi.stubEnv('AWS_PROFILE', undefined);
+  vi.stubEnv('AGENT_OUTPUTS_TABLE', 'agent-outputs-test');
+  vi.stubEnv('QUESTIONS_TABLE', 'agent-questions-test');
+  ({ handler } = await import('../index.js'));
+
+  const url = `ws://${process.env.NEPTUNE_ENDPOINT}:${process.env.GREMLIN_PORT}/gremlin`;
+  conn = new gremlin.driver.DriverRemoteConnection(url);
+  g = gremlin.process.AnonymousTraversalSource.traversal()
+    .withRemote(conn)
+    .withStrategies(
+      new PartitionStrategy({
+        partitionKey: '_partition',
+        writePartition: PARTITION,
+        readPartitions: [PARTITION],
+      }),
+    );
+});
+
+afterAll(async () => {
+  vi.unstubAllEnvs();
+  await conn?.close();
+});
+
+beforeEach(async () => {
+  ddbMock.reset();
+  await g.V().drop().next();
+});
+
+const event = ({ path, projectId, taskId, sprintId, executionId, sub }) => ({
+  httpMethod: 'GET',
+  path,
+  pathParameters: {
+    ...(projectId ? { projectId } : {}),
+    ...(taskId ? { taskId } : {}),
+  },
+  queryStringParameters: {
+    ...(sprintId ? { sprintId } : {}),
+    ...(executionId ? { executionId } : {}),
+  },
+  requestContext: { authorizer: { claims: { sub } } },
+});
+
+const seedProject = async (memberId, { executionId = `exec-${randomUUID()}` } = {}) => {
+  const projectId = `p-${randomUUID()}`;
+  const sprintId = `s-${randomUUID()}`;
+  const executionArn = `arn:aws:ecs:eu-west-1:123456789012:task/${randomUUID()}`;
+  await g.addV('Project').property('id', projectId).next();
+  await g.addV('User').property('id', memberId).next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .V()
+    .has('User', 'id', memberId)
+    .as('u')
+    .addE('HAS_MEMBER')
+    .from_('p')
+    .to('u')
+    .property('role', 'owner')
+    .next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .addV('Sprint')
+    .property('id', sprintId)
+    .property('current_execution_id', executionId)
+    .property('current_execution_arn', executionArn)
+    .property('current_agent_status', 'running')
+    .as('s')
+    .addE('HAS_SPRINT')
+    .from_('p')
+    .to('s')
+    .next();
+  await g
+    .V()
+    .has('Sprint', 'id', sprintId)
+    .as('s')
+    .addV('Task')
+    .property('id', `task-${randomUUID()}`)
+    .property('title', 'Private task')
+    .property('status', 'todo')
+    .property('task_execution_id', executionId)
+    .property('task_execution_arn', executionArn)
+    .as('t')
+    .addE('CONTAINS')
+    .from_('s')
+    .to('t')
+    .next();
+  return { projectId, sprintId, executionId, executionArn };
+};
+
+describe('legacy project agent history authorization', () => {
+  it('rejects non-members and project/sprint scope confusion', async () => {
+    const caller = `u-${randomUUID()}`;
+    const own = await seedProject(caller);
+    const foreign = await seedProject(`u-${randomUUID()}`);
+
+    const denied = await handler(
+      event({
+        path: `/projects/${foreign.projectId}/agents/tasks`,
+        projectId: foreign.projectId,
+        sprintId: foreign.sprintId,
+        sub: caller,
+      }),
+    );
+    expect(denied.statusCode).toBe(403);
+
+    const mismatched = await handler(
+      event({
+        path: `/projects/${own.projectId}/agents/tasks`,
+        projectId: own.projectId,
+        sprintId: foreign.sprintId,
+        sub: caller,
+      }),
+    );
+    expect(mismatched.statusCode).toBe(404);
+  });
+
+  it('authorizes before lazy status reconciliation can mutate a sprint', async () => {
+    const caller = `u-${randomUUID()}`;
+    const foreign = await seedProject(`u-${randomUUID()}`);
+
+    const denied = await handler(
+      event({
+        path: `/projects/${foreign.projectId}/agents`,
+        projectId: foreign.projectId,
+        sprintId: foreign.sprintId,
+        sub: caller,
+      }),
+    );
+    expect(denied.statusCode).toBe(403);
+
+    const status = await g
+      .V()
+      .has('Sprint', 'id', foreign.sprintId)
+      .values('current_agent_status')
+      .next();
+    expect(status.value).toBe('running');
+  });
+});
+
+describe('direct agent history authorization', () => {
+  it('blocks cross-project output reads', async () => {
+    const caller = `u-${randomUUID()}`;
+    const foreignMember = `u-${randomUUID()}`;
+    const foreign = await seedProject(foreignMember);
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          executionId: foreign.executionId,
+          projectId: foreign.projectId,
+          status: 'completed',
+          outputText: 'private output',
+        },
+      ],
+    });
+
+    const denied = await handler(
+      event({
+        path: `/agents/${foreign.executionId}`,
+        taskId: foreign.executionId,
+        sub: caller,
+      }),
+    );
+    expect(denied.statusCode).toBe(403);
+
+    const allowed = await handler(
+      event({
+        path: `/agents/${foreign.executionId}`,
+        taskId: foreign.executionId,
+        sub: foreignMember,
+      }),
+    );
+    expect(allowed.statusCode).toBe(200);
+    expect(JSON.parse(allowed.body).outputText).toBe('private output');
+  });
+
+  it('blocks cross-project questions and strips internal callback fields', async () => {
+    const caller = `u-${randomUUID()}`;
+    const foreignMember = `u-${randomUUID()}`;
+    const foreign = await seedProject(foreignMember);
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        {
+          questionId: 'q-1',
+          agentTaskId: foreign.executionId,
+          projectId: foreign.projectId,
+          sprintId: foreign.sprintId,
+          taskToken: 'internal-step-functions-token',
+          questions: [{ text: 'Private decision?' }],
+          status: 'pending',
+          createdAt: 1,
+        },
+      ],
+    });
+
+    const denied = await handler(
+      event({
+        path: `/agents/${foreign.executionId}/questions`,
+        taskId: foreign.executionId,
+        sub: caller,
+      }),
+    );
+    expect(denied.statusCode).toBe(403);
+
+    const allowed = await handler(
+      event({
+        path: `/agents/${foreign.executionId}/questions`,
+        taskId: foreign.executionId,
+        sub: foreignMember,
+      }),
+    );
+    expect(allowed.statusCode).toBe(200);
+    const [question] = JSON.parse(allowed.body).questions;
+    expect(question).toMatchObject({ questionId: 'q-1', status: 'pending' });
+    expect(question).not.toHaveProperty('taskToken');
+    expect(question).not.toHaveProperty('projectId');
+    expect(question).not.toHaveProperty('sprintId');
+  });
+
+  it('uses graph ownership after an output row expires', async () => {
+    const member = `u-${randomUUID()}`;
+    const owned = await seedProject(member);
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+    const allowed = await handler(
+      event({
+        path: `/agents/${encodeURIComponent(owned.executionArn)}`,
+        taskId: owned.executionArn,
+        executionId: owned.executionId,
+        sub: member,
+      }),
+    );
+    expect(allowed.statusCode).toBe(200);
+    expect(JSON.parse(allowed.body)).toMatchObject({ status: 'FAILED' });
+  });
+});

--- a/lambda/code-files/index.js
+++ b/lambda/code-files/index.js
@@ -2,6 +2,7 @@ import gremlin from 'gremlin';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
@@ -38,8 +39,16 @@ export const handler = async (event) => {
     // the v1 execution engine, so only the GET routes remain.
     switch (httpMethod) {
       case 'GET': {
+        const auth = await authorizeLegacySprintRead(g, event, sprintId);
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         if (codeFileId) {
-          const r = await g.V().has('CodeFile', 'id', codeFileId).valueMap().next();
+          const r = await g
+            .V()
+            .has('Sprint', 'id', sprintId)
+            .out('CONTAINS')
+            .has('CodeFile', 'id', codeFileId)
+            .valueMap()
+            .next();
           if (!r.value) return res(404, { error: 'Code file not found' });
           return res(200, mapCodeFile(r.value));
         }

--- a/lambda/general-info/index.js
+++ b/lambda/general-info/index.js
@@ -2,6 +2,7 @@ import gremlin from 'gremlin';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
@@ -38,8 +39,16 @@ export const handler = async (event) => {
     // the v1 execution engine, so only the GET routes remain.
     switch (httpMethod) {
       case 'GET': {
+        const auth = await authorizeLegacySprintRead(g, event, sprintId);
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         if (infoId) {
-          const r = await g.V().has('GeneralInfo', 'id', infoId).valueMap().next();
+          const r = await g
+            .V()
+            .has('Sprint', 'id', sprintId)
+            .out('CONTAINS')
+            .has('GeneralInfo', 'id', infoId)
+            .valueMap()
+            .next();
           if (!r.value) return res(404, { error: 'GeneralInfo not found' });
           return res(200, mapInfo(r.value));
         }

--- a/lambda/questions/index.js
+++ b/lambda/questions/index.js
@@ -1,5 +1,6 @@
 import { create } from 'neptune-lambda-client';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 // Tests point GREMLIN_PROTOCOL at a plain ws:// gremlin-server (no IAM); Neptune
 // in production is wss:// + SigV4. Tying useIam to the protocol keeps the test
@@ -77,8 +78,18 @@ export const handler = async (event) => {
     // the GET routes (list + single) remain.
     switch (httpMethod) {
       case 'GET': {
+        const auth = await query((g) => authorizeLegacySprintRead(g, event, sprintId));
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         if (questionId) {
-          const r = await query((g) => g.V().has('Question', 'id', questionId).valueMap().next());
+          const r = await query((g) =>
+            g
+              .V()
+              .has('Sprint', 'id', sprintId)
+              .out('CONTAINS')
+              .has('Question', 'id', questionId)
+              .valueMap()
+              .next(),
+          );
           if (!r.value) return res(404, { error: 'Question not found' });
           return res(200, mapQuestion(r.value));
         }

--- a/lambda/questions/test/questions.test.js
+++ b/lambda/questions/test/questions.test.js
@@ -5,6 +5,7 @@ import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 
 // File-level partition: every test in this file shares it.
 const PARTITION = `t-${randomUUID()}`;
+const USER_ID = `u-${randomUUID()}`;
 
 let handler;
 let close;
@@ -52,7 +53,34 @@ const STRUCTURED_QUESTIONS = [{ text: 'Which database?', type: 'single', options
 
 const ANSWER = { answers: [{ selectedOptions: [0], freeText: 'PostgreSQL' }] };
 
-const addSprint = async (sprintId) => g.addV('Sprint').property('id', sprintId).next();
+const addSprint = async (sprintId) => {
+  const projectId = `p-${randomUUID()}`;
+  await g.addV('Project').property('id', projectId).next();
+  await g.addV('User').property('id', USER_ID).next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .V()
+    .has('User', 'id', USER_ID)
+    .as('u')
+    .addE('HAS_MEMBER')
+    .from_('p')
+    .to('u')
+    .property('role', 'owner')
+    .next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .addV('Sprint')
+    .property('id', sprintId)
+    .as('s')
+    .addE('HAS_SPRINT')
+    .from_('p')
+    .to('s')
+    .next();
+};
 
 const addQuestion = async (sprintId, id, { structuredAnswer = '', answeredBy = '' } = {}) =>
   g
@@ -74,8 +102,12 @@ const addQuestion = async (sprintId, id, { structuredAnswer = '', answeredBy = '
     .to('q')
     .next();
 
-const get = (sprintId, questionId) =>
-  handler({ httpMethod: 'GET', pathParameters: { sprintId, questionId } });
+const get = (sprintId, questionId, sub = USER_ID) =>
+  handler({
+    httpMethod: 'GET',
+    pathParameters: { sprintId, questionId },
+    requestContext: { authorizer: { claims: { sub } } },
+  });
 
 describe('OPTIONS', () => {
   it('short-circuits with 200', async () => {
@@ -116,6 +148,13 @@ describe('GET /sprints/:sprintId/questions', () => {
 
     const res = await get(sprintId);
     expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('rejects a signed-in non-member', async () => {
+    const sprintId = `s-${randomUUID()}`;
+    await addSprint(sprintId);
+    const res = await get(sprintId, undefined, 'outsider');
+    expect(res.statusCode).toBe(403);
   });
 
   it('returns a single answered question with the parsed structuredAnswer', async () => {

--- a/lambda/requirements/index.js
+++ b/lambda/requirements/index.js
@@ -2,6 +2,7 @@ import gremlin from 'gremlin';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
@@ -37,8 +38,16 @@ export const handler = async (event) => {
     // the v1 execution engine, so only the GET routes remain.
     switch (httpMethod) {
       case 'GET': {
+        const auth = await authorizeLegacySprintRead(g, event, sprintId);
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         if (requirementId) {
-          const r = await g.V().has('Requirement', 'id', requirementId).valueMap().next();
+          const r = await g
+            .V()
+            .has('Sprint', 'id', sprintId)
+            .out('CONTAINS')
+            .has('Requirement', 'id', requirementId)
+            .valueMap()
+            .next();
           if (!r.value) return res(404, { error: 'Requirement not found' });
           return res(200, mapReq(r.value));
         }

--- a/lambda/reviews/index.js
+++ b/lambda/reviews/index.js
@@ -2,6 +2,7 @@ import gremlin from 'gremlin';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
@@ -52,6 +53,8 @@ export const handler = async (event) => {
     // v1 execution engine, so only the GET route remains.
     switch (httpMethod) {
       case 'GET': {
+        const auth = await authorizeLegacySprintRead(g, event, sprintId);
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         // Return the active (non-stale) review. If all are stale, return the most
         // recent one. valueMap().toList() order is NOT guaranteed by the graph
         // engine, so order by stale_at desc. The active review has no stale_at, so

--- a/lambda/shared/legacy-authz.js
+++ b/lambda/shared/legacy-authz.js
@@ -1,0 +1,88 @@
+import { fetchMembershipRole } from './trackers.js';
+
+const denied = (statusCode, error) => ({ denied: true, statusCode, error });
+
+const getCallerSub = (event) => event?.requestContext?.authorizer?.claims?.sub || null;
+
+const fetchProjectIdForSprint = async (g, sprintId) => {
+  const r = await g
+    .V()
+    .has('Sprint', 'id', sprintId)
+    .in_('HAS_SPRINT')
+    .hasLabel('Project')
+    .values('id')
+    .next();
+  return r.done ? null : r.value;
+};
+
+const authorizeLegacyProjectRead = async (g, event, projectId) => {
+  const sub = getCallerSub(event);
+  if (!sub) return denied(401, 'Unauthorized');
+  const role = await fetchMembershipRole(g, projectId, sub);
+  if (!role) return denied(403, 'Not a project member');
+  return { denied: false, projectId, role };
+};
+
+const authorizeLegacySprintRead = async (g, event, sprintId, expectedProjectId = null) => {
+  const sub = getCallerSub(event);
+  if (!sub) return denied(401, 'Unauthorized');
+  const projectId = await fetchProjectIdForSprint(g, sprintId);
+  if (!projectId || (expectedProjectId && projectId !== expectedProjectId)) {
+    return denied(404, 'Sprint not found');
+  }
+  const role = await fetchMembershipRole(g, projectId, sub);
+  if (!role) return denied(403, 'Not a project member');
+  return { denied: false, projectId, role };
+};
+
+const fetchProjectIdForExecution = async (g, executionIds) => {
+  const candidates = [...new Set(executionIds.filter(Boolean))];
+  for (const executionId of candidates) {
+    let r = await g
+      .V()
+      .has('AgentRun', 'execution_id', executionId)
+      .in_('HAS_AGENT_RUN')
+      .hasLabel('Sprint')
+      .in_('HAS_SPRINT')
+      .hasLabel('Project')
+      .values('id')
+      .next();
+    if (!r.done) return r.value;
+
+    for (const property of ['current_execution_id', 'current_execution_arn']) {
+      r = await g
+        .V()
+        .has('Sprint', property, executionId)
+        .in_('HAS_SPRINT')
+        .hasLabel('Project')
+        .values('id')
+        .next();
+      if (!r.done) return r.value;
+
+      r = await g.V().has('Project', property, executionId).values('id').next();
+      if (!r.done) return r.value;
+    }
+
+    for (const property of ['task_execution_id', 'task_execution_arn']) {
+      r = await g
+        .V()
+        .has('Task', property, executionId)
+        .in_('CONTAINS')
+        .hasLabel('Sprint')
+        .in_('HAS_SPRINT')
+        .hasLabel('Project')
+        .values('id')
+        .next();
+      if (!r.done) return r.value;
+    }
+  }
+  return null;
+};
+
+export {
+  authorizeLegacyProjectRead,
+  authorizeLegacySprintRead,
+  fetchProjectIdForExecution,
+  fetchProjectIdForSprint,
+  getCallerSub,
+};

--- a/lambda/sprint-graph/index.js
+++ b/lambda/sprint-graph/index.js
@@ -3,6 +3,7 @@ import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
@@ -38,6 +39,8 @@ export const handler = async (event) => {
       );
     }
     const { sprintId } = event.pathParameters || {};
+    const auth = await authorizeLegacySprintRead(g, event, sprintId);
+    if (auth.denied) return res(auth.statusCode, { error: auth.error });
 
     // Get all vertices contained in this sprint (CONTAINS + HAS_REVIEW + HAS_PR
     // + HAS_AGENT_RUN + HAS_DISCUSSION). Discussion threads are shown (linked

--- a/lambda/sprint-graph/test/sprint-graph.test.js
+++ b/lambda/sprint-graph/test/sprint-graph.test.js
@@ -4,6 +4,7 @@ import gremlin from 'gremlin';
 import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 
 const PARTITION = `t-${randomUUID()}`;
+const USER_ID = `u-${randomUUID()}`;
 
 let handler;
 let conn;
@@ -36,7 +37,34 @@ beforeEach(async () => {
   await g.V().drop().next();
 });
 
-const addSprint = async (sprintId) => g.addV('Sprint').property('id', sprintId).next();
+const addSprint = async (sprintId) => {
+  const projectId = `p-${randomUUID()}`;
+  await g.addV('Project').property('id', projectId).next();
+  await g.addV('User').property('id', USER_ID).next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .V()
+    .has('User', 'id', USER_ID)
+    .as('u')
+    .addE('HAS_MEMBER')
+    .from_('p')
+    .to('u')
+    .property('role', 'owner')
+    .next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .addV('Sprint')
+    .property('id', sprintId)
+    .as('s')
+    .addE('HAS_SPRINT')
+    .from_('p')
+    .to('s')
+    .next();
+};
 
 // containment is one of: CONTAINS, HAS_REVIEW, HAS_PR, HAS_AGENT_RUN
 const addContained = async (sprintId, label, props, containment = 'CONTAINS') => {
@@ -65,7 +93,12 @@ const addEdge = async (fromLabel, fromId, edge, toLabel, toId) => {
     .next();
 };
 
-const invoke = (sprintId) => handler({ httpMethod: 'GET', pathParameters: { sprintId } });
+const invoke = (sprintId, sub = USER_ID) =>
+  handler({
+    httpMethod: 'GET',
+    pathParameters: { sprintId },
+    requestContext: { authorizer: { claims: { sub } } },
+  });
 
 describe('OPTIONS', () => {
   it('short-circuits with 200', async () => {
@@ -82,6 +115,13 @@ describe('GET /sprint-graph', () => {
     const res = await invoke(sprintId);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ nodes: [], edges: [] });
+  });
+
+  it('rejects a signed-in non-member', async () => {
+    const sprintId = `s-${randomUUID()}`;
+    await addSprint(sprintId);
+    const res = await invoke(sprintId, 'outsider');
+    expect(res.statusCode).toBe(403);
   });
 
   it('uses the title → file_path → agent_type → status → "(unnamed)" label fallback chain', async () => {

--- a/lambda/sprints/index.js
+++ b/lambda/sprints/index.js
@@ -3,6 +3,7 @@ import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacyProjectRead, authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
@@ -111,10 +112,20 @@ export const handler = async (event) => {
     switch (httpMethod) {
       case 'GET': {
         if (sprintId) {
-          const r = await g.V().has('Sprint', 'id', sprintId).valueMap().next();
+          const auth = await authorizeLegacySprintRead(g, event, sprintId, projectId);
+          if (auth.denied) return res(auth.statusCode, { error: auth.error });
+          const r = await g
+            .V()
+            .has('Project', 'id', projectId)
+            .out('HAS_SPRINT')
+            .has('Sprint', 'id', sprintId)
+            .valueMap()
+            .next();
           if (!r.value) return res(404, { error: 'Sprint not found' });
           return res(200, mapSprint(r.value));
         }
+        const auth = await authorizeLegacyProjectRead(g, event, projectId);
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         const list = await g
           .V()
           .has('Project', 'id', projectId)

--- a/lambda/sprints/test/sprints.test.js
+++ b/lambda/sprints/test/sprints.test.js
@@ -5,6 +5,7 @@ import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 
 const NOW = new Date('2026-05-28T00:00:00.000Z');
 const PARTITION = `t-${randomUUID()}`;
+const USER_ID = `u-${randomUUID()}`;
 
 let handler;
 let conn;
@@ -53,9 +54,21 @@ const seedProject = async ({ gitRepo = 'acme/widgets' } = {}) => {
     .property('agent_cli', 'kiro')
     .property('issue_integration_enabled', 'true')
     .property('created_at', NOW.toISOString())
+    .as('p')
+    .addV('User')
+    .property('id', USER_ID)
+    .as('u')
+    .addE('HAS_MEMBER')
+    .from_('p')
+    .to('u')
+    .property('role', 'owner')
     .next();
   return id;
 };
+
+const claims = (sub = USER_ID) => ({
+  requestContext: { authorizer: { claims: { sub } } },
+});
 
 // Seeds a Sprint vertex on the legacy shape (issue_number/issue_url only,
 // no tracker_*) — simulates pre-#194 data that hasn't been migrated yet.
@@ -118,10 +131,11 @@ const seedTrackerSprint = async (projectId, tracker) => {
   return id;
 };
 
-const getSprint = async (sprintId) => {
+const getSprint = async (projectId, sprintId) => {
   const res = await handler({
     httpMethod: 'GET',
-    pathParameters: { sprintId },
+    pathParameters: { projectId, sprintId },
+    ...claims(),
   });
   expect(res.statusCode).toBe(200);
   return JSON.parse(res.body);
@@ -133,7 +147,11 @@ describe('GET /projects/:projectId/sprints (list)', () => {
     const a = await seedLegacySprint(projectId);
     const b = await seedLegacySprint(projectId);
 
-    const res = await handler({ httpMethod: 'GET', pathParameters: { projectId } });
+    const res = await handler({
+      httpMethod: 'GET',
+      pathParameters: { projectId },
+      ...claims(),
+    });
     expect(res.statusCode).toBe(200);
     const list = JSON.parse(res.body);
     expect(list.map((s) => s.id).toSorted()).toEqual([a, b].toSorted());
@@ -144,16 +162,44 @@ describe('GET /projects/:projectId/sprints (list)', () => {
     const otherProjectId = await seedProject();
     await seedLegacySprint(otherProjectId);
 
-    const res = await handler({ httpMethod: 'GET', pathParameters: { projectId } });
+    const res = await handler({
+      httpMethod: 'GET',
+      pathParameters: { projectId },
+      ...claims(),
+    });
     expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('rejects a signed-in non-member', async () => {
+    const projectId = await seedProject();
+    const res = await handler({
+      httpMethod: 'GET',
+      pathParameters: { projectId },
+      ...claims('outsider'),
+    });
+    expect(res.statusCode).toBe(403);
   });
 });
 
 describe('GET /sprints/:id (single)', () => {
   it('returns 404 for an unknown sprint', async () => {
+    const projectId = await seedProject();
     const res = await handler({
       httpMethod: 'GET',
-      pathParameters: { sprintId: 'nope' },
+      pathParameters: { projectId, sprintId: 'nope' },
+      ...claims(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('does not accept a sprint from another project', async () => {
+    const projectId = await seedProject();
+    const otherProjectId = await seedProject();
+    const sprintId = await seedLegacySprint(otherProjectId);
+    const res = await handler({
+      httpMethod: 'GET',
+      pathParameters: { projectId, sprintId },
+      ...claims(),
     });
     expect(res.statusCode).toBe(404);
   });
@@ -165,7 +211,7 @@ describe('GET /sprints/:id (single)', () => {
       issueUrl: 'https://github.com/foo/bar/issues/42',
     });
 
-    const fetched = await getSprint(sprintId);
+    const fetched = await getSprint(projectId, sprintId);
     // Legacy data path: tracker is null because the migration hasn't run,
     // but issueNumber/issueUrl render exactly as before #194.
     expect(fetched.tracker).toBeNull();
@@ -184,7 +230,7 @@ describe('GET /sprints/:id (single)', () => {
       resourceUrl: 'https://github.com/octo/repo/issues/7',
     });
 
-    const fetched = await getSprint(sprintId);
+    const fetched = await getSprint(projectId, sprintId);
     expect(fetched.tracker).toEqual({
       provider: 'github-issues',
       instance: 'public',
@@ -208,7 +254,7 @@ describe('GET /sprints/:id (single)', () => {
       resourceUrl: 'https://acme.atlassian.net/browse/PROJ-123',
     });
 
-    const fetched = await getSprint(sprintId);
+    const fetched = await getSprint(projectId, sprintId);
     expect(fetched.tracker).toMatchObject({
       provider: 'jira-cloud',
       externalProjectKey: 'PROJ',

--- a/lambda/tasks/index.js
+++ b/lambda/tasks/index.js
@@ -3,6 +3,7 @@ import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
@@ -53,8 +54,16 @@ export const handler = async (event) => {
     // ECS runtime) were removed, so only the GET routes (list + single) remain.
     switch (httpMethod) {
       case 'GET': {
+        const auth = await authorizeLegacySprintRead(g, event, sprintId);
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         if (taskId) {
-          const r = await g.V().has('Task', 'id', taskId).valueMap().next();
+          const r = await g
+            .V()
+            .has('Sprint', 'id', sprintId)
+            .out('CONTAINS')
+            .has('Task', 'id', taskId)
+            .valueMap()
+            .next();
           if (!r.value) return res(404, { error: 'Task not found' });
           return res(200, mapTask(r.value));
         }

--- a/lambda/tasks/test/tasks.test.js
+++ b/lambda/tasks/test/tasks.test.js
@@ -4,6 +4,7 @@ import gremlin from 'gremlin';
 import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 
 const PARTITION = `t-${randomUUID()}`;
+const USER_ID = `u-${randomUUID()}`;
 
 let handler;
 let conn;
@@ -38,10 +39,40 @@ afterAll(async () => {
 // ---------------------------------------------------------------------------
 
 const seedSprint = async () => {
+  const projectId = randomUUID();
   const sprintId = randomUUID();
-  await g.addV('Sprint').property('id', sprintId).property('name', 'Sprint 1').next();
+  await g.addV('Project').property('id', projectId).next();
+  await g.addV('User').property('id', USER_ID).next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .V()
+    .has('User', 'id', USER_ID)
+    .as('u')
+    .addE('HAS_MEMBER')
+    .from_('p')
+    .to('u')
+    .property('role', 'owner')
+    .next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .addV('Sprint')
+    .property('id', sprintId)
+    .property('name', 'Sprint 1')
+    .as('s')
+    .addE('HAS_SPRINT')
+    .from_('p')
+    .to('s')
+    .next();
   return sprintId;
 };
+
+const claims = (sub = USER_ID) => ({
+  requestContext: { authorizer: { claims: { sub } } },
+});
 
 const seedTask = async (
   sprintId,
@@ -87,6 +118,7 @@ describe('GET /sprints/:sprintId/tasks', () => {
     const res = await handler({
       httpMethod: 'GET',
       pathParameters: { sprintId },
+      ...claims(),
     });
     expect(res.statusCode).toBe(200);
     const tasks = JSON.parse(res.body);
@@ -102,8 +134,19 @@ describe('GET /sprints/:sprintId/tasks', () => {
     const res = await handler({
       httpMethod: 'GET',
       pathParameters: { sprintId },
+      ...claims(),
     });
     expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('rejects a signed-in non-member', async () => {
+    const sprintId = await seedSprint();
+    const res = await handler({
+      httpMethod: 'GET',
+      pathParameters: { sprintId },
+      ...claims('outsider'),
+    });
+    expect(res.statusCode).toBe(403);
   });
 
   it('returns a single task by id with all fields mapped', async () => {
@@ -119,6 +162,7 @@ describe('GET /sprints/:sprintId/tasks', () => {
     const res = await handler({
       httpMethod: 'GET',
       pathParameters: { sprintId, taskId: id },
+      ...claims(),
     });
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({
@@ -136,6 +180,19 @@ describe('GET /sprints/:sprintId/tasks', () => {
     const res = await handler({
       httpMethod: 'GET',
       pathParameters: { sprintId, taskId: 'nonexistent' },
+      ...claims(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('does not accept a task from another sprint', async () => {
+    const sprintId = await seedSprint();
+    const otherSprintId = await seedSprint();
+    const taskId = await seedTask(otherSprintId);
+    const res = await handler({
+      httpMethod: 'GET',
+      pathParameters: { sprintId, taskId },
+      ...claims(),
     });
     expect(res.statusCode).toBe(404);
   });

--- a/lambda/timeline-events/index.js
+++ b/lambda/timeline-events/index.js
@@ -1,6 +1,7 @@
 import gremlin from 'gremlin';
 import { create } from 'neptune-lambda-client';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const order = gremlin.process.order;
 
@@ -51,6 +52,8 @@ export const handler = async (event) => {
     // write path was removed together with the v1 execution engine.
     switch (httpMethod) {
       case 'GET': {
+        const auth = await query((g) => authorizeLegacySprintRead(g, event, sprintId));
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         const list = await query((g) =>
           g
             .V()

--- a/lambda/timeline-events/test/timeline-events.test.js
+++ b/lambda/timeline-events/test/timeline-events.test.js
@@ -5,6 +5,7 @@ import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 
 // File-level partition: every test in this file shares it.
 const PARTITION = `t-${randomUUID()}`;
+const USER_ID = `u-${randomUUID()}`;
 
 let handler;
 let close;
@@ -48,7 +49,34 @@ beforeEach(async () => {
   await g.V().drop().next();
 });
 
-const addSprint = async (sprintId) => g.addV('Sprint').property('id', sprintId).next();
+const addSprint = async (sprintId) => {
+  const projectId = `p-${randomUUID()}`;
+  await g.addV('Project').property('id', projectId).next();
+  await g.addV('User').property('id', USER_ID).next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .V()
+    .has('User', 'id', USER_ID)
+    .as('u')
+    .addE('HAS_MEMBER')
+    .from_('p')
+    .to('u')
+    .property('role', 'owner')
+    .next();
+  await g
+    .V()
+    .has('Project', 'id', projectId)
+    .as('p')
+    .addV('Sprint')
+    .property('id', sprintId)
+    .as('s')
+    .addE('HAS_SPRINT')
+    .from_('p')
+    .to('s')
+    .next();
+};
 
 // Seeds a TimelineEvent with the same property shape the removed POST handler
 // used to write.
@@ -76,7 +104,12 @@ const addEvent = async (sprintId, data) => {
   return id;
 };
 
-const get = (sprintId) => handler({ httpMethod: 'GET', pathParameters: { sprintId } });
+const get = (sprintId, sub = USER_ID) =>
+  handler({
+    httpMethod: 'GET',
+    pathParameters: { sprintId },
+    requestContext: { authorizer: { claims: { sub } } },
+  });
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
@@ -160,6 +193,13 @@ describe('GET /sprints/:sprintId/timeline', () => {
 
     const res = await get(sprintId);
     expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it('rejects a signed-in non-member', async () => {
+    const sprintId = `s-${randomUUID()}`;
+    await addSprint(sprintId);
+    const res = await get(sprintId, 'outsider');
+    expect(res.statusCode).toBe(403);
   });
 });
 

--- a/lambda/user-stories/index.js
+++ b/lambda/user-stories/index.js
@@ -2,6 +2,7 @@ import gremlin from 'gremlin';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getUrlAndHeaders } from 'gremlin-aws-sigv4/lib/utils.js';
 import { buildResponse } from '../shared/response.js';
+import { authorizeLegacySprintRead } from '../shared/legacy-authz.js';
 
 const DriverRemoteConnection = gremlin.driver.DriverRemoteConnection;
 const traversal = gremlin.process.AnonymousTraversalSource.traversal;
@@ -37,8 +38,16 @@ export const handler = async (event) => {
     // the v1 execution engine, so only the GET routes remain.
     switch (httpMethod) {
       case 'GET': {
+        const auth = await authorizeLegacySprintRead(g, event, sprintId);
+        if (auth.denied) return res(auth.statusCode, { error: auth.error });
         if (storyId) {
-          const r = await g.V().has('UserStory', 'id', storyId).valueMap().next();
+          const r = await g
+            .V()
+            .has('Sprint', 'id', sprintId)
+            .out('CONTAINS')
+            .has('UserStory', 'id', storyId)
+            .valueMap()
+            .next();
           if (!r.value) return res(404, { error: 'User story not found' });
           return res(200, mapStory(r.value));
         }


### PR DESCRIPTION
## Summary

- enforce current project membership across legacy v1 history reads
- bind nested sprint and entity identifiers to their parent project or sprint
- derive project ownership for direct agent output and question lookups
- authorize before lazy status reconciliation writes
- allowlist agent-question response fields so internal callback tokens are never returned

## Security impact

Prevents authenticated users from reading or triggering history reconciliation for projects where they are not current members. It also closes equivalent authorization gaps in adjacent legacy sprint history handlers.

## Verification

- npm test: 111 files, 2,353 tests passed
- focused authorization tests: 7 files, 60 tests passed
- npm run lint
- npm run format:check
- production bundles built for all affected Lambdas

Closes #318