### PR TITLE
fix: make durable PR waits callback-driven

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -117,6 +117,7 @@ flowchart TB
   SPA["Browser SPA"]
 
   INT -->|async Invoke on start| ORCH
+  INT -->|scheduled unit-PR reconciliation| GITP
   ORCH -->|dispatch stage<br/>as background job| AC
   AC -.->|durable callback:<br/>stage verdict| ORCH
   INT -.->|durable callback:<br/>gate answered| ORCH
@@ -141,7 +142,7 @@ flowchart TB
 
 **Human gates.** When an agent calls the `ask_question` MCP tool — or the orchestrator opens an engine gate (walking-skeleton review, batch review, halt-and-ask) — the run parks on a durable callback. The question renders in the UI; the user's answer flows through the `intents` Lambda, which completes the callback and resumes the run exactly where it parked. No polling, no queue.
 
-**Pull requests.** When an execution succeeds, the orchestrator opens pull requests in-process through the shared git-provider layer (GitHub / GitLab), from the intent branch onto the base branch.
+**Pull requests.** For PR-per-unit delivery, the orchestrator persists one durable callback when a unit is ready for review. A scheduled `intents` maintenance pass checks GitHub or GitLab while the durable execution remains suspended, waking it only when the PR merges or closes, a reviewed branch moves, or authenticated feedback is queued. The sparse process-table maintenance index also lets the same pass detect terminal durable executions before their local expiry. After every unit and shared stage succeeds, the orchestrator opens the final intent-to-base pull request through the same provider layer.
 
 **Auth.** At container startup the runtime reads the agent CLI credentials from SSM Parameter Store — a Bedrock bearer token for Claude Code / OpenCode, or a Kiro API key — as configured in **Admin → Agents**. The runtime's IAM role deliberately has no Bedrock model-invocation permissions; token auth is the only path. Git pushes use the starting user's provider token, injected only inside the engine's push/fetch windows and scrubbed from the checkout otherwise. None of these auth lookups appear in the diagram.
 

--- a/lambda/agentcore/test/helpers/v2-table.js
+++ b/lambda/agentcore/test/helpers/v2-table.js
@@ -1,5 +1,6 @@
 // Test helper: create/destroy the v2 process table in DynamoDB Local, matching
-// the production schema (PK/SK + GSI1 project-status + GSI2 type/state).
+// the production schema (PK/SK + GSI1 project-status + GSI2 type/state +
+// sparse GSI3 maintenance work).
 
 import {
   DynamoDBClient,
@@ -30,6 +31,8 @@ export const createV2Table = async (client, tableName) => {
         { AttributeName: 'GSI1SK', AttributeType: 'S' },
         { AttributeName: 'GSI2PK', AttributeType: 'S' },
         { AttributeName: 'GSI2SK', AttributeType: 'S' },
+        { AttributeName: 'GSI3PK', AttributeType: 'S' },
+        { AttributeName: 'GSI3SK', AttributeType: 'S' },
       ],
       KeySchema: [
         { AttributeName: 'pk', KeyType: 'HASH' },
@@ -49,6 +52,14 @@ export const createV2Table = async (client, tableName) => {
           KeySchema: [
             { AttributeName: 'GSI2PK', KeyType: 'HASH' },
             { AttributeName: 'GSI2SK', KeyType: 'RANGE' },
+          ],
+          Projection: { ProjectionType: 'ALL' },
+        },
+        {
+          IndexName: 'GSI3',
+          KeySchema: [
+            { AttributeName: 'GSI3PK', KeyType: 'HASH' },
+            { AttributeName: 'GSI3SK', KeyType: 'RANGE' },
           ],
           Projection: { ProjectionType: 'ALL' },
         },

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -1198,11 +1198,14 @@ export const handler = async (event) => {
     await ingestAttachmentUpload(event);
     return { ok: true };
   }
+  if (event?.action === 'repair-durable-executions') {
+    return runDurableExecutionWatchdog(event);
+  }
   if (
-    event?.action === 'repair-durable-executions' ||
+    event?.action === 'reconcile-provider-state' ||
     (event?.source === 'aws.events' && event?.['detail-type'] === 'Scheduled Event')
   ) {
-    return runDurableExecutionWatchdog(event);
+    return runScheduledMaintenance(event);
   }
   if (event.httpMethod === 'OPTIONS') return response(200, {});
 
@@ -1402,6 +1405,15 @@ export const handler = async (event) => {
             state: 'QUEUED',
             summary,
           }).catch(() => {});
+          const wait = await store.getUnit(intentId, sectionIndex, unitSlug).catch(() => null);
+          if (wait?.prWaitCallbackId) {
+            await wakeUnitPrWait(wait, {
+              reason: 'queued_feedback',
+              detail: { batchId, commentCount: selected.length },
+            }).catch((error) =>
+              console.error('Queued feedback PR-wait wake failed:', error.message),
+            );
+          }
         }
         return response(created.created ? 202 : 200, mapFeedbackBatch(created.item));
       }
@@ -2965,19 +2977,37 @@ export const handler = async (event) => {
           stage.unitSlug &&
           !pendingByStage.has(stage.stageInstanceId),
       );
-      if (orphaned.length === 0) {
+      const activeReviewStates = new Set([
+        'PR_DRAFT',
+        'RECONCILING',
+        'PR_READY',
+        'ADDRESSING_FEEDBACK',
+        'MERGING',
+      ]);
+      const prUnits = (records.units ?? []).filter(
+        (unit) =>
+          activeReviewStates.has(unit.state) &&
+          (records.unitPrs ?? []).some(
+            (pr) =>
+              Number(pr.sectionIndex) === Number(unit.sectionIndex) &&
+              pr.unitSlug === unit.slug &&
+              pr.number != null,
+          ),
+      );
+      if (orphaned.length === 0 && prUnits.length === 0) {
         return response(409, {
-          error: 'No orphaned parallel lane waits were detected',
+          error: 'No orphaned parallel lane waits or recoverable PR reviews were detected',
           code: 'repair_not_needed',
         });
       }
       const sectionIndexes = [
         ...new Set(
-          orphaned
-            .map((stage) => stage.sectionIndex)
-            .filter(
-              (index) => index !== null && index !== undefined && Number.isInteger(Number(index)),
-            ),
+          [
+            ...orphaned.map((stage) => stage.sectionIndex),
+            ...prUnits.map((unit) => unit.sectionIndex),
+          ].filter(
+            (index) => index !== null && index !== undefined && Number.isInteger(Number(index)),
+          ),
         ),
       ];
       if (sectionIndexes.length !== 1) {
@@ -3031,18 +3061,77 @@ export const handler = async (event) => {
       }
       const planNamespace =
         planResult.plan.namespace ?? `${meta.workflowId}@${meta.workflowVersion}`;
-      const resetInstances = sectionStages.flatMap((stage) =>
+      const sectionInstances = sectionStages.flatMap((stage) =>
         repairSlugs.map((slug) => ({
           stage,
           slug,
           stageInstanceId: planStageInstanceId(planNamespace, stage.stageId, slug, sectionIndex),
         })),
       );
+      const stagesByInstance = new Map(
+        (records.stages ?? []).map((stage) => [stage.stageInstanceId, stage]),
+      );
+      const completedStageStates = new Set(['SUCCEEDED', 'SKIPPED']);
+      const resetInstances = sectionInstances.filter((instance) => {
+        const row = stagesByInstance.get(instance.stageInstanceId);
+        return row && !completedStageStates.has(row.state);
+      });
       const responder = getResponder(event);
       const repairId = `repair-${randomUUID()}`;
-      const repairReason = `Repair orphaned parallel lanes in section ${sectionIndex}`;
+      const repairReason = `Recover durable parallel work in section ${sectionIndex}`;
       const sourceControlBlocked = await sourceControlLaunchGuard(meta, response);
       if (sourceControlBlocked) return sourceControlBlocked;
+
+      // Reconcile provider truth before retiring the old execution. A merged PR
+      // is accepted only when the exact reviewed head is reachable from the
+      // intent branch; open drafts are retained for the resumed lane.
+      const repairPrs = (records.unitPrs ?? []).filter(
+        (pr) => Number(pr.sectionIndex) === sectionIndex && repairSlugs.includes(pr.unitSlug),
+      );
+      const remotePrs = new Map();
+      try {
+        for (const pr of repairPrs) {
+          if (pr.state === 'UNCHANGED' || pr.number == null) continue;
+          const provider =
+            pr.provider || meta.repoProviders?.[pr.repository] || meta.gitProvider || 'github';
+          const status = await sourceControlOperation({
+            projectId,
+            provider,
+            repo: pr.repository,
+            operation: 'pr-status',
+            args: { number: pr.number },
+          });
+          if (!status?.state) {
+            throw new Error(`${pr.repository}#${pr.number}: provider status unavailable`);
+          }
+          let mergedHeadIsAncestor = null;
+          if (status.state === 'merged') {
+            const reviewedHead = pr.readyHeadSha ?? pr.headSha ?? status.headSha;
+            mergedHeadIsAncestor =
+              Boolean(reviewedHead) &&
+              Boolean(
+                await sourceControlOperation({
+                  projectId,
+                  provider,
+                  repo: pr.repository,
+                  operation: 'is-ancestor',
+                  args: {
+                    ancestorSha: reviewedHead,
+                    descendantRef: pr.targetBranch ?? meta.branch,
+                  },
+                }),
+              );
+          }
+          remotePrs.set(pr.sk, { status, mergedHeadIsAncestor });
+        }
+      } catch (error) {
+        console.error('Repair provider reconciliation failed:', error.code || error.message);
+        return response(502, {
+          error: 'Pull request state could not be reconciled; repair made no changes',
+          code: 'provider_reconciliation_failed',
+        });
+      }
+
       let priorDurableExecutionArn = meta.durableExecutionArn ?? null;
       if (!priorDurableExecutionArn && meta.durableExecutionName && ORCHESTRATOR_FN()) {
         const listed = await lambdaClient.send(
@@ -3132,42 +3221,97 @@ export const handler = async (event) => {
           })
           .catch(() => {});
       });
-      await mapWithConcurrency(repairSlugs, 8, (slug) =>
-        store.updateUnitState({
-          executionId: intentId,
-          sectionIndex,
-          slug,
-          state: 'PENDING',
-          fields: {
-            failureReason: null,
-            blockedOn: null,
-            integrationOwner: false,
-            blockedReason: 'Replaying after orphaned lane recovery',
-          },
-        }),
-      );
-      const repairPrs = (records.unitPrs ?? []).filter(
-        (pr) => Number(pr.sectionIndex) === sectionIndex && repairSlugs.includes(pr.unitSlug),
-      );
-      await mapWithConcurrency(repairPrs, 8, (pr) =>
-        store.updateUnitPr({
+      const reconciledPrs = await mapWithConcurrency(repairPrs, 8, async (pr) => {
+        if (pr.state === 'UNCHANGED' || pr.number == null) return pr;
+        const remote = remotePrs.get(pr.sk);
+        const status = remote.status;
+        let state;
+        let repositoryOutcome = null;
+        if (status.state === 'merged') {
+          state = remote.mergedHeadIsAncestor ? 'MERGED' : 'FAILED';
+          repositoryOutcome = remote.mergedHeadIsAncestor ? 'merged' : 'ready_head_not_on_intent';
+        } else if (status.state === 'closed') {
+          state = 'CLOSED';
+          repositoryOutcome = 'closed_without_merge';
+        } else {
+          const stillReady =
+            !status.draft &&
+            pr.readyHeadSha &&
+            status.headSha === pr.readyHeadSha &&
+            (!pr.targetSha || !status.targetSha || status.targetSha === pr.targetSha);
+          state = stillReady ? 'READY' : 'DRAFT';
+        }
+        return store.updateUnitPr({
           executionId: intentId,
           sectionIndex,
           slug: pr.unitSlug,
           repository: pr.repository,
-          state: 'DRAFT',
+          state,
           fields: {
-            readyHeadSha: null,
-            repositoryOutcome: 'replaying_after_lane_repair',
+            providerId: status.providerId ?? pr.providerId ?? null,
+            number: status.number ?? pr.number,
+            url: status.url ?? pr.url,
+            sourceBranch: status.sourceBranch ?? pr.sourceBranch,
+            targetBranch: status.targetBranch ?? pr.targetBranch,
+            headSha: status.headSha ?? pr.headSha ?? null,
+            targetSha: status.targetSha ?? pr.targetSha ?? null,
+            readyHeadSha: state === 'READY' || state === 'MERGED' ? pr.readyHeadSha : null,
+            mergeable: status.mergeable ?? null,
+            repositoryOutcome,
           },
-        }),
-      );
+        });
+      });
+      const prsByUnit = new Map();
+      for (const pr of reconciledPrs.filter(Boolean)) {
+        const rows = prsByUnit.get(pr.unitSlug) ?? [];
+        rows.push(pr);
+        prsByUnit.set(pr.unitSlug, rows);
+      }
+      await mapWithConcurrency(repairSlugs, 8, async (slug) => {
+        const prs = prsByUnit.get(slug) ?? [];
+        const changed = prs.filter((pr) => pr.state !== 'UNCHANGED');
+        const constructionComplete = sectionStages.every((stage) => {
+          const stageInstanceId = planStageInstanceId(
+            planNamespace,
+            stage.stageId,
+            slug,
+            sectionIndex,
+          );
+          return completedStageStates.has(stagesByInstance.get(stageInstanceId)?.state);
+        });
+        const fullyMerged =
+          changed.length > 0 &&
+          changed.every((pr) => pr.state === 'MERGED') &&
+          prs.every((pr) => pr.state === 'MERGED' || pr.state === 'UNCHANGED');
+        const resumeReview =
+          constructionComplete &&
+          changed.some((pr) => pr.state === 'DRAFT' || pr.state === 'READY') &&
+          !changed.some((pr) => pr.state === 'CLOSED' || pr.state === 'FAILED');
+        return store.updateUnitState({
+          executionId: intentId,
+          sectionIndex,
+          slug,
+          state: fullyMerged ? 'MERGED' : resumeReview ? 'PR_DRAFT' : 'PENDING',
+          fields: {
+            failureReason: null,
+            blockedOn: null,
+            integrationOwner: false,
+            recoveryPreserveCompleted: true,
+            blockedReason: fullyMerged
+              ? null
+              : resumeReview
+                ? 'Resuming existing pull request after durable recovery'
+                : 'Replaying unfinished work after durable recovery',
+            ...(fullyMerged ? { mergedAt: true } : {}),
+          },
+        });
+      });
       await store
         .appendEvent({
           executionId: intentId,
           type: 'v2.execution.lanes_repaired',
           actor: responder.displayName || responder.sub,
-          summary: `${responder.displayName || 'Someone'} repaired section ${sectionIndex}; replaying active lanes [${repairSlugs.join(', ')}] (${archivedArtifacts.length} artifact version(s) archived)`,
+          summary: `${responder.displayName || 'Someone'} recovered section ${sectionIndex}; reconciled ${repairPrs.length} pull request(s), preserved completed stages, and relaunched unfinished lanes [${repairSlugs.join(', ')}] (${archivedArtifacts.length} artifact version(s) archived)`,
         })
         .catch(() => {});
 
@@ -4201,6 +4345,59 @@ const resumeDurableCallback = async (callbackId, answer) => {
   );
 };
 
+const isMissingDurableCallbackError = (error) =>
+  isCallbackTimeoutError(error) ||
+  [
+    'ResourceNotFoundException',
+    'CallbackNotFoundException',
+    'InvalidParameterValueException',
+  ].includes(error?.name);
+
+// A provider scheduler and a feedback request can observe the same transition.
+// Claim the persisted wait before sending so only one caller completes the
+// one-shot durable callback. A transient send failure releases the claim; a
+// callback that is already gone clears the sparse wait instead of retrying it
+// forever.
+const wakeUnitPrWait = async (wait, { reason, detail = null } = {}) => {
+  if (!wait?.prWaitCallbackId || !wait?.prWaitRunId) return { woken: false };
+  const claimId = `wake-${randomUUID()}`;
+  const claimExpiresAt = new Date(Date.now() + 2 * 60 * 1000).toISOString();
+  const identity = {
+    executionId: wait.executionId,
+    sectionIndex: Number(wait.sectionIndex),
+    slug: wait.slug,
+    callbackId: wait.prWaitCallbackId,
+    runId: wait.prWaitRunId,
+  };
+  const claimed = await store.claimUnitPrWait({
+    ...identity,
+    claimId,
+    claimExpiresAt,
+  });
+  if (!claimed) return { woken: false, duplicate: true };
+
+  try {
+    await resumeDurableCallback(wait.prWaitCallbackId, {
+      type: 'unit-pr-transition',
+      reason,
+      detail,
+    });
+  } catch (error) {
+    if (!isMissingDurableCallbackError(error)) {
+      await store.releaseUnitPrWaitClaim({ ...identity, claimId }).catch(() => {});
+      throw error;
+    }
+  }
+  await store
+    .completeUnitPrWait({
+      ...identity,
+      claimId,
+      reason,
+    })
+    .catch((error) => console.error('PR-wait completion cleanup failed:', error.message));
+  return { woken: true };
+};
+
 // A UNIQUE durable execution name per launch: durable executions are
 // idempotent by name, so every start/rewind/recompose relaunch needs a fresh
 // one. The service caps DurableExecutionName at 64 chars — `intent-` (7) +
@@ -4256,14 +4453,16 @@ const repairExpiredDurableExecution = async ({
   actor = 'system',
   eventType = 'v2.execution.repaired',
   summary = 'Durable execution expired while the intent was waiting',
+  failureReason = 'durable_callback_expired',
 }) => {
   const updated = await store.updateExecution({
     executionId,
     projectId,
     status: 'FAILED',
+    ...(meta?.status ? { fromStatus: meta.status } : {}),
     startedAt: meta?.startedAt,
     completedAt: new Date().toISOString(),
-    failureReason: 'durable_callback_expired',
+    failureReason,
     pendingHumanTaskId: null,
     ...(meta?.orchestratorRunId ? { ifOrchestratorRunId: meta.orchestratorRunId } : {}),
   });
@@ -4282,35 +4481,176 @@ const runDurableExecutionWatchdog = async ({ candidates: injectedCandidates = nu
   const nowIso = new Date().toISOString();
   const candidates =
     injectedCandidates ??
-    (await store.listStaleActiveExecutions({
-      nowIso,
-      timeoutSeconds: DURABLE_EXECUTION_TIMEOUT_SECONDS(),
+    (await store.listActiveExecutions({
       limit: Number(process.env.DURABLE_WATCHDOG_LIMIT || 100),
     }));
   const out = { checked: candidates.length, repaired: 0, skipped: 0, errors: [] };
   for (const meta of candidates) {
     try {
       const durableStatus = await lookupDurableExecutionStatus(meta).catch((err) => {
-        if (err?.name === 'ResourceNotFoundException') return 'TIMED_OUT';
+        if (err?.name === 'ResourceNotFoundException') return 'NOT_FOUND';
         throw err;
       });
-      if (durableStatus && !DURABLE_TERMINAL_STATUSES.has(durableStatus)) {
+      const terminal =
+        DURABLE_TERMINAL_STATUSES.has(durableStatus) || durableStatus === 'NOT_FOUND';
+      const expiry = Date.parse(meta.orchestratorExpiresAt ?? '');
+      // Legacy rows may not carry an explicit durable expiry. Prefer the most
+      // recent process write over the intent's original start time so a rewind
+      // or repair cannot be declared stale in the narrow launch-before-claim
+      // window.
+      const legacyStart = Date.parse(
+        meta.orchestratorStartedAt ?? meta.updatedAt ?? meta.startedAt ?? '',
+      );
+      const legacyExpiry =
+        Number.isFinite(legacyStart) &&
+        legacyStart + DURABLE_EXECUTION_TIMEOUT_SECONDS() * 1000 <= Date.parse(nowIso);
+      const expired = Number.isFinite(expiry) ? expiry <= Date.parse(nowIso) : legacyExpiry;
+      if (!terminal && (durableStatus || !expired)) {
         out.skipped += 1;
         continue;
       }
+      const failureReason = terminal
+        ? `durable_execution_${String(durableStatus).toLowerCase()}`
+        : 'durable_callback_expired';
       await repairExpiredDurableExecution({
         executionId: meta.executionId,
         projectId: meta.projectId,
         meta,
         actor: 'durable-watchdog',
-        summary: `Watchdog repaired stale ${meta.status} intent after durable execution ${durableStatus ?? 'exceeded local timeout'}`,
+        failureReason,
+        summary: `Watchdog repaired active ${meta.status} intent after durable execution ${durableStatus ?? 'exceeded local timeout'}`,
       });
       out.repaired += 1;
     } catch (err) {
+      // The execution can finish locally after the sparse-index read but
+      // before this repair write. The status CAS deliberately loses that race.
+      if (err?.name === 'ConditionalCheckFailedException') {
+        out.skipped += 1;
+        continue;
+      }
       out.errors.push({ executionId: meta.executionId, error: err?.message ?? String(err) });
     }
   }
   return out;
+};
+
+const normalizePrSnapshot = (pr, status) => ({
+  repository: pr.repository,
+  number: pr.number,
+  state: status.state,
+  headSha: status.headSha ?? null,
+  targetSha: status.targetSha ?? null,
+});
+
+const providerTransitionFor = (before, after) => {
+  if (!before) return null;
+  if (after.state === 'merged' && before.state !== 'merged') return 'merged';
+  if (after.state === 'closed' && before.state !== 'closed') return 'closed';
+  if (after.state !== 'open') return null;
+  if (before.headSha && after.headSha && before.headSha !== after.headSha) return 'head_moved';
+  if (before.targetSha && after.targetSha && before.targetSha !== after.targetSha) {
+    return 'target_moved';
+  }
+  return null;
+};
+
+const runPrWaitReconciler = async ({ waits: injectedWaits = null } = {}) => {
+  const waits =
+    injectedWaits ??
+    (await store.listUnitPrWaits({
+      limit: Number(process.env.PR_WAIT_RECONCILER_LIMIT || 100),
+    }));
+  const out = {
+    checked: waits.length,
+    woken: 0,
+    unchanged: 0,
+    stale: 0,
+    duplicates: 0,
+    errors: [],
+  };
+  for (const wait of waits) {
+    try {
+      const meta = await store.getExecution(wait.executionId);
+      if (
+        !meta ||
+        !['CREATED', 'RUNNING', 'WAITING'].includes(meta.status) ||
+        !wait.prWaitRunId ||
+        meta.orchestratorRunId !== wait.prWaitRunId
+      ) {
+        await store
+          .clearUnitPrWait({
+            executionId: wait.executionId,
+            sectionIndex: Number(wait.sectionIndex),
+            slug: wait.slug,
+            callbackId: wait.prWaitCallbackId,
+            runId: wait.prWaitRunId,
+          })
+          .catch(() => {});
+        out.stale += 1;
+        continue;
+      }
+
+      const queued = await store.listFeedbackBatches(wait.executionId, {
+        sectionIndex: Number(wait.sectionIndex),
+        slug: wait.slug,
+        state: 'QUEUED',
+      });
+      let reason = queued.length > 0 ? 'queued_feedback' : null;
+      let detail = queued.length > 0 ? { batchId: queued[0].batchId } : null;
+
+      if (!reason) {
+        const prior = new Map(
+          (Array.isArray(wait.prWaitSnapshot) ? wait.prWaitSnapshot : []).map((entry) => [
+            entry.repository,
+            entry,
+          ]),
+        );
+        const prs = (
+          await store.listUnitPrs(wait.executionId, {
+            sectionIndex: Number(wait.sectionIndex),
+            slug: wait.slug,
+          })
+        ).filter((pr) => pr.number != null && prior.has(pr.repository));
+        const observations = [];
+        for (const pr of prs) {
+          const provider =
+            pr.provider || meta.repoProviders?.[pr.repository] || meta.gitProvider || 'github';
+          const status = await sourceControlOperation({
+            projectId: meta.projectId,
+            provider,
+            repo: pr.repository,
+            operation: 'pr-status',
+            args: { number: pr.number },
+          });
+          const observation = normalizePrSnapshot(pr, status);
+          observations.push(observation);
+          reason ??= providerTransitionFor(prior.get(pr.repository), observation);
+        }
+        if (reason) detail = { observations };
+      }
+
+      if (!reason) {
+        out.unchanged += 1;
+        continue;
+      }
+      const wake = await wakeUnitPrWait(wait, { reason, detail });
+      if (wake.woken) out.woken += 1;
+      else if (wake.duplicate) out.duplicates += 1;
+    } catch (error) {
+      out.errors.push({
+        executionId: wait.executionId,
+        unitSlug: wait.slug,
+        error: error?.message ?? String(error),
+      });
+    }
+  }
+  return out;
+};
+
+const runScheduledMaintenance = async (event = {}) => {
+  const prWaits = await runPrWaitReconciler(event);
+  const durableExecutions = await runDurableExecutionWatchdog(event);
+  return { prWaits, durableExecutions };
 };
 
 // Retire a parked run for cancel/rewind: supersede every still-pending gate
@@ -4343,6 +4683,12 @@ const retireParkedRun = async (executionId, reason) => {
         )
         .catch((err) => console.error('Cancel callback send failed:', err.message));
     }
+  }
+  for (const wait of (records.units ?? []).filter((unit) => unit.prWaitCallbackId)) {
+    await wakeUnitPrWait(wait, {
+      reason: 'retired',
+      detail: { reason },
+    }).catch((error) => console.error('Retired PR-wait callback send failed:', error.message));
   }
 };
 

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -4622,6 +4622,9 @@ const runPrWaitReconciler = async ({ waits: injectedWaits = null } = {}) => {
             operation: 'pr-status',
             args: { number: pr.number },
           });
+          if (!status?.state) {
+            throw new Error(`PR status unavailable for ${pr.repository}#${pr.number}`);
+          }
           const observation = normalizePrSnapshot(pr, status);
           observations.push(observation);
           reason ??= providerTransitionFor(prior.get(pr.repository), observation);

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -62,6 +62,7 @@ let sourceControlReviewComments = [];
 let sourceControlValidationResponse = { ready: true, repositories: [] };
 const s3Mock = mockClient(S3Client);
 let attachmentUpdateConflict = null;
+let sourceControlOperationHandler = null;
 
 // In-memory single-table fake for the v2 process table + blocks table.
 const procStore = new Map();
@@ -116,6 +117,9 @@ const installDdbFakes = () => {
     if (input.IndexName === 'GSI1') {
       items = items.filter((i) => i.GSI1PK === values[':pk']);
       if (values[':sk']) items = items.filter((i) => (i.GSI1SK || '').startsWith(values[':sk']));
+    } else if (input.IndexName === 'GSI3') {
+      items = items.filter((i) => i.GSI3PK === values[':pk']);
+      items.sort((a, b) => (a.GSI3SK || '').localeCompare(b.GSI3SK || ''));
     } else {
       items = items.filter((i) => i.pk === values[':pk']);
       // SK conditions the store actually issues: begins_with prefix reads and
@@ -172,6 +176,34 @@ const installDdbFakes = () => {
       casFail();
     }
     if (cond.includes('attribute_exists(pk)') && !existing) casFail();
+    if (cond.includes('#state = :ready') && (!existing || existing.state !== values[':ready'])) {
+      casFail();
+    }
+    if (
+      cond.includes('prWaitCallbackId = :callbackId') &&
+      (!existing || existing.prWaitCallbackId !== values[':callbackId'])
+    ) {
+      casFail();
+    }
+    if (
+      cond.includes('prWaitRunId = :runId') &&
+      (!existing || existing.prWaitRunId !== values[':runId'])
+    ) {
+      casFail();
+    }
+    if (
+      cond.includes('prWaitWakeClaimId = :claimId') &&
+      (!existing || existing.prWaitWakeClaimId !== values[':claimId'])
+    ) {
+      casFail();
+    }
+    if (
+      cond.includes('attribute_not_exists(prWaitWakeClaimId)') &&
+      existing?.prWaitWakeClaimId &&
+      !(existing.prWaitWakeClaimExpiresAt < values[':ts'])
+    ) {
+      casFail();
+    }
     // Lifecycle CAS used by updateUnitState / updateQuorumEdit: `#state IN (:from0, …)`.
     const inMatch = /#state IN \(([^)]+)\)/.exec(cond);
     if (inMatch) {
@@ -203,13 +235,20 @@ const installDdbFakes = () => {
     }
     const next = { ...(existing || { pk: input.Key.pk, sk: input.Key.sk }) };
     // Generic SET applier: "SET a = :x, b = :y, #n = :z" (names resolved).
-    const setMatch = /SET (.+)$/.exec(input.UpdateExpression || '');
+    const setMatch = /SET (.*?)(?: REMOVE |$)/.exec(input.UpdateExpression || '');
     if (setMatch) {
       for (const clause of setMatch[1].split(',')) {
         const [lhs, rhs] = clause.split('=').map((s) => s.trim());
         if (!lhs || !rhs) continue;
         const field = names[lhs] ?? lhs;
         if (rhs in values) next[field] = values[rhs];
+      }
+    }
+    const removeMatch = / REMOVE (.+)$/.exec(input.UpdateExpression || '');
+    if (removeMatch) {
+      for (const raw of removeMatch[1].split(',')) {
+        const field = names[raw.trim()] ?? raw.trim();
+        delete next[field];
       }
     }
     procStore.set(k, next);
@@ -239,7 +278,7 @@ const installDdbFakes = () => {
           ? sourceControlValidationResponse
           : request.operation === 'list-review-comments'
             ? { ok: true, result: sourceControlReviewComments }
-            : { ok: true, result: null };
+            : { ok: true, result: sourceControlOperationHandler?.(request) ?? null };
       return { StatusCode: 200, Payload: Buffer.from(JSON.stringify(response)) };
     }
     return { StatusCode: 202 };
@@ -318,6 +357,7 @@ beforeEach(() => {
   installDdbFakes();
   sourceControlReviewComments = [];
   sourceControlValidationResponse = { ready: true, repositories: [] };
+  sourceControlOperationHandler = null;
   ssmMock.reset();
   agentcoreMock.reset();
   attachmentUpdateConflict = null;
@@ -1056,6 +1096,21 @@ describe('unit PR review feedback', () => {
     });
     expect(get.statusCode).toBe(200);
     expect(JSON.parse(get.body).comments).toHaveLength(1);
+    const metaKey = keyOf(`EXEC#${intent.id}`, 'META');
+    procStore.set(metaKey, {
+      ...procStore.get(metaKey),
+      orchestratorRunId: 'run-feedback',
+    });
+    const unitKey = keyOf(`EXEC#${intent.id}`, 'UNIT#S1#auth');
+    procStore.set(unitKey, {
+      ...procStore.get(unitKey),
+      state: 'PR_READY',
+      prWaitCallbackId: 'callback-feedback',
+      prWaitRunId: 'run-feedback',
+      prWaitSnapshot: [],
+      GSI3PK: 'PR_WAITS',
+      GSI3SK: `EXEC#${intent.id}#UNIT#S1#auth`,
+    });
 
     const post = await handler({
       httpMethod: 'POST',
@@ -1079,6 +1134,13 @@ describe('unit PR review feedback', () => {
       repository: 'owner/repo',
       version: '2026-01-01T00:01:00Z',
     });
+    expect(lambdaMock.commandCalls(SendDurableExecutionCallbackSuccessCommand)).toHaveLength(1);
+    const wake = JSON.parse(
+      Buffer.from(
+        lambdaMock.commandCalls(SendDurableExecutionCallbackSuccessCommand)[0].args[0].input.Result,
+      ).toString(),
+    );
+    expect(wake.answer.reason).toBe('queued_feedback');
   });
 
   it('atomically rejects concurrent feedback batches that overlap on a comment version', async () => {
@@ -3014,12 +3076,258 @@ describe('durable execution watchdog', () => {
     expect(procStore.get(keyOf(`EXEC#${stale.id}`, 'META'))).toMatchObject({
       status: 'FAILED',
       pendingHumanTaskId: null,
-      failureReason: 'durable_callback_expired',
+      failureReason: 'durable_execution_timed_out',
     });
     expect(procStore.get(keyOf(`EXEC#${live.id}`, 'META'))).toMatchObject({
       status: 'WAITING',
       pendingHumanTaskId: 'h-live',
     });
+  });
+
+  it('detects a failed durable execution before its configured expiry', async () => {
+    const sub = `u-${randomUUID()}`;
+    const projectId = await seedV2Project(sub);
+    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+    const metaKey = keyOf(`EXEC#${intent.id}`, 'META');
+    procStore.set(metaKey, {
+      ...procStore.get(metaKey),
+      status: 'RUNNING',
+      orchestratorRunId: 'run-failed-early',
+      orchestratorExpiresAt: '2099-01-01T00:00:00.000Z',
+      durableExecutionArn: 'arn:aws:lambda:durable:failed-early',
+    });
+    lambdaMock.on(GetDurableExecutionCommand).resolves({ Status: 'FAILED' });
+
+    const out = await handler({
+      action: 'repair-durable-executions',
+      candidates: [procStore.get(metaKey)],
+    });
+
+    expect(out).toMatchObject({ checked: 1, repaired: 1, skipped: 0 });
+    expect(procStore.get(metaKey)).toMatchObject({
+      status: 'FAILED',
+      failureReason: 'durable_execution_failed',
+    });
+  });
+
+  it('does not overwrite a locally completed execution from a stale active-index read', async () => {
+    const sub = `u-${randomUUID()}`;
+    const projectId = await seedV2Project(sub);
+    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+    const metaKey = keyOf(`EXEC#${intent.id}`, 'META');
+    const candidate = {
+      ...procStore.get(metaKey),
+      status: 'RUNNING',
+      orchestratorRunId: 'run-finishing',
+      durableExecutionArn: 'arn:aws:lambda:durable:finishing',
+    };
+    procStore.set(metaKey, { ...candidate });
+    lambdaMock.on(GetDurableExecutionCommand).callsFake(() => {
+      procStore.set(metaKey, {
+        ...procStore.get(metaKey),
+        status: 'SUCCEEDED',
+        completedAt: '2026-07-21T10:00:00.000Z',
+      });
+      return { Status: 'FAILED' };
+    });
+
+    const out = await handler({
+      action: 'repair-durable-executions',
+      candidates: [{ ...candidate }],
+    });
+
+    expect(out).toEqual({ checked: 1, repaired: 0, skipped: 1, errors: [] });
+    expect(procStore.get(metaKey)).toMatchObject({
+      status: 'SUCCEEDED',
+      completedAt: '2026-07-21T10:00:00.000Z',
+    });
+  });
+
+  it('gives a legacy relaunch without an explicit expiry a fresh launch window', async () => {
+    const sub = `u-${randomUUID()}`;
+    const projectId = await seedV2Project(sub);
+    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+    const metaKey = keyOf(`EXEC#${intent.id}`, 'META');
+    const candidate = {
+      ...procStore.get(metaKey),
+      status: 'CREATED',
+      startedAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: new Date().toISOString(),
+      orchestratorStartedAt: null,
+      orchestratorExpiresAt: null,
+      durableExecutionName: null,
+      durableExecutionArn: null,
+    };
+    procStore.set(metaKey, { ...candidate });
+
+    const out = await handler({
+      action: 'repair-durable-executions',
+      candidates: [{ ...candidate }],
+    });
+
+    expect(out).toEqual({ checked: 1, repaired: 0, skipped: 1, errors: [] });
+    expect(procStore.get(metaKey).status).toBe('CREATED');
+  });
+});
+
+describe('scheduled unit PR reconciliation', () => {
+  const seedWait = ({
+    executionId,
+    runId = 'run-current',
+    slug = 'views',
+    repos = [{ repository: 'owner/web', provider: 'github', number: 12 }],
+  }) => {
+    procStore.set(keyOf(`EXEC#${executionId}`, 'META'), {
+      pk: `EXEC#${executionId}`,
+      sk: 'META',
+      type: 'Execution',
+      executionId,
+      intentId: executionId,
+      projectId: 'p-maintenance',
+      status: 'RUNNING',
+      orchestratorRunId: runId,
+      gitProvider: 'github',
+      repoProviders: Object.fromEntries(repos.map((repo) => [repo.repository, repo.provider])),
+    });
+    const snapshot = repos.map((repo) => ({
+      repository: repo.repository,
+      number: repo.number,
+      state: 'open',
+      headSha: `${repo.repository}-head`,
+      targetSha: `${repo.repository}-target`,
+    }));
+    const wait = {
+      pk: `EXEC#${executionId}`,
+      sk: `UNIT#S1#${slug}`,
+      type: 'Unit',
+      executionId,
+      sectionIndex: 1,
+      slug,
+      state: 'PR_READY',
+      prWaitCallbackId: `callback-${executionId}`,
+      prWaitRunId: runId,
+      prWaitSnapshot: snapshot,
+      GSI3PK: 'PR_WAITS',
+      GSI3SK: `EXEC#${executionId}#UNIT#S1#${slug}`,
+    };
+    procStore.set(keyOf(wait.pk, wait.sk), wait);
+    for (const repo of repos) {
+      const row = {
+        pk: `EXEC#${executionId}`,
+        sk: `UNITPR#S1#${slug}#${encodeURIComponent(repo.repository)}`,
+        type: 'UnitPullRequest',
+        executionId,
+        sectionIndex: 1,
+        unitSlug: slug,
+        repository: repo.repository,
+        provider: repo.provider,
+        number: repo.number,
+        state: 'READY',
+      };
+      procStore.set(keyOf(row.pk, row.sk), row);
+    }
+    return { wait, snapshot };
+  };
+
+  it('does not wake an unchanged GitHub wait, then wakes a merge exactly once', async () => {
+    const { wait, snapshot } = seedWait({ executionId: 'exec-github' });
+    let state = 'open';
+    sourceControlOperationHandler = (request) =>
+      request.operation === 'pr-status'
+        ? {
+            number: 12,
+            state,
+            headSha: snapshot[0].headSha,
+            targetSha: snapshot[0].targetSha,
+          }
+        : null;
+
+    const unchanged = await handler({
+      action: 'reconcile-provider-state',
+      waits: [{ ...wait }],
+      candidates: [],
+    });
+    expect(unchanged.prWaits).toMatchObject({ checked: 1, unchanged: 1, woken: 0 });
+    expect(lambdaMock.commandCalls(SendDurableExecutionCallbackSuccessCommand)).toHaveLength(0);
+
+    state = 'merged';
+    const merged = await handler({
+      action: 'reconcile-provider-state',
+      waits: [{ ...wait }],
+      candidates: [],
+    });
+    expect(merged.prWaits).toMatchObject({ checked: 1, woken: 1 });
+
+    const duplicate = await handler({
+      action: 'reconcile-provider-state',
+      waits: [{ ...wait }],
+      candidates: [],
+    });
+    expect(duplicate.prWaits).toMatchObject({ checked: 1, duplicates: 1 });
+    expect(lambdaMock.commandCalls(SendDurableExecutionCallbackSuccessCommand)).toHaveLength(1);
+  });
+
+  it('wakes one multi-repository wait when a GitLab target branch moves', async () => {
+    const repos = [
+      { repository: 'owner/api', provider: 'github', number: 21 },
+      { repository: 'group/web', provider: 'gitlab', number: 22 },
+    ];
+    const { wait, snapshot } = seedWait({ executionId: 'exec-multi', repos });
+    const providers = [];
+    sourceControlOperationHandler = (request) => {
+      providers.push(request.provider);
+      const before = snapshot.find((entry) => entry.repository === request.repo);
+      return {
+        number: request.args.number,
+        state: 'open',
+        headSha: before.headSha,
+        targetSha: request.provider === 'gitlab' ? 'advanced-intent-head' : before.targetSha,
+      };
+    };
+
+    const out = await handler({
+      action: 'reconcile-provider-state',
+      waits: [{ ...wait }],
+      candidates: [],
+    });
+
+    expect(out.prWaits).toMatchObject({ checked: 1, woken: 1 });
+    expect(providers.toSorted()).toEqual(['github', 'gitlab']);
+    const result = JSON.parse(
+      Buffer.from(
+        lambdaMock.commandCalls(SendDurableExecutionCallbackSuccessCommand)[0].args[0].input.Result,
+      ).toString(),
+    );
+    expect(result.answer.reason).toBe('target_moved');
+  });
+
+  it('wakes queued feedback and drops a stale-run wait without resuming it', async () => {
+    const current = seedWait({ executionId: 'exec-feedback' }).wait;
+    const stale = seedWait({ executionId: 'exec-stale', runId: 'run-old' }).wait;
+    procStore.set(keyOf('EXEC#exec-stale', 'META'), {
+      ...procStore.get(keyOf('EXEC#exec-stale', 'META')),
+      orchestratorRunId: 'run-new',
+    });
+    procStore.set(keyOf('EXEC#exec-feedback', 'FEEDBACK#S1#views#batch-1'), {
+      pk: 'EXEC#exec-feedback',
+      sk: 'FEEDBACK#S1#views#batch-1',
+      type: 'FeedbackBatch',
+      executionId: 'exec-feedback',
+      sectionIndex: 1,
+      unitSlug: 'views',
+      batchId: 'batch-1',
+      state: 'QUEUED',
+    });
+
+    const out = await handler({
+      action: 'reconcile-provider-state',
+      waits: [{ ...current }, { ...stale }],
+      candidates: [],
+    });
+
+    expect(out.prWaits).toMatchObject({ checked: 2, woken: 1, stale: 1 });
+    expect(lambdaMock.commandCalls(SendDurableExecutionCallbackSuccessCommand)).toHaveLength(1);
+    expect(procStore.get(keyOf(stale.pk, stale.sk))).not.toHaveProperty('prWaitCallbackId');
   });
 });
 
@@ -4289,11 +4597,12 @@ describe('WP4 — rewind expands per-unit stage instances', () => {
         intentId: intent.id,
         stageInstanceIds: expect.arrayContaining([
           siOf('cg', 'asset-containment', 1),
-          siOf('cg', 'blocked-dependent', 1),
           siOf('cg', 'live-data-energy-flow', 1),
-          siOf('cg', 'echarts-integration', 1),
         ]),
       }),
+    );
+    expect(archiveArtifactsSpy.mock.calls[0][0].stageInstanceIds).not.toContain(
+      siOf('cg', 'echarts-integration', 1),
     );
     expect(procStore.get(keyOf(`EXEC#${intent.id}`, 'UNIT#S1#foundation'))).toMatchObject({
       state: 'MERGED',
@@ -4308,24 +4617,25 @@ describe('WP4 — rewind expands per-unit stage instances', () => {
       'echarts-integration',
     ]) {
       expect(procStore.get(keyOf(`EXEC#${intent.id}`, `UNIT#S1#${slug}`))).toMatchObject({
-        state: 'PENDING',
+        state: slug === 'echarts-integration' ? 'PR_DRAFT' : 'PENDING',
         failureReason: null,
       });
       const stageRow = procStore.get(keyOf(`EXEC#${intent.id}`, `STAGE#${siOf('cg', slug, 1)}`));
-      if (slug !== 'blocked-dependent') {
+      if (slug === 'asset-containment' || slug === 'live-data-energy-flow') {
         expect(stageRow).toMatchObject({
           state: 'PENDING',
           attempt: 1,
           pendingHumanTaskId: null,
         });
+      } else if (slug === 'echarts-integration') {
+        expect(stageRow).toMatchObject({ state: 'SUCCEEDED', attempt: 0 });
       }
     }
     expect(
       procStore.get(keyOf(`EXEC#${intent.id}`, 'UNITPR#S1#echarts-integration#owner%2Frepo')),
     ).toMatchObject({
-      state: 'DRAFT',
-      readyHeadSha: null,
-      repositoryOutcome: 'replaying_after_lane_repair',
+      state: 'READY',
+      readyHeadSha: 'tainted-head',
     });
     expect(procStore.get(keyOf(`EXEC#${intent.id}`, 'META'))).toMatchObject({
       status: 'CREATED',
@@ -4344,6 +4654,134 @@ describe('WP4 — rewind expands per-unit stage instances', () => {
         (row) => row.pk === `EXEC#${intent.id}` && row.eventType === 'v2.execution.lanes_repaired',
       ),
     ).toBe(true);
+  });
+
+  it('reconciles merged PR #11 and resumes draft PR #12 without rebuilding stages', async () => {
+    const sub = `u-${randomUUID()}`;
+    const projectId = await seedV2Project(sub);
+    seedSectionPlan();
+    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+    await seedIntentAnchor(intent.id);
+    setStatus(intent.id, {
+      status: 'RUNNING',
+      prStrategy: 'pr-per-unit',
+      durableExecutionArn: 'arn:aws:lambda:eu-central-1:123:durable-execution:old-pr-wait',
+      orchestratorRunId: 'old-pr-wait-run',
+    });
+    seedStageRow(intent.id, 'units-gen');
+    seedStageRow(intent.id, 'cg', 'comparison-feature', 'SUCCEEDED', 1);
+    seedStageRow(intent.id, 'cg', 'views', 'SUCCEEDED', 1);
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'UNITPLAN'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'UNITPLAN',
+      executionId: intent.id,
+      units: [
+        { slug: 'comparison-feature', dependsOn: [] },
+        { slug: 'views', dependsOn: ['comparison-feature'] },
+      ],
+      batches: [['comparison-feature'], ['views']],
+      walkingSkeleton: 'comparison-feature',
+      autonomyMode: 'autonomous',
+    });
+    for (const slug of ['comparison-feature', 'views']) {
+      procStore.set(keyOf(`EXEC#${intent.id}`, `UNIT#S1#${slug}`), {
+        pk: `EXEC#${intent.id}`,
+        sk: `UNIT#S1#${slug}`,
+        type: 'Unit',
+        executionId: intent.id,
+        sectionIndex: 1,
+        slug,
+        state: 'PR_READY',
+      });
+    }
+    const unitPr = (slug, number, headSha) => {
+      const row = {
+        pk: `EXEC#${intent.id}`,
+        sk: `UNITPR#S1#${slug}#owner%2Frepo`,
+        type: 'UnitPullRequest',
+        executionId: intent.id,
+        sectionIndex: 1,
+        unitSlug: slug,
+        repository: 'owner/repo',
+        provider: 'github',
+        number,
+        state: 'READY',
+        sourceBranch: `aidlc/i--s1-unit-${slug}`,
+        targetBranch: 'aidlc/i',
+        headSha,
+        readyHeadSha: headSha,
+        targetSha: 'intent-before',
+      };
+      procStore.set(keyOf(row.pk, row.sk), row);
+    };
+    unitPr('comparison-feature', 11, 'comparison-head');
+    unitPr('views', 12, 'views-head');
+    sourceControlOperationHandler = (request) => {
+      if (request.operation === 'is-ancestor')
+        return request.args.ancestorSha === 'comparison-head';
+      if (request.operation !== 'pr-status') return null;
+      return request.args.number === 11
+        ? {
+            number: 11,
+            state: 'merged',
+            draft: false,
+            headSha: 'comparison-head',
+            targetSha: 'intent-after-comparison',
+          }
+        : {
+            number: 12,
+            state: 'open',
+            draft: true,
+            headSha: 'views-head',
+            targetSha: 'intent-after-comparison',
+          };
+    };
+    vi.stubEnv('V2_ORCHESTRATOR_FUNCTION', 'orchestrator-test:live');
+    try {
+      const res = await repair(sub, projectId, intent.id);
+
+      expect(res.statusCode).toBe(202);
+      expect(procStore.get(keyOf(`EXEC#${intent.id}`, 'UNIT#S1#comparison-feature'))).toMatchObject(
+        {
+          state: 'MERGED',
+        },
+      );
+      expect(procStore.get(keyOf(`EXEC#${intent.id}`, 'UNIT#S1#views'))).toMatchObject({
+        state: 'PR_DRAFT',
+        recoveryPreserveCompleted: true,
+      });
+      expect(
+        procStore.get(keyOf(`EXEC#${intent.id}`, 'UNITPR#S1#comparison-feature#owner%2Frepo')),
+      ).toMatchObject({
+        number: 11,
+        state: 'MERGED',
+        repositoryOutcome: 'merged',
+      });
+      expect(
+        procStore.get(keyOf(`EXEC#${intent.id}`, 'UNITPR#S1#views#owner%2Frepo')),
+      ).toMatchObject({
+        number: 12,
+        state: 'DRAFT',
+        headSha: 'views-head',
+      });
+      expect(
+        procStore.get(keyOf(`EXEC#${intent.id}`, `STAGE#${siOf('cg', 'comparison-feature', 1)}`)),
+      ).toMatchObject({ state: 'SUCCEEDED', attempt: 0 });
+      expect(
+        procStore.get(keyOf(`EXEC#${intent.id}`, `STAGE#${siOf('cg', 'views', 1)}`)),
+      ).toMatchObject({ state: 'SUCCEEDED', attempt: 0 });
+      expect(archiveArtifactsSpy.mock.calls.at(-1)[0].stageInstanceIds).toEqual([]);
+      const relaunch = lambdaMock
+        .commandCalls(InvokeCommand)
+        .find((call) => call.args[0].input.FunctionName === 'orchestrator-test:live');
+      expect(relaunch).toBeDefined();
+      expect(JSON.parse(Buffer.from(relaunch.args[0].input.Payload).toString())).toMatchObject({
+        action: 'start',
+        startAtStageId: 'cg',
+      });
+    } finally {
+      vi.stubEnv('V2_ORCHESTRATOR_FUNCTION', 'orchestrator-test');
+    }
   });
 
   it('leaves a stop failure retryable without archiving or resetting lanes', async () => {

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -3267,6 +3267,35 @@ describe('scheduled unit PR reconciliation', () => {
     expect(lambdaMock.commandCalls(SendDurableExecutionCallbackSuccessCommand)).toHaveLength(1);
   });
 
+  it('reports an unavailable PR status without waking or clearing the wait', async () => {
+    const { wait } = seedWait({ executionId: 'exec-status-unavailable' });
+    sourceControlOperationHandler = () => null;
+
+    const out = await handler({
+      action: 'reconcile-provider-state',
+      waits: [{ ...wait }],
+      candidates: [],
+    });
+
+    expect(out.prWaits).toMatchObject({
+      checked: 1,
+      woken: 0,
+      unchanged: 0,
+      errors: [
+        {
+          executionId: 'exec-status-unavailable',
+          unitSlug: 'views',
+          error: 'PR status unavailable for owner/web#12',
+        },
+      ],
+    });
+    expect(lambdaMock.commandCalls(SendDurableExecutionCallbackSuccessCommand)).toHaveLength(0);
+    expect(procStore.get(keyOf(wait.pk, wait.sk))).toMatchObject({
+      prWaitCallbackId: wait.prWaitCallbackId,
+      prWaitRunId: wait.prWaitRunId,
+    });
+  });
+
   it('wakes one multi-repository wait when a GitLab target branch moves', async () => {
     const repos = [
       { repository: 'owner/api', provider: 'github', number: 21 },

--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -63,6 +63,7 @@ describe('v2-process-keys', () => {
     expect(meta.GSI1PK).toBe('PROJECT#p1');
     expect(meta.GSI1SK).toBe('STATUS#RUNNING#STARTED#2026-01-01T00:00:00.000Z#EXEC#e1');
     expect(meta.GSI2SK).toBe('TYPE#EXECUTION#STATE#RUNNING#META');
+    expect(meta).toMatchObject({ GSI3PK: 'ACTIVE_EXECUTIONS', GSI3SK: 'EXEC#e1' });
   });
 
   it('stamps a stage row with startedAt only when RUNNING', () => {
@@ -156,6 +157,19 @@ describe('createProcessStore', () => {
     expect(input.ExpressionAttributeValues[':status']).toBe('RUNNING');
     expect(input.ExpressionAttributeValues[':g1pk']).toBe('PROJECT#p1');
     expect(input.ExpressionAttributeValues[':cs']).toBe('req');
+    expect(input.ExpressionAttributeValues[':g3pk']).toBe('ACTIVE_EXECUTIONS');
+  });
+
+  it('removes the sparse active projection on a terminal execution state', async () => {
+    ddb.on(UpdateCommand).resolves({ Attributes: { status: 'FAILED' } });
+    await store.updateExecution({
+      executionId: 'e1',
+      projectId: 'p1',
+      status: 'FAILED',
+      startedAt: 'T',
+    });
+    const input = ddb.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.UpdateExpression).toContain('REMOVE GSI3PK, GSI3SK');
   });
 
   it('updateExecution back-fills GSI1 from META when a runtime caller omits projectId/startedAt', async () => {
@@ -1120,6 +1134,71 @@ describe('unit store methods', () => {
     expect(rows).toHaveLength(1);
     const input = ddb.commandCalls(QueryCommand)[0].args[0].input;
     expect(input.ExpressionAttributeValues[':p']).toBe('UNIT#');
+  });
+
+  it('binds a PR wait onto the sparse index and claims it with callback ownership', async () => {
+    ddb.on(UpdateCommand).resolves({ Attributes: { state: 'PR_READY' } });
+    await store.bindUnitPrWait({
+      executionId: 'e1',
+      sectionIndex: 2,
+      slug: 'auth',
+      callbackId: 'callback-1',
+      runId: 'run-1',
+      snapshot: [{ repository: 'owner/api', state: 'open', headSha: 'h1' }],
+    });
+    const bind = ddb.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(bind.ConditionExpression).toContain('#state = :ready');
+    expect(bind.ExpressionAttributeValues).toMatchObject({
+      ':callbackId': 'callback-1',
+      ':runId': 'run-1',
+      ':g3pk': 'PR_WAITS',
+      ':g3sk': 'EXEC#e1#UNIT#S2#auth',
+    });
+
+    await store.claimUnitPrWait({
+      executionId: 'e1',
+      sectionIndex: 2,
+      slug: 'auth',
+      callbackId: 'callback-1',
+      runId: 'run-1',
+      claimId: 'claim-1',
+      claimExpiresAt: 'T2',
+    });
+    const claim = ddb.commandCalls(UpdateCommand)[1].args[0].input;
+    expect(claim.ConditionExpression).toContain('prWaitCallbackId = :callbackId');
+    expect(claim.ConditionExpression).toContain('prWaitRunId = :runId');
+  });
+
+  it('completes a claimed PR wait by removing its callback and sparse projection', async () => {
+    ddb.on(UpdateCommand).resolves({ Attributes: {} });
+    await store.completeUnitPrWait({
+      executionId: 'e1',
+      sectionIndex: 2,
+      slug: 'auth',
+      callbackId: 'callback-1',
+      runId: 'run-1',
+      claimId: 'claim-1',
+      reason: 'merged',
+    });
+    const input = ddb.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.UpdateExpression).toContain('REMOVE prWaitCallbackId');
+    expect(input.UpdateExpression).toContain('GSI3PK, GSI3SK');
+    expect(input.ConditionExpression).toContain('prWaitWakeClaimId = :claimId');
+  });
+
+  it('queries active executions and PR waits through separate GSI3 partitions', async () => {
+    ddb.on(QueryCommand).resolves({ Items: [] });
+    await store.listActiveExecutions();
+    await store.listUnitPrWaits();
+    const [active, waits] = ddb.commandCalls(QueryCommand).map((call) => call.args[0].input);
+    expect(active).toMatchObject({
+      IndexName: 'GSI3',
+      ExpressionAttributeValues: { ':pk': 'ACTIVE_EXECUTIONS' },
+    });
+    expect(waits).toMatchObject({
+      IndexName: 'GSI3',
+      ExpressionAttributeValues: { ':pk': 'PR_WAITS' },
+    });
   });
 
   it('syncUnitRows creates missing lanes, refreshes PENDING/READY, preserves active, reports orphans', async () => {

--- a/lambda/shared/v2-process-keys.js
+++ b/lambda/shared/v2-process-keys.js
@@ -32,12 +32,17 @@
 //     (list a project's executions by status, newest first)
 //   GSI2PK = EXEC#<executionId>       GSI2SK = TYPE#<type>#STATE#<state>#<id>
 //     (query one execution's records by record type + state)
+//   GSI3PK = ACTIVE_EXECUTIONS | PR_WAITS
+//     GSI3SK = EXEC#<executionId>[#UNIT#S<section>#<slug>]
+//     (sparse maintenance index: only live executions and parked unit PR waits)
 
 const META = 'META';
 
 // ── Partition keys ──
 const executionPk = (executionId) => `EXEC#${executionId}`;
 const projectPk = (projectId) => `PROJECT#${projectId}`;
+const ACTIVE_EXECUTIONS_INDEX_PK = 'ACTIVE_EXECUTIONS';
+const PR_WAITS_INDEX_PK = 'PR_WAITS';
 
 // ── Item keys ──
 const executionMetaKey = (executionId) => ({ pk: executionPk(executionId), sk: META });
@@ -149,6 +154,14 @@ const executionTypeStateIndex = ({ executionId, type, state, id }) => ({
   GSI2PK: executionPk(executionId),
   GSI2SK: `TYPE#${type}#STATE#${state}#${id}`,
 });
+const activeExecutionIndex = ({ executionId }) => ({
+  GSI3PK: ACTIVE_EXECUTIONS_INDEX_PK,
+  GSI3SK: `EXEC#${executionId}`,
+});
+const unitPrWaitIndex = ({ executionId, sectionIndex, slug }) => ({
+  GSI3PK: PR_WAITS_INDEX_PK,
+  GSI3SK: `EXEC#${executionId}#UNIT#${unitLaneId(sectionIndex, slug)}`,
+});
 
 // ── Vocabularies ──
 // Execution-level status (the run as a whole). DRAFT is the pre-Start state:
@@ -164,6 +177,7 @@ const EXECUTION_STATUS = [
   'FAILED',
   'CANCELLED',
 ];
+const ACTIVE_EXECUTION_STATUSES = ['CREATED', 'RUNNING', 'WAITING'];
 // Per-stage runtime status. The container drives a stage RUNNING → terminal; a
 // stage that opens a human gate parks on WAITING_FOR_HUMAN.
 const STAGE_STATE = ['PENDING', 'RUNNING', 'WAITING_FOR_HUMAN', 'SUCCEEDED', 'FAILED', 'SKIPPED'];
@@ -387,6 +401,7 @@ const buildExecutionMeta = ({
   ...executionMetaKey(executionId),
   ...projectStatusIndex({ projectId, status, startedAt, executionId }),
   ...executionTypeStateIndex({ executionId, type: 'EXECUTION', state: status, id: META }),
+  ...(ACTIVE_EXECUTION_STATUSES.includes(status) ? activeExecutionIndex({ executionId }) : {}),
   type: 'Execution',
   executionId,
   projectId,
@@ -1062,7 +1077,12 @@ export {
   composeKey,
   projectStatusIndex,
   executionTypeStateIndex,
+  activeExecutionIndex,
+  unitPrWaitIndex,
+  ACTIVE_EXECUTIONS_INDEX_PK,
+  PR_WAITS_INDEX_PK,
   EXECUTION_STATUS,
+  ACTIVE_EXECUTION_STATUSES,
   STAGE_STATE,
   HUMAN_TASK_KINDS,
   HUMAN_TASK_STATUSES,
@@ -1117,7 +1137,12 @@ export default {
   composeKey,
   projectStatusIndex,
   executionTypeStateIndex,
+  activeExecutionIndex,
+  unitPrWaitIndex,
+  ACTIVE_EXECUTIONS_INDEX_PK,
+  PR_WAITS_INDEX_PK,
   EXECUTION_STATUS,
+  ACTIVE_EXECUTION_STATUSES,
   STAGE_STATE,
   HUMAN_TASK_KINDS,
   HUMAN_TASK_STATUSES,

--- a/lambda/shared/v2-process-store.js
+++ b/lambda/shared/v2-process-store.js
@@ -14,7 +14,6 @@ import {
   GetCommand,
   PutCommand,
   QueryCommand,
-  ScanCommand,
   TransactWriteCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
@@ -35,6 +34,10 @@ import {
   projectPk,
   projectStatusIndex,
   executionTypeStateIndex,
+  activeExecutionIndex,
+  unitPrWaitIndex,
+  ACTIVE_EXECUTIONS_INDEX_PK,
+  PR_WAITS_INDEX_PK,
   buildExecutionMeta,
   buildStageRow,
   buildEventRow,
@@ -57,6 +60,7 @@ import {
   QUORUM_EDIT_STATES,
   COMPOSE_STATES,
   CONSTRUCTION_AUTONOMY_MODES,
+  ACTIVE_EXECUTION_STATUSES,
 } from './v2-process-keys.js';
 
 const bySk = (a, b) => a.sk.localeCompare(b.sk);
@@ -71,17 +75,6 @@ const queryAll = async (ddb, input) => {
   let ExclusiveStartKey;
   do {
     const page = await ddb.send(new QueryCommand({ ...input, ExclusiveStartKey }));
-    items.push(...(page.Items ?? []));
-    ExclusiveStartKey = page.LastEvaluatedKey;
-  } while (ExclusiveStartKey);
-  return items;
-};
-
-const scanAll = async (ddb, input) => {
-  const items = [];
-  let ExclusiveStartKey;
-  do {
-    const page = await ddb.send(new ScanCommand({ ...input, ExclusiveStartKey }));
     items.push(...(page.Items ?? []));
     ExclusiveStartKey = page.LastEvaluatedKey;
   } while (ExclusiveStartKey);
@@ -164,6 +157,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
   }) => {
     const ts = now();
     const sets = ['updatedAt = :ts'];
+    const removes = [];
     const names = {};
     const values = { ':ts': ts };
     if (status !== undefined) {
@@ -196,6 +190,14 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
         state: status,
         id: META,
       }).GSI2SK;
+      if (ACTIVE_EXECUTION_STATUSES.includes(status)) {
+        const maintenance = activeExecutionIndex({ executionId });
+        sets.push('GSI3PK = :g3pk', 'GSI3SK = :g3sk');
+        values[':g3pk'] = maintenance.GSI3PK;
+        values[':g3sk'] = maintenance.GSI3SK;
+      } else {
+        removes.push('GSI3PK', 'GSI3SK');
+      }
     }
     if (currentPhase !== undefined) {
       sets.push('currentPhase = :cp');
@@ -340,7 +342,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     const params = {
       TableName: table(),
       Key: executionMetaKey(executionId),
-      UpdateExpression: `SET ${sets.join(', ')}`,
+      UpdateExpression: `SET ${sets.join(', ')}${removes.length ? ` REMOVE ${removes.join(', ')}` : ''}`,
       ExpressionAttributeValues: values,
       ReturnValues: 'ALL_NEW',
     };
@@ -1137,6 +1139,26 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     return items;
   };
 
+  const listActiveExecutions = async ({ limit = 100 } = {}) => {
+    const items = [];
+    let ExclusiveStartKey;
+    do {
+      const page = await ddb.send(
+        new QueryCommand({
+          TableName: table(),
+          IndexName: 'GSI3',
+          KeyConditionExpression: 'GSI3PK = :pk',
+          ExpressionAttributeValues: { ':pk': ACTIVE_EXECUTIONS_INDEX_PK },
+          Limit: limit - items.length,
+          ExclusiveStartKey,
+        }),
+      );
+      items.push(...(page.Items ?? []));
+      ExclusiveStartKey = page.LastEvaluatedKey;
+    } while (ExclusiveStartKey && items.length < limit);
+    return items;
+  };
+
   const listStaleActiveExecutions = async ({
     statuses = ['WAITING', 'RUNNING'],
     nowIso,
@@ -1150,11 +1172,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
         ? new Date(nowMs - timeoutMs).toISOString()
         : null;
     const statusSet = new Set(statuses);
-    const rows = await scanAll(ddb, {
-      TableName: table(),
-      FilterExpression: 'sk = :meta',
-      ExpressionAttributeValues: { ':meta': META },
-    });
+    const rows = await listActiveExecutions({ limit });
     return rows
       .filter((row) => statusSet.has(row.status))
       .filter((row) => {
@@ -1366,6 +1384,20 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     if (!UNIT_STATES.includes(state)) throw new Error(`invalid unit state: ${state}`);
     const ts = now();
     const sets = ['#state = :state', 'updatedAt = :ts', 'GSI2SK = :g2sk'];
+    const removes =
+      state === 'PR_READY'
+        ? []
+        : [
+            'prWaitCallbackId',
+            'prWaitRunId',
+            'prWaitSnapshot',
+            'prWaitBoundAt',
+            'prWaitWakeClaimId',
+            'prWaitWakeClaimedAt',
+            'prWaitWakeClaimExpiresAt',
+            'GSI3PK',
+            'GSI3SK',
+          ];
     const names = { '#state': 'state' };
     const values = {
       ':state': state,
@@ -1385,7 +1417,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     const params = {
       TableName: table(),
       Key: unitKey(executionId, sectionIndex, slug),
-      UpdateExpression: `SET ${sets.join(', ')}`,
+      UpdateExpression: `SET ${sets.join(', ')}${removes.length ? ` REMOVE ${removes.join(', ')}` : ''}`,
       ExpressionAttributeNames: names,
       ExpressionAttributeValues: values,
       ReturnValues: 'ALL_NEW',
@@ -1519,6 +1551,208 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     } catch (e) {
       if (e?.name === 'ConditionalCheckFailedException') return null;
       throw e;
+    }
+  };
+
+  const bindUnitPrWait = async ({
+    executionId,
+    sectionIndex,
+    slug,
+    callbackId,
+    runId,
+    snapshot,
+  }) => {
+    const ts = now();
+    const projection = unitPrWaitIndex({ executionId, sectionIndex, slug });
+    try {
+      const { Attributes } = await ddb.send(
+        new UpdateCommand({
+          TableName: table(),
+          Key: unitKey(executionId, sectionIndex, slug),
+          UpdateExpression:
+            'SET prWaitCallbackId = :callbackId, prWaitRunId = :runId, prWaitSnapshot = :snapshot, prWaitBoundAt = :ts, updatedAt = :ts, GSI3PK = :g3pk, GSI3SK = :g3sk REMOVE prWaitWakeClaimId, prWaitWakeClaimedAt, prWaitWakeClaimExpiresAt',
+          ConditionExpression:
+            'attribute_exists(pk) AND #state = :ready AND (attribute_not_exists(prWaitCallbackId) OR prWaitCallbackId = :callbackId) AND (attribute_not_exists(prWaitRunId) OR prWaitRunId = :runId)',
+          ExpressionAttributeNames: { '#state': 'state' },
+          ExpressionAttributeValues: {
+            ':callbackId': callbackId,
+            ':runId': runId,
+            ':snapshot': snapshot,
+            ':ts': ts,
+            ':ready': 'PR_READY',
+            ':g3pk': projection.GSI3PK,
+            ':g3sk': projection.GSI3SK,
+          },
+          ReturnValues: 'ALL_NEW',
+        }),
+      );
+      return Attributes;
+    } catch (error) {
+      if (error?.name === 'ConditionalCheckFailedException') return null;
+      throw error;
+    }
+  };
+
+  const listUnitPrWaits = async ({ limit = 100 } = {}) => {
+    const items = [];
+    let ExclusiveStartKey;
+    do {
+      const page = await ddb.send(
+        new QueryCommand({
+          TableName: table(),
+          IndexName: 'GSI3',
+          KeyConditionExpression: 'GSI3PK = :pk',
+          ExpressionAttributeValues: { ':pk': PR_WAITS_INDEX_PK },
+          Limit: limit - items.length,
+          ExclusiveStartKey,
+        }),
+      );
+      items.push(...(page.Items ?? []));
+      ExclusiveStartKey = page.LastEvaluatedKey;
+    } while (ExclusiveStartKey && items.length < limit);
+    return items;
+  };
+
+  const claimUnitPrWait = async ({
+    executionId,
+    sectionIndex,
+    slug,
+    callbackId,
+    runId,
+    claimId,
+    claimExpiresAt,
+  }) => {
+    const ts = now();
+    try {
+      const { Attributes } = await ddb.send(
+        new UpdateCommand({
+          TableName: table(),
+          Key: unitKey(executionId, sectionIndex, slug),
+          UpdateExpression:
+            'SET prWaitWakeClaimId = :claimId, prWaitWakeClaimedAt = :ts, prWaitWakeClaimExpiresAt = :claimExpiresAt, updatedAt = :ts',
+          ConditionExpression:
+            '#state = :ready AND prWaitCallbackId = :callbackId AND prWaitRunId = :runId AND (attribute_not_exists(prWaitWakeClaimId) OR prWaitWakeClaimExpiresAt < :ts)',
+          ExpressionAttributeNames: { '#state': 'state' },
+          ExpressionAttributeValues: {
+            ':ready': 'PR_READY',
+            ':callbackId': callbackId,
+            ':runId': runId,
+            ':claimId': claimId,
+            ':claimExpiresAt': claimExpiresAt,
+            ':ts': ts,
+          },
+          ReturnValues: 'ALL_NEW',
+        }),
+      );
+      return Attributes;
+    } catch (error) {
+      if (error?.name === 'ConditionalCheckFailedException') return null;
+      throw error;
+    }
+  };
+
+  const completeUnitPrWait = async ({
+    executionId,
+    sectionIndex,
+    slug,
+    callbackId,
+    runId,
+    claimId,
+    reason,
+  }) => {
+    const ts = now();
+    try {
+      const { Attributes } = await ddb.send(
+        new UpdateCommand({
+          TableName: table(),
+          Key: unitKey(executionId, sectionIndex, slug),
+          UpdateExpression:
+            'SET prWaitLastWakeReason = :reason, prWaitLastWokenAt = :ts, updatedAt = :ts REMOVE prWaitCallbackId, prWaitRunId, prWaitSnapshot, prWaitBoundAt, prWaitWakeClaimId, prWaitWakeClaimedAt, prWaitWakeClaimExpiresAt, GSI3PK, GSI3SK',
+          ConditionExpression:
+            'prWaitCallbackId = :callbackId AND prWaitRunId = :runId AND prWaitWakeClaimId = :claimId',
+          ExpressionAttributeValues: {
+            ':callbackId': callbackId,
+            ':runId': runId,
+            ':claimId': claimId,
+            ':reason': reason,
+            ':ts': ts,
+          },
+          ReturnValues: 'ALL_NEW',
+        }),
+      );
+      return Attributes;
+    } catch (error) {
+      if (error?.name === 'ConditionalCheckFailedException') return null;
+      throw error;
+    }
+  };
+
+  const releaseUnitPrWaitClaim = async ({
+    executionId,
+    sectionIndex,
+    slug,
+    callbackId,
+    runId,
+    claimId,
+  }) => {
+    try {
+      const { Attributes } = await ddb.send(
+        new UpdateCommand({
+          TableName: table(),
+          Key: unitKey(executionId, sectionIndex, slug),
+          UpdateExpression:
+            'SET updatedAt = :ts REMOVE prWaitWakeClaimId, prWaitWakeClaimedAt, prWaitWakeClaimExpiresAt',
+          ConditionExpression:
+            'prWaitCallbackId = :callbackId AND prWaitRunId = :runId AND prWaitWakeClaimId = :claimId',
+          ExpressionAttributeValues: {
+            ':callbackId': callbackId,
+            ':runId': runId,
+            ':claimId': claimId,
+            ':ts': now(),
+          },
+          ReturnValues: 'ALL_NEW',
+        }),
+      );
+      return Attributes;
+    } catch (error) {
+      if (error?.name === 'ConditionalCheckFailedException') return null;
+      throw error;
+    }
+  };
+
+  const clearUnitPrWait = async ({
+    executionId,
+    sectionIndex,
+    slug,
+    callbackId = null,
+    runId = null,
+  }) => {
+    const values = { ':ts': now() };
+    const conditions = ['attribute_exists(pk)'];
+    if (callbackId) {
+      conditions.push('prWaitCallbackId = :callbackId');
+      values[':callbackId'] = callbackId;
+    }
+    if (runId) {
+      conditions.push('prWaitRunId = :runId');
+      values[':runId'] = runId;
+    }
+    try {
+      const { Attributes } = await ddb.send(
+        new UpdateCommand({
+          TableName: table(),
+          Key: unitKey(executionId, sectionIndex, slug),
+          UpdateExpression:
+            'SET updatedAt = :ts REMOVE prWaitCallbackId, prWaitRunId, prWaitSnapshot, prWaitBoundAt, prWaitWakeClaimId, prWaitWakeClaimedAt, prWaitWakeClaimExpiresAt, GSI3PK, GSI3SK',
+          ConditionExpression: conditions.join(' AND '),
+          ExpressionAttributeValues: values,
+          ReturnValues: 'ALL_NEW',
+        }),
+      );
+      return Attributes;
+    } catch (error) {
+      if (error?.name === 'ConditionalCheckFailedException') return null;
+      throw error;
     }
   };
 
@@ -1970,6 +2204,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     appendOutput,
     getOutputs,
     listProjectExecutions,
+    listActiveExecutions,
     listStaleActiveExecutions,
     patchExecutionConfig,
     putUnitPlan,
@@ -1982,6 +2217,12 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     getUnitPr,
     listUnitPrs,
     updateUnitPr,
+    bindUnitPrWait,
+    listUnitPrWaits,
+    claimUnitPrWait,
+    completeUnitPrWait,
+    releaseUnitPrWaitClaim,
+    clearUnitPrWait,
     createFeedbackBatch,
     listFeedbackBatches,
     updateFeedbackBatch,

--- a/lambda/v2-orchestrator/section.js
+++ b/lambda/v2-orchestrator/section.js
@@ -436,6 +436,11 @@ export const runParallelSection = async (segment, toolkit) => {
   const persistedUnits = await ctx.step(`load-unit-states-${sk}`, () =>
     store.listUnits(executionId),
   );
+  const persistedBySlug = new Map(
+    (persistedUnits ?? [])
+      .filter((row) => Number(row.sectionIndex) === Number(segment.index))
+      .map((row) => [row.slug, row]),
+  );
   for (const row of persistedUnits ?? []) {
     if (
       Number(row.sectionIndex) === Number(segment.index) &&
@@ -1244,10 +1249,11 @@ export const runParallelSection = async (segment, toolkit) => {
         { unitSlug: slug, sectionIndex: segment.index, state: 'PR_READY' },
       );
 
-      let delaySeconds = 30;
       let repollForReconciliation = false;
-      for (let poll = 0; ; poll += 1) {
-        const pollFeedback = await processNextFeedback(`r${reconciliation}-poll-${poll}`);
+      for (let observation = 0; ; observation += 1) {
+        const pollFeedback = await processNextFeedback(
+          `r${reconciliation}-observation-${observation}`,
+        );
         if (pollFeedback.failed) {
           return laneFailed(laneCtx, slug, round, {
             stageId: 'review-feedback',
@@ -1262,7 +1268,7 @@ export const runParallelSection = async (segment, toolkit) => {
         let pollingError = null;
         try {
           statuses = await laneCtx.step(
-            `unit-pr-status-${sk}-${slug}${rTag}-${reconciliation}-${poll}`,
+            `unit-pr-status-${sk}-${slug}${rTag}-${reconciliation}-${observation}`,
             async () => {
               const out = [];
               for (const row of readyRows) {
@@ -1281,7 +1287,7 @@ export const runParallelSection = async (segment, toolkit) => {
         }
         if (pollingError || statuses.some(({ status }) => !status)) {
           await laneCtx.step(
-            `unit-pr-provider-failure-metric-${sk}-${slug}${rTag}-${reconciliation}-${poll}`,
+            `unit-pr-provider-failure-metric-${sk}-${slug}${rTag}-${reconciliation}-${observation}`,
             () =>
               store
                 .recordMetric?.({
@@ -1304,7 +1310,7 @@ export const runParallelSection = async (segment, toolkit) => {
         for (const { row, status } of statuses) {
           if (status.state === 'merged') {
             const ancestor = await laneCtx.step(
-              `unit-pr-ancestor-${sk}-${slug}-${encodeURIComponent(row.repository)}${rTag}-${reconciliation}-${poll}`,
+              `unit-pr-ancestor-${sk}-${slug}-${encodeURIComponent(row.repository)}${rTag}-${reconciliation}-${observation}`,
               () =>
                 callProvider('isAncestor', {
                   repoId: row.repository,
@@ -1328,7 +1334,7 @@ export const runParallelSection = async (segment, toolkit) => {
           const partial = merged.length > 0;
           if (partial) {
             await laneCtx.step(
-              `unit-pr-partial-metric-${sk}-${slug}${rTag}-${reconciliation}-${poll}`,
+              `unit-pr-partial-metric-${sk}-${slug}${rTag}-${reconciliation}-${observation}`,
               () =>
                 store
                   .recordMetric?.({
@@ -1343,7 +1349,7 @@ export const runParallelSection = async (segment, toolkit) => {
           const mergedRepositories = new Set(merged.map(({ row }) => row.repository));
           for (const { row, status } of statuses) {
             await laneCtx.step(
-              `unit-pr-halt-${sk}-${slug}-${encodeURIComponent(row.repository)}${rTag}-${reconciliation}-${poll}`,
+              `unit-pr-halt-${sk}-${slug}-${encodeURIComponent(row.repository)}${rTag}-${reconciliation}-${observation}`,
               () =>
                 store.updateUnitPr({
                   executionId,
@@ -1429,7 +1435,7 @@ export const runParallelSection = async (segment, toolkit) => {
         }
         if (moved) {
           await laneCtx.step(
-            `unit-pr-redraft-${sk}-${slug}${rTag}-${reconciliation}-${poll}`,
+            `unit-pr-redraft-${sk}-${slug}${rTag}-${reconciliation}-${observation}`,
             async () => {
               for (const { row, status } of statuses) {
                 if (status.state === 'open' && !status.draft) {
@@ -1454,11 +1460,47 @@ export const runParallelSection = async (segment, toolkit) => {
           break;
         }
 
-        await laneCtx.wait(`unit-pr-wait-${sk}-${slug}${rTag}-${reconciliation}-${poll}`, {
-          seconds: delaySeconds,
-        });
+        const [callbackPromise, callbackId] = await laneCtx.createCallback(
+          `unit-pr-wait-${sk}-${slug}${rTag}-${reconciliation}-${observation}`,
+        );
+        const snapshot = statuses.map(({ row, status }) => ({
+          repository: row.repository,
+          number: row.number,
+          state: status.state,
+          headSha: status.headSha ?? null,
+          targetSha: status.targetSha ?? null,
+        }));
+        const callbackBound = await laneCtx.step(
+          `unit-pr-bind-${sk}-${slug}${rTag}-${reconciliation}-${observation}`,
+          () =>
+            store.bindUnitPrWait({
+              executionId,
+              sectionIndex: segment.index,
+              slug,
+              callbackId,
+              runId,
+              snapshot,
+            }),
+        );
+        if (!callbackBound) {
+          const ownership = await laneCtx.step(
+            `unit-pr-bind-owner-${sk}-${slug}${rTag}-${reconciliation}-${observation}`,
+            () => store.getExecution(executionId),
+          );
+          if (
+            ownership?.status === 'CANCELLED' ||
+            (runId && ownership?.orchestratorRunId && ownership.orchestratorRunId !== runId)
+          ) {
+            return { slug, state: 'TERMINAL', value: { ok: false, reason: 'retired', intentId } };
+          }
+          return laneFailed(laneCtx, slug, round, {
+            stageId: 'unit-pr',
+            reason: 'pr_wait_callback_conflict',
+          });
+        }
+        await callbackPromise;
         const ownership = await laneCtx.step(
-          `unit-pr-owner-${sk}-${slug}${rTag}-${reconciliation}-${poll}`,
+          `unit-pr-owner-${sk}-${slug}${rTag}-${reconciliation}-${observation}`,
           () => store.getExecution(executionId),
         );
         if (
@@ -1467,19 +1509,6 @@ export const runParallelSection = async (segment, toolkit) => {
         ) {
           return { slug, state: 'TERMINAL', value: { ok: false, reason: 'retired', intentId } };
         }
-        await laneCtx.step(
-          `unit-pr-wait-metric-${sk}-${slug}${rTag}-${reconciliation}-${poll}`,
-          () =>
-            store
-              .recordMetric?.({
-                executionId,
-                sectionIndex: segment.index,
-                unitSlug: slug,
-                metrics: { prWaitMs: delaySeconds * 1000 },
-              })
-              ?.catch(() => {}),
-        );
-        delaySeconds = Math.min(delaySeconds * 2, 300);
       }
       if (!repollForReconciliation) break;
     }
@@ -1512,6 +1541,7 @@ export const runParallelSection = async (segment, toolkit) => {
       // vanished too, it is recreated from the intent branch — never main.
       baseBranch: intentBranch,
     };
+    const persistedUnit = persistedBySlug.get(slug);
 
     // Dependencies must be MERGED (A2 rule 4). In the wavefront, await the
     // dependency lanes' DurablePromises; settled lanes come from laneState.
@@ -1544,6 +1574,59 @@ export const runParallelSection = async (segment, toolkit) => {
         );
         return { slug, state: 'BLOCKED', blockedOn: dep };
       }
+    }
+
+    // A repair can relaunch a section after construction finished but while its
+    // unit PR was parked. Re-enter directly at provider reconciliation: the
+    // successful stage rows and existing draft PR are durable work, not inputs
+    // to regenerate. The all-terminal check prevents a half-built lane from
+    // skipping construction merely because its UNIT row has a review state.
+    const resumableUnitPr =
+      usesUnitPrs &&
+      round === 0 &&
+      !revive &&
+      ['PR_DRAFT', 'RECONCILING', 'PR_READY'].includes(persistedUnit?.state)
+        ? await laneCtx.step(`unit-pr-resume-check-${sk}-${slug}${rTag}`, async () => {
+            for (const stage of segment.stages) {
+              const stageRow = await store
+                .getStage(
+                  executionId,
+                  toolkit.stageInstanceIdFor(stage.stageId, slug, segment.index),
+                )
+                .catch(() => null);
+              if (!stageRow || !['SUCCEEDED', 'SKIPPED'].includes(stageRow.state)) return null;
+            }
+            const rows = await store.listUnitPrs(executionId, {
+              sectionIndex: segment.index,
+              slug,
+            });
+            return rows.length > 0 ? rows : null;
+          })
+        : null;
+    if (resumableUnitPr) {
+      await emitEvent(
+        laneCtx,
+        `unit-pr-resumed-event-${sk}-${slug}${rTag}`,
+        'v2.unit_pr.resumed',
+        `Unit ${slug} resumed from its existing review PR(s) without rebuilding completed stages`,
+        { unitSlug: slug, sectionIndex: segment.index, state: persistedUnit.state },
+      );
+      await waitForIntegrationTurn(slug);
+      const integrated = await withIntegrationLock(() =>
+        integrateUnitPullRequests({
+          laneCtx,
+          slug,
+          unitBranch,
+          laneSession,
+          round,
+          rTag,
+          rows: resumableUnitPr,
+        }),
+      );
+      await laneCtx
+        .step(`lane-integration-release-${sk}-${slug}${rTag}`, () => stopSession(laneSession))
+        .catch(() => {});
+      return integrated;
     }
 
     // Concurrency permit AFTER the dependency wait — blocked/waiting lanes
@@ -1615,6 +1698,21 @@ export const runParallelSection = async (segment, toolkit) => {
 
       // The section's stages, in plan order, per-unit instances (WP4 model).
       for (const stage of segment.stages) {
+        if (persistedUnit?.recoveryPreserveCompleted && !feedbackTaskId) {
+          const completed = await laneCtx.step(
+            `preserve-completed-${stage.stageId}-u-${slug}${rTag}`,
+            async () => {
+              const row = await store
+                .getStage(
+                  executionId,
+                  toolkit.stageInstanceIdFor(stage.stageId, slug, segment.index),
+                )
+                .catch(() => null);
+              return Boolean(row && ['SUCCEEDED', 'SKIPPED'].includes(row.state));
+            },
+          );
+          if (completed) continue;
+        }
         // Two deterministic per-unit skips, both recorded as SKIPPED rows:
         //   - the human-approved skip matrix (CONDITIONAL stages only);
         //   - kind pruning (produces_kinds): every required output of the

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -1446,6 +1446,7 @@ describe('PR per unit delivery', () => {
     });
     deps.store.listFeedbackBatches = vi.fn(async () => []);
     deps.store.updateFeedbackBatch = vi.fn(async (args) => args);
+    deps.store.bindUnitPrWait = vi.fn(async (args) => args);
     deps.store.recordMetric = vi.fn(async (args) => {
       metrics.push(args.metrics);
       return args;
@@ -1545,6 +1546,109 @@ describe('PR per unit delivery', () => {
       expect.arrayContaining(['PR_DRAFT', 'RECONCILING', 'PR_READY', 'MERGED']),
     );
     expect(deps.stopSession).toHaveBeenCalledWith('aidlc-intent-i1-s1-auth'.padEnd(33, '0'));
+  });
+
+  it('parks one callback for a long unchanged PR wait without growing durable operations', async () => {
+    const originalCreateCallback = ctx.createCallback;
+    let resolvePrWait;
+    ctx.step = vi.fn(async (_name, fn) => fn());
+    ctx.wait = vi.fn(async () => undefined);
+    ctx.createCallback = async (name) => {
+      if (!String(name).startsWith('unit-pr-wait-')) return originalCreateCallback(name);
+      const promise = new Promise((resolve) => {
+        resolvePrWait = resolve;
+      });
+      return [promise, `cb-${name}`];
+    };
+    let merged = false;
+    configure({
+      statusFor: async ({ number }) => ({
+        providerId: `provider-${number}`,
+        number,
+        url: `https://example.test/pr/${number}`,
+        sourceBranch: 'aidlc/i1--s1-unit-auth',
+        targetBranch: 'aidlc/i1',
+        headSha: `head-${number}`,
+        targetSha: 'intent-before',
+        state: merged ? 'merged' : 'open',
+        draft: false,
+        mergeable: true,
+      }),
+    });
+
+    const running = start();
+    await vi.waitFor(() => expect(deps.store.bindUnitPrWait).toHaveBeenCalledOnce());
+    const operationCount = ctx.step.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(ctx.step).toHaveBeenCalledTimes(operationCount);
+    expect(ctx.wait).not.toHaveBeenCalled();
+
+    merged = true;
+    resolvePrWait({ answer: { reason: 'merged' } });
+    await expect(running).resolves.toMatchObject({ ok: true });
+    expect(deps.store.bindUnitPrWait).toHaveBeenCalledOnce();
+  });
+
+  it('resumes an existing draft PR after repair without rerunning successful construction', async () => {
+    let statusCalls = 0;
+    configure({
+      statusFor: async ({ number }) => {
+        statusCalls += 1;
+        return {
+          providerId: `provider-${number}`,
+          number,
+          url: `https://example.test/pr/${number}`,
+          sourceBranch: 'aidlc/i1--s1-unit-auth',
+          targetBranch: 'aidlc/i1',
+          headSha: 'head-12',
+          targetSha: 'intent-before',
+          state: statusCalls >= 2 ? 'merged' : 'open',
+          draft: statusCalls < 2,
+          mergeable: true,
+        };
+      },
+    });
+    const existing = {
+      executionId: 'i1',
+      sectionIndex: 1,
+      unitSlug: 'auth',
+      repository: 'owner/repo',
+      provider: 'github',
+      number: 12,
+      sourceBranch: 'aidlc/i1--s1-unit-auth',
+      targetBranch: 'aidlc/i1',
+      headSha: 'head-12',
+      state: 'DRAFT',
+    };
+    unitPrRows.set('owner/repo', existing);
+    deps.store.listUnits = vi.fn(async () => [
+      { executionId: 'i1', sectionIndex: 1, slug: 'auth', state: 'PR_DRAFT' },
+    ]);
+    deps.store.listUnitPrs = vi.fn(async () => [existing]);
+    deps.store.getStage = vi.fn(async () => ({ state: 'SUCCEEDED' }));
+    deps.store.getUnitPlan = vi.fn(async () =>
+      UNIT_PLAN({
+        units: [{ slug: 'auth', dependsOn: [] }],
+        batches: [['auth']],
+        autonomyMode: 'autonomous',
+      }),
+    );
+
+    const result = await __durableHandler(
+      { action: 'start', intentId: 'i1', executionId: 'i1', startAtStageId: 'cg' },
+      ctx,
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(deps.unitPrProvider.createDraft).not.toHaveBeenCalled();
+    expect(invokes.filter((payload) => payload.command === 'init-lane')).toHaveLength(0);
+    expect(
+      stageStarts().filter((payload) => payload.stageId === 'cg' && payload.unitSlug === 'auth'),
+    ).toHaveLength(0);
+    expect(unitPrStates).toContainEqual(
+      expect.objectContaining({ repository: 'owner/repo', state: 'MERGED' }),
+    );
   });
 
   it('claims selected feedback, revises the last successful stage, and posts one summary', async () => {

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -2098,15 +2098,15 @@ module "intents_lambda" {
 
 resource "aws_cloudwatch_event_rule" "intents_durable_watchdog" {
   name                = "${var.project_name}-intents-durable-watchdog-${var.environment}"
-  description         = "Repair v2 intents whose durable orchestrator expired while process state remained active"
-  schedule_expression = "rate(1 day)"
+  description         = "Reconcile parked PR waits and detect terminal durable orchestrators"
+  schedule_expression = "rate(1 minute)"
 }
 
 resource "aws_cloudwatch_event_target" "intents_durable_watchdog" {
   rule      = aws_cloudwatch_event_rule.intents_durable_watchdog.name
   target_id = "intents-durable-watchdog"
   arn       = module.intents_lambda.lambda_function_arn
-  input     = jsonencode({ action = "repair-durable-executions" })
+  input     = jsonencode({ action = "reconcile-provider-state" })
 }
 
 resource "aws_lambda_permission" "intents_durable_watchdog" {

--- a/terraform/modules/compute/agentcore/main.tf
+++ b/terraform/modules/compute/agentcore/main.tf
@@ -177,6 +177,7 @@ module "agentcore_docker_build" {
 # ---------------------------------------------------------------------------
 # v2 process/state table (EXEC#/STAGE#/EVENT#/HUMAN#/METRIC#/OUTPUT#)
 #   GSI1 = project-status browse, GSI2 = per-execution type/state
+#   GSI3 = sparse maintenance index for active executions and parked PR waits
 # ---------------------------------------------------------------------------
 
 resource "aws_dynamodb_table" "v2_executions" {
@@ -211,6 +212,14 @@ resource "aws_dynamodb_table" "v2_executions" {
     name = "GSI2SK"
     type = "S"
   }
+  attribute {
+    name = "GSI3PK"
+    type = "S"
+  }
+  attribute {
+    name = "GSI3SK"
+    type = "S"
+  }
 
   global_secondary_index {
     name            = "GSI1"
@@ -238,6 +247,21 @@ resource "aws_dynamodb_table" "v2_executions" {
     }
     key_schema {
       attribute_name = "GSI2SK"
+      key_type       = "RANGE"
+    }
+  }
+
+  global_secondary_index {
+    name            = "GSI3"
+    projection_type = "ALL"
+    read_capacity   = local.read_capacity
+    write_capacity  = local.write_capacity
+    key_schema {
+      attribute_name = "GSI3PK"
+      key_type       = "HASH"
+    }
+    key_schema {
+      attribute_name = "GSI3SK"
       key_type       = "RANGE"
     }
   }


### PR DESCRIPTION
Closes #334


## Problem

PR-per-unit review used durable timer polling. One production-like execution exhausted Lambda's 3,000-operation limit while waiting for review, leaving process state active after the durable execution had failed.

The affected intent also demonstrated why repair must preserve state: one reviewed unit PR had merged remotely while local state lagged, and another unit's construction stages and draft PR were already complete and reusable.

## Approach

- Replace repeated durable PR polling with one persisted callback per observed provider state.
- Add sparse DynamoDB maintenance partitions for active executions and parked PR waits.
- Reconcile GitHub/GitLab state on a one-minute schedule and wake only for merge, closure, branch movement, or queued authenticated feedback.
- Atomically claim callback delivery so scheduler and feedback wakeups cannot double-resume a run.
- Detect terminal durable executions before their configured local expiry without overwriting a concurrently completed process row.
- Reconcile provider truth during repair, validate merged reviewed-head ancestry, preserve successful stages and artifacts, and resume existing draft PRs through the current orchestrator alias.

## Recovery verification

The deployed dev recovery was exercised against the failed execution that motivated #334:

- the prior durable execution was confirmed `FAILED` with `ExecutionLimitExceeded`;
- the merged reviewed head was confirmed reachable from the intent branch and the corresponding unit was marked merged;
- ten completed construction stage rows remained `SUCCEEDED` at attempt 0 and no artifacts were archived;
- the existing draft PR was reconciled in place, promoted to ready, and parked on exactly one persisted callback in the sparse `PR_WAITS` index.

The review PR was deliberately left unmerged.

## Testing

- `npm test` - 117 files, 2,331 tests passed
- focused shared/orchestrator/intents suites - 44 files, 887 tests passed
- commit hook - formatting, lint, secret scan, production dependency audits, and 561 targeted tests passed
- affected `intents` and `v2-orchestrator` Lambda bundles built successfully
- `terraform fmt -check -recursive terraform`

