### PR TITLE
Fix(frontend): UI improvements

### DIFF
--- a/frontend/src/components/intent/ArtifactMarkdown.test.tsx
+++ b/frontend/src/components/intent/ArtifactMarkdown.test.tsx
@@ -36,4 +36,58 @@ describe('ArtifactMarkdown', () => {
     expect(screen.getByText('const answer = 42;')).toBeInTheDocument();
     expect(mermaid.render).not.toHaveBeenCalled();
   });
+
+  it('links known wiki references to artifact previews', () => {
+    const onOpenArtifact = vi.fn();
+    render(
+      <ArtifactMarkdown
+        content="See [[reverse-engineering-timestamp]] for details."
+        artifacts={[
+          { id: 'reverse-engineering-timestamp', title: 'Reverse Engineering Timestamp' },
+        ]}
+        onOpenArtifact={onOpenArtifact}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Reverse Engineering Timestamp' });
+    expect(link).toHaveAttribute('href', '#artifact-reverse-engineering-timestamp');
+    link.click();
+    expect(onOpenArtifact).toHaveBeenCalledWith('reverse-engineering-timestamp');
+  });
+
+  it('links known derived-item slugs in ordinary Markdown text', () => {
+    const onOpenItem = vi.fn();
+    render(
+      <ArtifactMarkdown
+        content="Maps to story-upload-screen and req-upload-two-buttons."
+        derivedItems={[
+          { id: 'story-node', slug: 'story-upload-screen', label: 'Upload screen' },
+          { id: 'req-node', slug: 'req-upload-two-buttons', label: 'Two upload buttons' },
+        ]}
+        onOpenItem={onOpenItem}
+      />,
+    );
+
+    const storyLink = screen.getByRole('link', { name: 'Upload screen' });
+    const requirementLink = screen.getByRole('link', { name: 'Two upload buttons' });
+    expect(storyLink).toHaveAttribute('href', '#item-story-node');
+    expect(requirementLink).toHaveAttribute('href', '#item-req-node');
+    storyLink.click();
+    requirementLink.click();
+    expect(onOpenItem).toHaveBeenNthCalledWith(1, 'story-node');
+    expect(onOpenItem).toHaveBeenNthCalledWith(2, 'req-node');
+  });
+
+  it('does not link wiki references or derived-item slugs inside code', () => {
+    render(
+      <ArtifactMarkdown
+        content={'`[[artifact-id]] story-upload-screen`'}
+        artifacts={[{ id: 'artifact-id', title: 'Artifact' }]}
+        derivedItems={[{ id: 'story-node', slug: 'story-upload-screen', label: 'Upload screen' }]}
+      />,
+    );
+
+    expect(screen.getByText('[[artifact-id]] story-upload-screen')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/intent/ArtifactMarkdown.tsx
+++ b/frontend/src/components/intent/ArtifactMarkdown.tsx
@@ -1,6 +1,131 @@
-import { isValidElement, useEffect, useId, useRef, useState } from 'react';
+import {
+  isValidElement,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+} from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import type { PluggableList } from 'unified';
+
+export interface MarkdownArtifactLink {
+  id: string;
+  title: string | null;
+}
+
+export interface MarkdownDerivedItemLink {
+  id: string;
+  slug?: string | null;
+  label: string;
+}
+
+type MdastNode = {
+  type: string;
+  value?: string;
+  children?: MdastNode[];
+  url?: string;
+};
+
+const WIKI_LINK_RE = /\[\[([^\]\r\n]+)\]\]/g;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function remarkPreviewLinks(
+  artifacts: MarkdownArtifactLink[],
+  derivedItems: MarkdownDerivedItemLink[],
+) {
+  const artifactsById = new Map(artifacts.map((artifact) => [artifact.id.toLowerCase(), artifact]));
+  const itemsBySlug = new Map(
+    derivedItems.flatMap((item) =>
+      [item.slug, item.id].filter(Boolean).map((key) => [key!.toLowerCase(), item] as const),
+    ),
+  );
+  const derivedPattern =
+    itemsBySlug.size > 0
+      ? new RegExp(
+          `(?<![A-Za-z0-9_-])(${[...itemsBySlug.keys()]
+            .toSorted((a, b) => b.length - a.length)
+            .map(escapeRegex)
+            .join('|')})(?![A-Za-z0-9_-])`,
+          'gi',
+        )
+      : null;
+
+  const expandDerivedItems = (value: string): MdastNode[] => {
+    if (!derivedPattern) return [{ type: 'text', value }];
+
+    const nodes: MdastNode[] = [];
+    let lastIndex = 0;
+    for (const match of value.matchAll(derivedPattern)) {
+      const start = match.index ?? 0;
+      if (start > lastIndex) nodes.push({ type: 'text', value: value.slice(lastIndex, start) });
+
+      const item = itemsBySlug.get(match[1].toLowerCase());
+      if (item) {
+        nodes.push({
+          type: 'link',
+          url: `#item-${encodeURIComponent(item.id)}`,
+          children: [{ type: 'text', value: item.label || item.slug || item.id }],
+        });
+      }
+      lastIndex = start + match[0].length;
+    }
+
+    if (lastIndex === 0) return [{ type: 'text', value }];
+    if (lastIndex < value.length) nodes.push({ type: 'text', value: value.slice(lastIndex) });
+    return nodes;
+  };
+
+  const expandText = (value: string): MdastNode[] => {
+    const nodes: MdastNode[] = [];
+    let lastIndex = 0;
+
+    for (const match of value.matchAll(WIKI_LINK_RE)) {
+      const start = match.index ?? 0;
+      if (start > lastIndex) nodes.push(...expandDerivedItems(value.slice(lastIndex, start)));
+
+      const artifact = artifactsById.get(match[1].trim().toLowerCase());
+      nodes.push(
+        artifact
+          ? {
+              type: 'link',
+              url: `#artifact-${encodeURIComponent(artifact.id)}`,
+              children: [{ type: 'text', value: artifact.title || artifact.id }],
+            }
+          : { type: 'text', value: match[0] },
+      );
+      lastIndex = start + match[0].length;
+    }
+
+    if (lastIndex === 0) return expandDerivedItems(value);
+    if (lastIndex < value.length) nodes.push(...expandDerivedItems(value.slice(lastIndex)));
+    return nodes;
+  };
+
+  return (tree: MdastNode) => {
+    const visit = (node: MdastNode) => {
+      if (node.type === 'code' || node.type === 'inlineCode' || node.type === 'link') return;
+      if (!node.children) return;
+
+      const children: MdastNode[] = [];
+      for (const child of node.children) {
+        if (child.type === 'text' && child.value) {
+          children.push(...expandText(child.value));
+        } else {
+          children.push(child);
+          visit(child);
+        }
+      }
+      node.children = children;
+    };
+    visit(tree);
+  };
+}
 
 type MermaidState =
   | { status: 'idle' | 'loading'; svg?: undefined; error?: undefined }
@@ -36,9 +161,74 @@ const markdownComponents: Components = {
   },
 };
 
-export function ArtifactMarkdown({ content }: { content: string }) {
+type MarkdownLinkProps = ComponentPropsWithoutRef<'a'> & { node?: MdastNode };
+
+function makePreviewLinkComponent(
+  onOpenArtifact?: (artifactId: string) => void,
+  onOpenItem?: (itemId: string) => void,
+): NonNullable<Components['a']> {
+  return function PreviewLink({ href, children, ...props }: MarkdownLinkProps) {
+    const artifactId = href?.startsWith('#artifact-')
+      ? decodeURIComponent(href.slice('#artifact-'.length))
+      : null;
+    const itemId = href?.startsWith('#item-')
+      ? decodeURIComponent(href.slice('#item-'.length))
+      : null;
+
+    return (
+      <a
+        {...props}
+        href={href}
+        onClick={(event) => {
+          if (artifactId && onOpenArtifact) {
+            event.preventDefault();
+            onOpenArtifact(artifactId);
+          } else if (itemId && onOpenItem) {
+            event.preventDefault();
+            onOpenItem(itemId);
+          }
+        }}
+      >
+        {children}
+      </a>
+    );
+  };
+}
+
+export function ArtifactMarkdown({
+  content,
+  artifacts = [],
+  derivedItems = [],
+  onOpenArtifact,
+  onOpenItem,
+}: {
+  content: string;
+  artifacts?: MarkdownArtifactLink[];
+  derivedItems?: MarkdownDerivedItemLink[];
+  onOpenArtifact?: (artifactId: string) => void;
+  onOpenItem?: (itemId: string) => void;
+}) {
+  const remarkPlugins = useMemo<PluggableList>(
+    () => [
+      remarkGfm,
+      [remarkPreviewLinks, artifacts, derivedItems] as [
+        typeof remarkPreviewLinks,
+        MarkdownArtifactLink[],
+        MarkdownDerivedItemLink[],
+      ],
+    ],
+    [artifacts, derivedItems],
+  );
+  const components = useMemo(
+    () => ({
+      ...markdownComponents,
+      a: makePreviewLinkComponent(onOpenArtifact, onOpenItem),
+    }),
+    [onOpenArtifact, onOpenItem],
+  );
+
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+    <ReactMarkdown remarkPlugins={remarkPlugins} components={components}>
       {content}
     </ReactMarkdown>
   );

--- a/frontend/src/components/intent/DerivedItemRow.tsx
+++ b/frontend/src/components/intent/DerivedItemRow.tsx
@@ -1,0 +1,54 @@
+import { ChevronRight } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { IntentGraphNode } from '@/services/intents';
+import type { GraphNeighbor } from '@/hooks/useIntentGraph';
+import { DiscussButton } from '@/components/discussion/DiscussButton';
+import { IntentGraphPopover } from '@/components/intent/IntentGraphPopover';
+import { nodeTypeTextColor } from '@/components/graph/nodeStyles';
+
+export function DerivedItemRow({
+  item,
+  getNeighbors,
+  onPreview,
+  showGraph = true,
+}: {
+  item: IntentGraphNode;
+  getNeighbors: (id: string) => GraphNeighbor[];
+  onPreview: () => void;
+  showGraph?: boolean;
+}) {
+  return (
+    <div
+      id={`item-${item.id}`}
+      role="button"
+      tabIndex={0}
+      className="group/item flex items-center gap-1.5 rounded-md px-2 py-1 scroll-mt-4 cursor-pointer hover:bg-muted/50 transition-colors"
+      onClick={onPreview}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onPreview();
+        }
+      }}
+    >
+      <ChevronRight
+        className={cn('h-3 w-3 shrink-0', nodeTypeTextColor(item.type))}
+        strokeWidth={3}
+      />
+      <span className="min-w-0 flex-1 truncate text-sm">{item.label}</span>
+      {item.priority && (
+        <Badge variant="secondary" className="h-4 px-1 text-[9px] shrink-0">
+          {item.priority}
+        </Badge>
+      )}
+      {showGraph && <IntentGraphPopover neighbors={getNeighbors(item.id)} className="shrink-0" />}
+      <DiscussButton
+        entityType="item"
+        entityId={item.id}
+        entityTitle={item.label}
+        className="shrink-0"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/intent/ProvenanceTree.test.tsx
+++ b/frontend/src/components/intent/ProvenanceTree.test.tsx
@@ -53,7 +53,11 @@ const row = (over: Partial<IntentStageRow> = {}): IntentStageRow => ({
   ...over,
 });
 
-const PHASE_NAMES: Record<string, string> = { '01': 'Inception', '02': 'Construction' };
+const PHASE_NAMES: Record<string, string> = {
+  '01': 'Inception',
+  '02': 'Construction',
+  '03': 'Operation',
+};
 const phaseNameOf = (path: string) =>
   PHASE_NAMES[path] ?? (path ? path.charAt(0).toUpperCase() + path.slice(1) : path);
 
@@ -137,6 +141,79 @@ describe('ProvenanceTree — phase ordering', () => {
       .map((el) => el.id)
       .filter((id) => id.startsWith('provenance-phase-'));
     expect(phaseIds).toEqual(['provenance-phase-01', 'provenance-phase-02', 'provenance-phase-10']);
+  });
+});
+
+describe('ProvenanceTree — document ordering', () => {
+  const artifacts = [
+    doc({ id: 'older', title: 'Older document', createdAt: '2026-01-01T10:00:00Z' }),
+    doc({ id: 'newer', title: 'Newer document', createdAt: '2026-01-01T11:00:00Z' }),
+  ];
+
+  it('defaults to document production order within a stage', () => {
+    renderTree({ detail: { artifacts } as IntentDetail, stageRows: [row()] });
+
+    expect(
+      screen
+        .getByText('Older document')
+        .compareDocumentPosition(screen.getByText('Newer document')),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it('reverses phases, stages, and documents together', () => {
+    const artifacts = [
+      doc({
+        id: 'inception-first',
+        title: 'Inception first',
+        createdByStageInstanceId: 'si-inception-first',
+        createdAt: '2026-01-01T10:00:00Z',
+      }),
+      doc({
+        id: 'inception-last',
+        title: 'Inception last',
+        createdByStageInstanceId: 'si-inception-last',
+        createdAt: '2026-01-01T11:00:00Z',
+      }),
+      doc({
+        id: 'operation',
+        title: 'Operation document',
+        createdByStageInstanceId: 'si-operation',
+        createdAt: '2026-01-01T12:00:00Z',
+      }),
+    ];
+    renderTree({
+      detail: { artifacts } as IntentDetail,
+      stageRows: [
+        row({
+          stageId: 'research',
+          stageInstanceId: 'si-inception-first',
+          phase: '01',
+          order: 1,
+        }),
+        row({
+          stageId: 'requirements-analysis',
+          stageInstanceId: 'si-inception-last',
+          phase: '01',
+          order: 2,
+        }),
+        row({ stageId: 'operate', stageInstanceId: 'si-operation', phase: '03', order: 1 }),
+      ],
+      documentOrder: 'newest-first',
+    });
+
+    expect(
+      screen.getByText('Operation').compareDocumentPosition(screen.getByText('Inception')),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      screen
+        .getByText('Requirements Analysis')
+        .compareDocumentPosition(screen.getByText('Research')),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      screen
+        .getByText('Inception last')
+        .compareDocumentPosition(screen.getByText('Inception first')),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 });
 

--- a/frontend/src/components/intent/ProvenanceTree.tsx
+++ b/frontend/src/components/intent/ProvenanceTree.tsx
@@ -20,6 +20,7 @@ import {
 import { AlertTriangle } from 'lucide-react';
 import { getTimeAgo } from '@/lib/timeAgo';
 import { nodeTypeTextColor, shortNodeType } from '@/components/graph/nodeStyles';
+import { DerivedItemRow } from '@/components/intent/DerivedItemRow';
 import {
   onWorkProductFocus,
   scrollAndFlash,
@@ -256,7 +257,7 @@ export function ProvenanceTree({
                           {isExpanded && hasItems && (
                             <div className="space-y-0.5 pl-5">
                               {visibleItems.map((item) => (
-                                <ItemRow
+                                <DerivedItemRow
                                   key={item.id}
                                   item={item}
                                   getNeighbors={getNeighbors}
@@ -306,7 +307,7 @@ export function ProvenanceTree({
         >
           <div className="space-y-0.5 pl-5">
             {unlinkedItems.map((item) => (
-              <ItemRow
+              <DerivedItemRow
                 key={item.id}
                 item={item}
                 getNeighbors={getNeighbors}
@@ -456,50 +457,6 @@ function DocumentRow({
       <ArtifactHistoryDrawer artifact={doc} />
       <IntentGraphPopover neighbors={getNeighbors(doc.id)} className="shrink-0" />
       <DiscussButton entityType="artifact" entityId={doc.id} entityTitle={doc.title || doc.id} />
-    </div>
-  );
-}
-
-function ItemRow({
-  item,
-  getNeighbors,
-  onPreview,
-}: {
-  item: IntentGraphNode;
-  getNeighbors: (id: string) => GraphNeighbor[];
-  onPreview: () => void;
-}) {
-  return (
-    <div
-      id={`item-${item.id}`}
-      role="button"
-      tabIndex={0}
-      className="group/item flex items-center gap-1.5 rounded-md px-2 py-1 scroll-mt-4 cursor-pointer hover:bg-muted/50 transition-colors"
-      onClick={onPreview}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onPreview();
-        }
-      }}
-    >
-      <ChevronRight
-        className={cn('h-3 w-3 shrink-0', nodeTypeTextColor(item.type))}
-        strokeWidth={3}
-      />
-      <span className="min-w-0 flex-1 truncate text-sm">{item.label}</span>
-      {item.priority && (
-        <Badge variant="secondary" className="h-4 px-1 text-[9px] shrink-0">
-          {item.priority}
-        </Badge>
-      )}
-      <IntentGraphPopover neighbors={getNeighbors(item.id)} className="shrink-0" />
-      <DiscussButton
-        entityType="item"
-        entityId={item.id}
-        entityTitle={item.label}
-        className="shrink-0"
-      />
     </div>
   );
 }

--- a/frontend/src/components/intent/ProvenanceTree.tsx
+++ b/frontend/src/components/intent/ProvenanceTree.tsx
@@ -36,6 +36,7 @@ interface ProvenanceTreeProps {
   codeItems: CodeItem[];
   openArtifactPreview: (id: string) => void;
   openItemPreview: (id: string) => void;
+  documentOrder?: 'oldest-first' | 'newest-first';
 }
 
 interface PhaseNode {
@@ -64,6 +65,7 @@ export function ProvenanceTree({
   codeItems,
   openArtifactPreview,
   openItemPreview,
+  documentOrder = 'oldest-first',
 }: ProvenanceTreeProps) {
   const activeArtifacts = detail.artifacts.filter((a) => !a.supersededAt);
   const documents = activeArtifacts.filter(isDocumentArtifact);
@@ -80,7 +82,10 @@ export function ProvenanceTree({
     [stageRows, phaseNameOf],
   );
 
-  const tree = useMemo(() => buildPhaseTree(documents, getProvenance), [documents, getProvenance]);
+  const tree = useMemo(
+    () => buildPhaseTree(documents, getProvenance, documentOrder),
+    [documents, getProvenance, documentOrder],
+  );
 
   // Derived items keep the standardized graph node palette (nodeStyles).
   const itemTypeLegend = useMemo(() => {
@@ -550,6 +555,7 @@ const artifactTs = (a: IntentArtifact) => (a.createdAt ? new Date(a.createdAt).g
 function buildPhaseTree(
   documents: IntentArtifact[],
   getProvenance: (a: IntentArtifact) => DocProvenance,
+  documentOrder: 'oldest-first' | 'newest-first',
 ): PhaseNode[] {
   const phases = new Map<string, PhaseNode>();
   const stageNodeMap = new Map<string, StageNode>();
@@ -581,12 +587,18 @@ function buildPhaseTree(
 
   for (const phase of phases.values()) {
     phase.stages.sort((a, b) => {
-      if (a.order !== b.order) return a.order - b.order;
+      const stageOrder =
+        a.order !== b.order
+          ? a.order - b.order
+          : codepointCompare(a.unitSlug ?? '', b.unitSlug ?? '');
       // Same order (same stage, different units): tie-break with unitSlug for determinism.
-      return codepointCompare(a.unitSlug ?? '', b.unitSlug ?? '');
+      return documentOrder === 'newest-first' ? -stageOrder : stageOrder;
     });
     for (const stage of phase.stages) {
-      stage.documents.sort((a, b) => artifactTs(a) - artifactTs(b));
+      stage.documents.sort((a, b) => {
+        const chronological = artifactTs(a) - artifactTs(b);
+        return documentOrder === 'newest-first' ? -chronological : chronological;
+      });
     }
   }
 
@@ -596,7 +608,8 @@ function buildPhaseTree(
   return [...phases.values()].toSorted((a, b) => {
     if (a.phasePath === '__other__') return 1;
     if (b.phasePath === '__other__') return -1;
-    return codepointCompare(a.phasePath, b.phasePath);
+    const phaseOrder = codepointCompare(a.phasePath, b.phasePath);
+    return documentOrder === 'newest-first' ? -phaseOrder : phaseOrder;
   });
 }
 

--- a/frontend/src/components/intent/StageReviewPanel.tsx
+++ b/frontend/src/components/intent/StageReviewPanel.tsx
@@ -198,20 +198,6 @@ export function StageReviewPanel({
   // re-validated server-side.
   const [skipTo, setSkipTo] = useState('');
   const skipTargets = gate.skipTargets ?? [];
-  // Gate-time recompose delta: arbitrary LATER CONDITIONAL stages to drop,
-  // decided right here where the results are reviewed — rides the approve
-  // answer as { recompose: { skip: [...] } }, applied in place (no relaunch),
-  // re-validated server-side. The offer list was computed by the same
-  // validator that judges the answer.
-  const [reshapeSkips, setReshapeSkips] = useState<Set<string>>(new Set());
-  const recomposeTargets = gate.recomposeTargets ?? [];
-  const toggleReshapeSkip = (stageId: string) =>
-    setReshapeSkips((prev) => {
-      const next = new Set(prev);
-      if (next.has(stageId)) next.delete(stageId);
-      else next.add(stageId);
-      return next;
-    });
   const graph = useIntentGraph(projectId, intentId);
   const stage = detail.stages.find((s) => s.stageInstanceId === gate.stageInstanceId) ?? null;
   const artifacts = detail.artifacts.filter(
@@ -263,7 +249,6 @@ export function StageReviewPanel({
             ? {
                 decision,
                 ...(skipTo ? { skipTo } : {}),
-                ...(reshapeSkips.size ? { recompose: { skip: [...reshapeSkips] } } : {}),
               }
             : { decision, feedback: currentFeedback },
       });
@@ -534,91 +519,46 @@ export function StageReviewPanel({
               {gate.answeredAt ? ` at ${new Date(gate.answeredAt).toLocaleString()}` : ''}.
             </div>
           )}
-          {pending && recomposeTargets.length > 0 && (
-            <details className="rounded-md border bg-background/60 px-3 py-2">
-              <summary
-                className="cursor-pointer list-none text-xs font-medium"
-                data-testid="review-reshape-toggle"
+          {pending && skipTargets.length > 0 && (
+            <div>
+              <Label htmlFor="skip-to-select" className="sr-only">
+                After approval
+              </Label>
+              <Select
+                value={skipTo || 'next'}
+                onValueChange={(v) => setSkipTo(v === 'next' ? '' : v)}
+                disabled={submitting}
               >
-                Reshape upcoming stages
-                <span className="ml-1.5 font-normal text-muted-foreground">
-                  {reshapeSkips.size
-                    ? `— dropping ${reshapeSkips.size} with this approval`
-                    : '— optionally drop later optional stages based on what you just reviewed'}
-                </span>
-              </summary>
-              <div className="mt-2 space-y-2">
-                <p className="text-[11px] text-muted-foreground">
-                  Checked stages are skipped when you approve — applied in place, the run keeps
-                  going. Downstream stages treat their outputs as absent by design; rewind to a
-                  skipped stage to bring it back. For bigger reshapes (adding stages back, a whole
-                  new grid), use <em>Reshape remaining stages</em> on the intent page.
-                </p>
-                <div className="grid gap-1.5 sm:grid-cols-2">
-                  {recomposeTargets.map((t) => (
-                    <label
-                      key={t}
-                      className="flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-sm cursor-pointer hover:bg-muted/50"
-                      data-testid={`review-reshape-${t}`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={reshapeSkips.has(t)}
-                        onChange={() => toggleReshapeSkip(t)}
-                        disabled={submitting}
-                        className="h-3.5 w-3.5"
-                      />
-                      <span
-                        className={reshapeSkips.has(t) ? 'line-through text-muted-foreground' : ''}
-                      >
-                        {t}
-                      </span>
-                    </label>
+                <SelectTrigger id="skip-to-select" className="h-9 w-full text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {/* Name the COMPUTED next stage verbatim (upstream
+                      2.2.6) — "Complete workflow" when this is the last
+                      stage; the generic label only on legacy gates that
+                      never carried the field. */}
+                  <SelectItem value="next">
+                    {gate.nextStageId !== undefined
+                      ? gate.nextStageId
+                        ? `Continue to ${gate.nextStageId}`
+                        : 'Complete workflow'
+                      : 'Continue to the next stage'}
+                  </SelectItem>
+                  {skipTargets.map((t) => (
+                    <SelectItem key={t} value={t}>
+                      Skip ahead to {t}
+                    </SelectItem>
                   ))}
-                </div>
-              </div>
-            </details>
+                </SelectContent>
+              </Select>
+            </div>
           )}
-          <div className="flex flex-wrap items-center justify-end gap-2 pt-1">
+          <div className="flex flex-wrap items-center gap-2 pt-1">
             <Button variant="outline" className="mr-auto" onClick={onBack}>
               Back to intent
             </Button>
             {pending && (
               <>
-                {skipTargets.length > 0 && (
-                  <div className="flex items-center gap-2">
-                    <Label htmlFor="skip-to-select" className="text-xs text-muted-foreground">
-                      After approval
-                    </Label>
-                    <Select
-                      value={skipTo || 'next'}
-                      onValueChange={(v) => setSkipTo(v === 'next' ? '' : v)}
-                      disabled={submitting}
-                    >
-                      <SelectTrigger id="skip-to-select" className="h-8 w-56 text-xs">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {/* Name the COMPUTED next stage verbatim (upstream
-                            2.2.6) — "Complete workflow" when this is the last
-                            stage; the generic label only on legacy gates that
-                            never carried the field. */}
-                        <SelectItem value="next">
-                          {gate.nextStageId !== undefined
-                            ? gate.nextStageId
-                              ? `Continue to ${gate.nextStageId}`
-                              : 'Complete workflow'
-                            : 'Continue to the next stage'}
-                        </SelectItem>
-                        {skipTargets.map((t) => (
-                          <SelectItem key={t} value={t}>
-                            Skip ahead to {t}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
                 <Button
                   variant="outline"
                   disabled={submitting || !feedback.trim()}
@@ -629,13 +569,11 @@ export function StageReviewPanel({
                 <Button disabled={submitting} onClick={() => submit('approve')}>
                   {skipTo
                     ? `Approve & skip to ${skipTo}`
-                    : reshapeSkips.size
-                      ? `Approve & drop ${reshapeSkips.size} stage${reshapeSkips.size === 1 ? '' : 's'}`
-                      : gate.nextStageId !== undefined
-                        ? gate.nextStageId
-                          ? `Approve — continue to ${gate.nextStageId}`
-                          : 'Approve — complete workflow'
-                        : 'Approve stage'}
+                    : gate.nextStageId !== undefined
+                      ? gate.nextStageId
+                        ? `Approve — continue to ${gate.nextStageId}`
+                        : 'Approve — complete workflow'
+                      : 'Approve stage'}
                 </Button>
               </>
             )}

--- a/frontend/src/components/intent/StageReviewPanel.tsx
+++ b/frontend/src/components/intent/StageReviewPanel.tsx
@@ -6,6 +6,7 @@ import { useIntentGraph } from '@/hooks/useIntentGraph';
 import { useYjsDocument } from '@/hooks/useYjsDocument';
 import { CollaborativeTextarea } from '@/components/CollaborativeTextarea';
 import { ArtifactViewer } from '@/components/intent/ArtifactViewer';
+import { DerivedItemRow } from '@/components/intent/DerivedItemRow';
 import { scrollAndFlash } from '@/components/intent/workProductsFocus';
 import { DiscussButton } from '@/components/discussion/DiscussButton';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -191,7 +192,7 @@ export function StageReviewPanel({
   onBack,
 }: StageReviewPanelProps) {
   const [submitting, setSubmitting] = useState(false);
-  const { stageNameOf } = useIntent();
+  const { stageNameOf, openItemPreview } = useIntent();
   // Gate-time "skip to stage X" (stage-skip.js): the backend computed the
   // valid forward targets (every intermediate is CONDITIONAL); '' = none.
   // Rides the approve answer as { decision: 'approve', skipTo } and is
@@ -455,17 +456,15 @@ export function StageReviewPanel({
                       {reviewItemGroupLabel(type)}
                       <span className="ml-1.5 font-normal">({items.length})</span>
                     </div>
-                    <div className="flex flex-wrap gap-1.5">
+                    <div className="space-y-0.5">
                       {items.map((item) => (
-                        <Badge
+                        <DerivedItemRow
                           key={item.id}
-                          variant="outline"
-                          className="max-w-full truncate"
-                          title={item.slug ? `${item.slug}: ${item.label}` : item.label}
-                        >
-                          {item.slug ? `${item.slug}: ` : ''}
-                          {item.label}
-                        </Badge>
+                          item={item}
+                          getNeighbors={graph.getNeighbors}
+                          onPreview={() => openItemPreview(item.id)}
+                          showGraph={false}
+                        />
                       ))}
                     </div>
                   </div>

--- a/frontend/src/components/intent/UnitLaneBoard.test.tsx
+++ b/frontend/src/components/intent/UnitLaneBoard.test.tsx
@@ -415,6 +415,46 @@ describe('isBeforeConstructionPhase', () => {
     expect(isBeforeConstructionPhase('03', phases)).toBe(false);
   });
 
+  it('uses nested zero-padded paths rather than sibling order', () => {
+    const nestedPhases: PhaseNode[] = [
+      {
+        phaseId: 'discovery',
+        name: 'Discovery',
+        kind: 'phase',
+        path: '01',
+        parentPath: null,
+        order: 1,
+      },
+      {
+        phaseId: 'inception',
+        name: 'Inception',
+        kind: 'phase',
+        path: '01.02',
+        parentPath: '01',
+        order: 2,
+      },
+      {
+        phaseId: 'construction',
+        name: 'Construction',
+        kind: 'phase',
+        path: '02',
+        parentPath: null,
+        order: 2,
+      },
+      {
+        phaseId: 'implementation',
+        name: 'Implementation',
+        kind: 'phase',
+        path: '02.01',
+        parentPath: '02',
+        order: 1,
+      },
+    ];
+
+    expect(isBeforeConstructionPhase('01.02', nestedPhases)).toBe(true);
+    expect(isBeforeConstructionPhase('02.01', nestedPhases)).toBe(false);
+  });
+
   it('does not hide units when phase metadata is unavailable', () => {
     expect(isBeforeConstructionPhase('01', null)).toBe(false);
   });

--- a/frontend/src/components/intent/UnitLaneBoard.test.tsx
+++ b/frontend/src/components/intent/UnitLaneBoard.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { UnitLaneBoardView, isFanoutActive } from './UnitLaneBoard';
+import { UnitLaneBoardView, isBeforeConstructionPhase, isFanoutActive } from './UnitLaneBoard';
 import type { IntentUnit, IntentUnitPlan, UnitState } from '@/services/intents';
+import type { PhaseNode } from '@/services/workflows';
 
 const unit = (slug: string, state: UnitState, over: Partial<IntentUnit> = {}): IntentUnit => ({
   slug,
@@ -38,6 +39,33 @@ const units: IntentUnit[] = [
   unit('billing', 'RUNNING', { dependsOn: ['auth'], startedAt: '2026-01-01T00:00:00Z' }),
   unit('ui', 'BLOCKED', { dependsOn: ['auth'], blockedOn: 'waiting for merge slot' }),
   unit('reporting', 'PENDING', { dependsOn: ['billing', 'ui'] }),
+];
+
+const phases: PhaseNode[] = [
+  {
+    phaseId: 'inception',
+    name: 'Inception',
+    kind: 'phase',
+    path: '01',
+    parentPath: null,
+    order: 1,
+  },
+  {
+    phaseId: 'construction',
+    name: 'Construction',
+    kind: 'phase',
+    path: '02',
+    parentPath: null,
+    order: 2,
+  },
+  {
+    phaseId: 'operation',
+    name: 'Operation',
+    kind: 'phase',
+    path: '03',
+    parentPath: null,
+    order: 3,
+  },
 ];
 
 const renderView = (over: Partial<React.ComponentProps<typeof UnitLaneBoardView>> = {}) =>
@@ -377,5 +405,17 @@ describe('isFanoutActive', () => {
         ],
       }),
     ).toBe(true);
+  });
+});
+
+describe('isBeforeConstructionPhase', () => {
+  it('hides units during inception, then shows them from construction onward', () => {
+    expect(isBeforeConstructionPhase('01', phases)).toBe(true);
+    expect(isBeforeConstructionPhase('02', phases)).toBe(false);
+    expect(isBeforeConstructionPhase('03', phases)).toBe(false);
+  });
+
+  it('does not hide units when phase metadata is unavailable', () => {
+    expect(isBeforeConstructionPhase('01', null)).toBe(false);
   });
 });

--- a/frontend/src/components/intent/UnitLaneBoard.tsx
+++ b/frontend/src/components/intent/UnitLaneBoard.tsx
@@ -630,9 +630,8 @@ export function isBeforeConstructionPhase(
   workflowPhases: PhaseNode[] | null,
 ): boolean {
   if (!currentPhasePath || !workflowPhases) return false;
-  const currentPhase = workflowPhases.find((phase) => phase.path === currentPhasePath);
   const constructionPhase = workflowPhases.find((phase) => phase.phaseId === 'construction');
-  return Boolean(currentPhase && constructionPhase && currentPhase.order < constructionPhase.order);
+  return Boolean(constructionPhase && currentPhasePath < constructionPhase.path);
 }
 
 export function UnitLaneBoard({

--- a/frontend/src/components/intent/UnitLaneBoard.tsx
+++ b/frontend/src/components/intent/UnitLaneBoard.tsx
@@ -15,6 +15,7 @@ import { cn } from '@/lib/utils';
 import { deriveLaneWaits, laneWaitKey, type LaneWaitStatus } from '@/lib/intentRecovery';
 import { useIntent, type IntentStageRow } from '@/contexts/IntentContext';
 import { formatDuration, useTick } from '@/components/intent/stageStyle';
+import type { PhaseNode } from '@/services/workflows';
 import {
   intentsService,
   type IntentFeedbackBatch,
@@ -624,10 +625,29 @@ export function isFanoutActive(detail: { events?: { type: string }[] } | null): 
   return open > 0;
 }
 
+export function isBeforeConstructionPhase(
+  currentPhasePath: string | null,
+  workflowPhases: PhaseNode[] | null,
+): boolean {
+  if (!currentPhasePath || !workflowPhases) return false;
+  const currentPhase = workflowPhases.find((phase) => phase.path === currentPhasePath);
+  const constructionPhase = workflowPhases.find((phase) => phase.phaseId === 'construction');
+  return Boolean(currentPhase && constructionPhase && currentPhase.order < constructionPhase.order);
+}
+
 export function UnitLaneBoard({
   onViewLiveOutput,
 }: { onViewLiveOutput?: (stageInstanceId: string) => void } = {}) {
-  const { detail, stageRows, gates, outputBuffers, ensureOutputs, outputVersion } = useIntent();
+  const {
+    detail,
+    stageRows,
+    gates,
+    outputBuffers,
+    ensureOutputs,
+    outputVersion,
+    currentPhasePath,
+    workflowPhases,
+  } = useIntent();
   const unitPlan = detail?.unitPlan ?? null;
   const units = useMemo(() => detail?.units ?? [], [detail?.units]);
   const unitPrs = useMemo(() => detail?.unitPrs ?? [], [detail?.unitPrs]);
@@ -678,7 +698,13 @@ export function UnitLaneBoard({
   // Keep the complete unit review history visible after fan-in. IntentView
   // still uses isFanoutActive to decide whether the single running-stage card
   // should yield to this board while lanes are live.
-  if (!unitPlan || units.length === 0) return null;
+  if (
+    !unitPlan ||
+    units.length === 0 ||
+    isBeforeConstructionPhase(currentPhasePath, workflowPhases)
+  ) {
+    return null;
+  }
 
   return (
     <>

--- a/frontend/src/components/intent/WorkProductsSection.tsx
+++ b/frontend/src/components/intent/WorkProductsSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import type { IntentDetail, IntentGate } from '@/services/intents';
 import { useIntent } from '@/contexts/IntentContext';
 import { useIntentGraph } from '@/hooks/useIntentGraph';
@@ -6,7 +6,11 @@ import { buildCodeItems } from '@/components/intent/CodeSection';
 import { ProvenanceTree } from '@/components/intent/ProvenanceTree';
 import { HistorySection } from '@/components/intent/HistorySection';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Info } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { isDocumentArtifact } from '@/components/intent/documentHelpers';
+import { getDocumentOrder, setDocumentOrder } from '@/lib/workProductsPreference';
+import { ArrowDownUp, Info } from 'lucide-react';
 
 export interface WorkProductsSectionProps {
   detail: IntentDetail;
@@ -20,6 +24,14 @@ export function WorkProductsSection({ detail, gates }: WorkProductsSectionProps)
 
   const questionGates = useMemo(() => gates.filter((g) => g.kind === 'question'), [gates]);
   const steering = detail.steering ?? [];
+  const [documentOrder, setDocumentOrderState] = useState(getDocumentOrder);
+  const newestFirst = documentOrder === 'newest-first';
+  const documentCount = useMemo(
+    () =>
+      detail.artifacts.filter((artifact) => !artifact.supersededAt && isDocumentArtifact(artifact))
+        .length,
+    [detail.artifacts],
+  );
 
   const influencedArtifactsByQuestion = useMemo(
     () =>
@@ -61,7 +73,39 @@ export function WorkProductsSection({ detail, gates }: WorkProductsSectionProps)
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-sm">Work products</CardTitle>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-sm">Work products</CardTitle>
+          {documentCount > 1 && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    aria-label={
+                      newestFirst
+                        ? 'Sort work products by oldest first'
+                        : 'Sort work products by newest first'
+                    }
+                    onClick={() => {
+                      const nextOrder = newestFirst ? 'oldest-first' : 'newest-first';
+                      setDocumentOrderState(nextOrder);
+                      setDocumentOrder(nextOrder);
+                    }}
+                  >
+                    <ArrowDownUp className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {newestFirst
+                    ? 'Show oldest work products first'
+                    : 'Show newest work products first'}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
         {detail.intent.planWarnings &&
           detail.intent.planWarnings.length > 0 &&
           detail.intent.status !== 'SUCCEEDED' && (
@@ -92,6 +136,7 @@ export function WorkProductsSection({ detail, gates }: WorkProductsSectionProps)
           codeItems={codeItems}
           openArtifactPreview={openArtifactPreview}
           openItemPreview={openItemPreview}
+          documentOrder={documentOrder}
         />
 
         <HistorySection

--- a/frontend/src/components/layout/AppShell.test.tsx
+++ b/frontend/src/components/layout/AppShell.test.tsx
@@ -18,6 +18,10 @@ describe('shouldDefaultOpen', () => {
     expect(shouldDefaultOpen('/space/p1/intent/i1/review/ht-1')).toBe(true);
   });
 
+  it('returns false for new intent creation', () => {
+    expect(shouldDefaultOpen('/space/p1/intent/new')).toBe(false);
+  });
+
   it('returns false for intent graph', () => {
     expect(shouldDefaultOpen('/space/p1/intent/i1/graph')).toBe(false);
   });

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -37,6 +37,8 @@ const NON_WORK_SUFFIXES = ['/graph', '/audit', '/compose', '/observability'];
 export function shouldDefaultOpen(pathname: string): boolean {
   // Sprint routes are always work routes.
   if (/\/sprint\//.test(pathname)) return true;
+  // Intent creation is a focused form, not an active intent workspace.
+  if (/\/intent\/new(?:\/|$)/.test(pathname)) return false;
   // Intent routes: open unless the path ends with a non-work section.
   if (/\/intent\//.test(pathname)) {
     return !NON_WORK_SUFFIXES.some((suffix) => pathname.endsWith(suffix));

--- a/frontend/src/components/layout/IntentActivityPanel.tsx
+++ b/frontend/src/components/layout/IntentActivityPanel.tsx
@@ -512,6 +512,10 @@ function PreviewTab() {
       <ScrollArea className="flex-1">
         <ArtifactPreviewContent
           artifact={artifact}
+          artifacts={detail?.artifacts ?? []}
+          derivedItems={derivedItems}
+          onOpenArtifact={openArtifactPreview}
+          onOpenItem={openItemPreview}
           editing={editing}
           onDoneEditing={() => setEditingId(null)}
           onStartEdit={() => setEditingId(artifact.id)}
@@ -532,6 +536,10 @@ function PreviewTab() {
           <ScrollArea className="min-h-0">
             <ArtifactPreviewContent
               artifact={artifact}
+              artifacts={detail?.artifacts ?? []}
+              derivedItems={derivedItems}
+              onOpenArtifact={openArtifactPreview}
+              onOpenItem={openItemPreview}
               editing={editing}
               onDoneEditing={() => setEditingId(null)}
               onStartEdit={() => setEditingId(artifact.id)}
@@ -548,6 +556,10 @@ function PreviewTab() {
 
 function ArtifactPreviewContent({
   artifact,
+  artifacts,
+  derivedItems,
+  onOpenArtifact,
+  onOpenItem,
   editing,
   onDoneEditing,
   onStartEdit,
@@ -557,6 +569,10 @@ function ArtifactPreviewContent({
   contentClassName,
 }: {
   artifact: IntentArtifact;
+  artifacts: IntentArtifact[];
+  derivedItems: ReturnType<typeof useIntentGraph>['derivedItems'];
+  onOpenArtifact: (artifactId: string) => void;
+  onOpenItem: (itemId: string) => void;
   editing: boolean;
   onDoneEditing: () => void;
   onStartEdit: () => void;
@@ -617,7 +633,13 @@ function ArtifactPreviewContent({
       ) : (
         artifact.content && (
           <div className={cn('prose prose-sm dark:prose-invert max-w-none', contentClassName)}>
-            <ArtifactMarkdown content={artifact.content} />
+            <ArtifactMarkdown
+              content={artifact.content}
+              artifacts={artifacts}
+              derivedItems={derivedItems}
+              onOpenArtifact={onOpenArtifact}
+              onOpenItem={onOpenItem}
+            />
           </div>
         )
       )}

--- a/frontend/src/lib/trackerSourceLabel.test.ts
+++ b/frontend/src/lib/trackerSourceLabel.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { formatTrackerSourceLabel } from './trackerSourceLabel';
+
+describe('formatTrackerSourceLabel', () => {
+  it('uses numbered issue labels for GitHub and GitLab', () => {
+    expect(formatTrackerSourceLabel({ provider: 'github-issues', resourceId: '2' })).toBe(
+      'Issue #2',
+    );
+    expect(formatTrackerSourceLabel({ provider: 'gitlab-issues', resourceId: '3' })).toBe(
+      'Issue #3',
+    );
+  });
+
+  it('keeps Jira resource keys and uses the subtype when available', () => {
+    expect(formatTrackerSourceLabel({ provider: 'jira-cloud', resourceId: 'TAS-01' })).toBe(
+      'TAS-01',
+    );
+    expect(
+      formatTrackerSourceLabel({
+        provider: 'jira-cloud',
+        resourceId: 'TAS-01',
+        entityType: 'Task',
+      }),
+    ).toBe('Task TAS-01');
+  });
+});

--- a/frontend/src/lib/trackerSourceLabel.ts
+++ b/frontend/src/lib/trackerSourceLabel.ts
@@ -1,0 +1,19 @@
+export interface TrackerSourceLabelInput {
+  provider: string;
+  resourceId: string;
+  entityType?: string | null;
+}
+
+// GitHub and GitLab use issue numbers, while Jira keys already identify their
+// project. Jira's subtype is available while selecting a source but is not
+// persisted on intent provenance.
+export function formatTrackerSourceLabel({
+  provider,
+  resourceId,
+  entityType,
+}: TrackerSourceLabelInput): string {
+  if (provider === 'jira-cloud') {
+    return entityType ? `${entityType} ${resourceId}` : resourceId;
+  }
+  return `Issue #${resourceId}`;
+}

--- a/frontend/src/lib/workProductsPreference.test.ts
+++ b/frontend/src/lib/workProductsPreference.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDocumentOrder, setDocumentOrder } from './workProductsPreference';
+
+describe('workProductsPreference', () => {
+  let values: Map<string, string>;
+
+  beforeEach(() => {
+    values = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      clear: () => values.clear(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('defaults to documents in production order', () => {
+    expect(getDocumentOrder()).toBe('oldest-first');
+  });
+
+  it('persists the selected document order', () => {
+    setDocumentOrder('newest-first');
+
+    expect(getDocumentOrder()).toBe('newest-first');
+    expect(localStorage.getItem('aidlc.workProducts.documentOrder.v1')).toBe('newest-first');
+  });
+
+  it('falls back to production order for an invalid stored value', () => {
+    localStorage.setItem('aidlc.workProducts.documentOrder.v1', 'invalid');
+
+    expect(getDocumentOrder()).toBe('oldest-first');
+  });
+});

--- a/frontend/src/lib/workProductsPreference.ts
+++ b/frontend/src/lib/workProductsPreference.ts
@@ -1,0 +1,19 @@
+export type DocumentOrder = 'oldest-first' | 'newest-first';
+
+const STORAGE_KEY = 'aidlc.workProducts.documentOrder.v1';
+
+export function getDocumentOrder(): DocumentOrder {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'newest-first' ? 'newest-first' : 'oldest-first';
+  } catch {
+    return 'oldest-first';
+  }
+}
+
+export function setDocumentOrder(order: DocumentOrder): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, order);
+  } catch {
+    /* best-effort persistence */
+  }
+}

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -425,49 +425,6 @@ describe('IntentView', () => {
     });
   });
 
-  // The review gate is where results are judged, so it is also where the plan
-  // may be reshaped: checked recompose targets ride the approve answer as
-  // { recompose: { skip: [...] } } — applied in place, no relaunch.
-  it('reshapes upcoming stages from the review gate via the approve answer', async () => {
-    get.mockResolvedValue({
-      ...baseDetail({ status: 'WAITING', pendingHumanTaskId: 'eg-validation-si-a-0-run1' }),
-      stages: [
-        { stageInstanceId: 'si-a', stageId: 'stage-a', state: 'WAITING_FOR_HUMAN', phase: 'build' },
-      ],
-      gates: [
-        {
-          humanTaskId: 'eg-validation-si-a-0-run1',
-          stageInstanceId: 'si-a',
-          unitSlug: null,
-          kind: 'validation',
-          status: 'pending',
-          prompt: 'Review stage stage-a.',
-          options: ['approve', 'request-changes'],
-          recomposeTargets: ['nfr-design', 'performance-validation'],
-          questions: null,
-          answer: null,
-          answeredBy: null,
-          answeredAt: null,
-          createdAt: null,
-        },
-      ],
-      sensorRuns: [],
-      artifacts: [],
-    });
-    graph.mockResolvedValue({ nodes: [], edges: [] });
-    answerGate.mockResolvedValue({});
-    renderAt('/space/p1/intent/i1/review/eg-validation-si-a-0-run1');
-    expect(await screen.findByText('Review: stage-a')).toBeInTheDocument();
-    await userEvent.click(screen.getByTestId('review-reshape-toggle'));
-    await userEvent.click(screen.getByTestId('review-reshape-nfr-design').querySelector('input')!);
-    const approve = screen.getByRole('button', { name: /Approve & drop 1 stage/ });
-    await userEvent.click(approve);
-    expect(answerGate).toHaveBeenCalledWith('p1', 'i1', 'eg-validation-si-a-0-run1', {
-      answer: { decision: 'approve', recompose: { skip: ['nfr-design'] } },
-      status: 'approved',
-    });
-  });
-
   // Empty-state consistency: sections with nothing to show are hidden entirely
   // (no "No … recorded" placeholders), and their stat cards are not clickable.
   it('hides empty evidence sections and disables their stat cards on the review gate', async () => {

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -410,7 +410,12 @@ describe('IntentView', () => {
       .find((b) => b.hasAttribute('aria-expanded'))!;
     expect(identified).toHaveAttribute('aria-expanded', 'false');
     await userEvent.click(identified);
-    expect(await screen.findByText(/REQ-1:/)).toBeInTheDocument();
+    expect(await screen.findByText('MFA is required for sign in')).toBeInTheDocument();
+    const itemDiscuss = screen
+      .getAllByTestId('discuss')
+      .find((button) => button.getAttribute('data-entity') === 'item');
+    expect(itemDiscuss).toHaveAttribute('data-entity-id', 'req-1');
+    expect(itemDiscuss).toHaveAttribute('data-entity-title', 'MFA is required for sign in');
     expect(screen.getByRole('button', { name: /Reviewer Agent findings/i })).toHaveAttribute(
       'aria-expanded',
       'false',

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -8,6 +8,7 @@ import { RecomposePanel } from '@/components/intent/RecomposePanel';
 import { DiscussButton } from '@/components/discussion/DiscussButton';
 import { humanizeStageId } from '@/components/intent/documentHelpers';
 import { deriveLaneWaits } from '@/lib/intentRecovery';
+import { formatTrackerSourceLabel } from '@/lib/trackerSourceLabel';
 import { PendingQuestionsTabs } from '@/components/intent/PendingQuestionsTabs';
 import { ScopeBadge } from '@/components/intent/ScopeBadge';
 import { QuorumEditPanel } from '@/components/intent/QuorumEditPanel';
@@ -246,10 +247,10 @@ export default function IntentView() {
                   rel="noopener noreferrer"
                   className="underline hover:no-underline"
                 >
-                  from {intent.source.resourceId}
+                  from {formatTrackerSourceLabel(intent.source)}
                 </a>
               ) : (
-                <>from {intent.source.resourceId}</>
+                <>from {formatTrackerSourceLabel(intent.source)}</>
               )}
             </span>
           )}

--- a/frontend/src/pages/NewIntentPage.tsx
+++ b/frontend/src/pages/NewIntentPage.tsx
@@ -6,6 +6,7 @@ import { trackersService, type TrackerIssue } from '@/services/trackers';
 import type { TrackerBinding } from '@/services/projects';
 import { getGitProviderService } from '@/services/gitProvider';
 import { buildSprintDescription } from '@/lib/buildSprintDescription';
+import { formatTrackerSourceLabel } from '@/lib/trackerSourceLabel';
 import { IntentSourcePicker } from '@/components/IntentSourcePicker';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -21,17 +22,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { AlertCircle, ArrowLeft, ChevronDown, ChevronRight, Loader2, X } from 'lucide-react';
-
-// Human-readable label for the imported-source badge. GitHub/GitLab expose
-// numeric issue numbers, so we render "Issue #2" (their own convention). Jira
-// keys (e.g. TAS-01) already encode the project and never use '#', so we
-// show the provider subtype instead (e.g. "Task TAS-01").
-function sourceLabel(binding: TrackerBinding, issue: TrackerIssue): string {
-  if (binding.provider === 'jira-cloud') {
-    return issue.entityType ? `${issue.entityType} ${issue.resourceId}` : issue.resourceId;
-  }
-  return `Issue #${issue.resourceId}`;
-}
 
 // Step one of intent creation: capture the seed (title/prompt/tracker import/
 // base branch) and create the intent as a DRAFT immediately. Everything else —
@@ -231,10 +221,18 @@ export default function NewIntentPage() {
                     rel="noopener noreferrer"
                     className="hover:underline"
                   >
-                    {sourceLabel(source.binding, source.issue)}
+                    {formatTrackerSourceLabel({
+                      provider: source.binding.provider,
+                      resourceId: source.issue.resourceId,
+                      entityType: source.issue.entityType,
+                    })}
                   </a>
                 ) : (
-                  sourceLabel(source.binding, source.issue)
+                  formatTrackerSourceLabel({
+                    provider: source.binding.provider,
+                    resourceId: source.issue.resourceId,
+                    entityType: source.issue.entityType,
+                  })
                 )}
                 <button
                   type="button"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4567,7 +4567,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Simplified review-stage controls and hid the side panel while creating an intent.
- Improved work products with persistent chronological/reverse ordering across phases, stages, and documents.
- Made review identified items actionable with previews and item-level discussions.
- Improved intent tracker labels and added links between referenced work artifacts in previews.
- Hide generated units while still in inception, only show at construction and after

*Validation:*
- Deployed and tested 
- Git pre commit hook

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
