### PR TITLE
fix: extract items from multiple yaml blocks

### DIFF
--- a/lambda/shared/artifact-extractors.js
+++ b/lambda/shared/artifact-extractors.js
@@ -47,11 +47,16 @@ const extractCitations = (content = '') => {
 
 const fencedYaml = (content = '', key) => {
   const body = String(content ?? '');
+  const values = [];
+  let found = false;
   for (const m of body.matchAll(/```ya?ml\s*\n([\s\S]*?)\n```/gi)) {
     const parsed = yaml.load(m[1]);
-    if (parsed && typeof parsed === 'object' && Object.hasOwn(parsed, key)) return parsed;
+    if (parsed && typeof parsed === 'object' && Object.hasOwn(parsed, key)) {
+      found = true;
+      values.push(...asList(parsed[key]));
+    }
   }
-  return null;
+  return found ? { [key]: values } : null;
 };
 
 const asList = (value) => (Array.isArray(value) ? value : []);

--- a/lambda/shared/test/artifact-extractors.test.js
+++ b/lambda/shared/test/artifact-extractors.test.js
@@ -59,6 +59,34 @@ describe('artifact extractors', () => {
     expect(out.citations).toEqual(['requirements']);
   });
 
+  it('combines matching yaml blocks in document order', () => {
+    const out = extractArtifactStructure({
+      artifactType: 'requirements',
+      content: [
+        '## Requirements',
+        '',
+        '```yaml',
+        'requirements:',
+        '  - id: req-sign-in',
+        '    title: Sign in',
+        '```',
+        '',
+        '## Non-functional requirements',
+        '',
+        '```yaml',
+        'requirements:',
+        '  - id: req-fast-response',
+        '    title: Fast response',
+        '    category: non-functional',
+        '```',
+      ].join('\n'),
+    });
+
+    expect(out.structuredPresent).toBe(true);
+    expect(out.items.map((item) => item.slug)).toEqual(['req-sign-in', 'req-fast-response']);
+    expect(out.items[1].props.category).toBe('non-functional');
+  });
+
   it('falls back to sections and citations for unknown artifact types', () => {
     const out = extractArtifactStructure({
       artifactType: 'unknown',


### PR DESCRIPTION
*Issue #, if available:* #317

*Description of changes:*
- aggregate matching fenced YAML blocks in document order                                                                                                                                                                                                                                                               
- retain explicit empty structured blocks                                                                                                                                                                                                                                                                               
- add coverage for requirements and NFR blocks in one document     

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
