### PR TITLE
fix: forward proxy settings to Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ cp terraform/environments/dev.tfvars.example terraform/environments/dev.tfvars
 
 `bootstrap.sh` writes `terraform/environments/dev.s3.tfbackend`. Infrastructure deployment reads that backend file and `terraform/environments/dev.tfvars`, regardless of the AWS profile name. On this advanced manual path, nothing rewrites the tfvars; it is yours to edit. The managed installer described above instead keeps its own tfvars synchronized with `install.conf`. For an approval boundary between planning and applying:
 
+Export proxy variables before running `--phase plan`. Terraform resolves
+`TF_VAR_docker_build_args` while planning and stores the value in the saved
+plan, so exporting or changing proxy variables before `--phase apply` has no
+effect.
+
 ```bash
 ./scripts/deploy-terraform.sh dev --phase plan --plan-file /tmp/aidlc-dev.tfplan
 ./scripts/deploy-terraform.sh dev --phase apply --plan-file /tmp/aidlc-dev.tfplan

--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ bash /tmp/aidlc-install.sh install \
   --admin <administrator-email>
 ```
 
+For managed installs or updates behind an HTTP proxy, export the standard proxy
+variables before downloading or running the installer:
+
+```bash
+export HTTP_PROXY=http://proxy.example.com:8080
+export HTTPS_PROXY=http://proxy.example.com:8080
+export NO_PROXY=localhost,127.0.0.1
+
+curl -fsSLo /tmp/aidlc-install.sh \
+  https://raw.githubusercontent.com/aws-samples/sample-collaborative-ai-dlc/main/scripts/install.sh
+bash /tmp/aidlc-install.sh install \
+  --profile <aws-profile> \
+  --region <aws-region> \
+  --environment dev \
+  --admin <administrator-email>
+```
+
+The installer inherits these settings and forwards non-empty `HTTP_PROXY`,
+`HTTPS_PROXY`, `FTP_PROXY`, `NO_PROXY`, and `ALL_PROXY` variables (including
+lowercase variants) to both Docker Buildx builds. Without those variables, no
+proxy build arguments are added. Set `TF_VAR_docker_build_args` to a JSON object
+to override auto-detection. Proxy values are hidden in Terraform CLI output but
+remain in saved plans and Terraform state, so protect both and keep the state
+backend encrypted and access-restricted.
+
 The password prompt is silent. The permanent Cognito password is sent directly to Cognito and is never written to installer configuration. After installation, sign in at the URL reported by `status`:
 
 ```bash
@@ -146,6 +171,9 @@ cp terraform/environments/dev.tfvars.example terraform/environments/dev.tfvars
 ./scripts/deploy-terraform.sh dev --phase plan --plan-file /tmp/aidlc-dev.tfplan
 ./scripts/deploy-terraform.sh dev --phase apply --plan-file /tmp/aidlc-dev.tfplan
 ```
+
+Manual deployments honor the same proxy variables documented for the managed
+installer. You can also define `docker_build_args` in the `.tfvars` file.
 
 Individual variables can be overridden without editing the file, repeating `--var` per variable:
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -58,6 +58,22 @@ key presence, model syntax, and outbound connectivity. It supplies inert AWS
 credentials to DynamoDB Local and does not require an AWS profile, Terraform
 state, Cognito login, or deployed stack.
 
+When running behind an HTTP proxy, export the standard proxy variables before
+starting the E2E:
+
+```bash
+export HTTP_PROXY=http://proxy.example.com:8080
+export HTTPS_PROXY=http://proxy.example.com:8080
+export NO_PROXY=localhost,127.0.0.1
+./scripts/agent-e2e-testing.sh
+```
+
+The harness forwards non-empty standard proxy variables, including lowercase
+variants, to the Buildx build, outbound-connectivity check, and AgentCore test
+containers. No proxy flags or container variables are added when none are set.
+The Docker daemon still needs its own proxy configuration to pull base and test
+images.
+
 ### Run all CLIs
 
 To avoid placing credentials directly in shell history, enter them in a Bash

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -21,6 +21,30 @@ bash /tmp/aidlc-install.sh install \
   --admin <administrator-email>
 ```
 
+For a managed install or update behind an HTTP proxy, export the proxy settings
+before downloading or running the installer:
+
+```bash
+export HTTP_PROXY=http://proxy.example.com:8080
+export HTTPS_PROXY=http://proxy.example.com:8080
+export NO_PROXY=localhost,127.0.0.1
+
+curl -fsSLo /tmp/aidlc-install.sh \
+  https://raw.githubusercontent.com/aws-samples/sample-collaborative-ai-dlc/main/scripts/install.sh
+bash /tmp/aidlc-install.sh install \
+  --profile <aws-profile> \
+  --region <aws-region> \
+  --environment dev \
+  --admin <administrator-email>
+```
+
+The installer passes non-empty standard proxy variables, including lowercase
+variants, to both Docker Buildx builds. It adds no proxy build arguments in a
+non-proxy environment. Set `TF_VAR_docker_build_args` to a JSON object to
+override auto-detection. These values are hidden in Terraform CLI output but
+remain in saved plans and Terraform state, so protect both and keep the backend
+encrypted and access-restricted.
+
 The password prompt is silent and the permanent password is never stored. The installer keeps immutable tagged checkouts under the XDG data directory, keeps Terraform configuration under the XDG config directory, and only changes `current` after infrastructure, administrator setup, and frontend deployment all succeed.
 
 Use the same script to inspect or update the deployment:
@@ -267,6 +291,9 @@ To review a saved plan before applying:
 ```
 
 The plan is rejected if it would destroy a Cognito user pool, Neptune cluster, S3 bucket, or DynamoDB table. The check runs in both phases, so a saved plan is re-inspected before it is applied.
+
+Manual deployments honor the same proxy variables documented for the managed
+installer. You can also define `docker_build_args` in the `.tfvars` file.
 
 The deployment takes 15-30 minutes. Neptune DB cluster creation takes the longest.
 

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -285,6 +285,11 @@ Unlike the managed installer, nothing here rewrites `dev.tfvars` for you — it 
 
 To review a saved plan before applying:
 
+Export proxy variables before running `--phase plan`. Terraform resolves
+`TF_VAR_docker_build_args` while planning and stores the value in the saved
+plan, so exporting or changing proxy variables before `--phase apply` has no
+effect.
+
 ```bash
 ./scripts/deploy-terraform.sh dev --phase plan --plan-file /tmp/aidlc-dev.tfplan
 ./scripts/deploy-terraform.sh dev --phase apply --plan-file /tmp/aidlc-dev.tfplan

--- a/scripts/agent-e2e-testing.sh
+++ b/scripts/agent-e2e-testing.sh
@@ -25,6 +25,7 @@ OUTPUT_DIR="${E2E_OUTPUT_DIR:-$ROOT/test/e2e/artifacts/agent-output/$RUN_ID}"
 SECRET_FILE=""
 OVERALL_FAIL=0
 IMAGE=""
+DOCKER_PROXY_VARIABLES="HTTP_PROXY HTTPS_PROXY FTP_PROXY NO_PROXY ALL_PROXY http_proxy https_proxy ftp_proxy no_proxy all_proxy"
 
 declare -a SELECTED_CLIS=()
 SELECTED_CLI_COUNT=0
@@ -101,6 +102,9 @@ set_result() {
 }
 
 preflight() {
+  local proxy_name
+  local -a outbound_check=(docker run --rm --platform linux/arm64)
+
   log "Preflight"
   command -v docker >/dev/null 2>&1 || fail "docker is required"
   command -v node >/dev/null 2>&1 || fail "node is required"
@@ -121,7 +125,12 @@ preflight() {
 
   docker run --rm --platform linux/arm64 alpine:3.20 true >/dev/null 2>&1 ||
     fail "Docker cannot execute linux/arm64 containers"
-  docker run --rm --platform linux/arm64 curlimages/curl:8.12.1 \
+
+  for proxy_name in $DOCKER_PROXY_VARIABLES; do
+    [ -n "${!proxy_name:-}" ] && outbound_check+=(--env "$proxy_name")
+  done
+  outbound_check+=(curlimages/curl:8.12.1)
+  "${outbound_check[@]}" \
     -fsS --connect-timeout 10 --max-time 20 -o /dev/null https://aws.amazon.com/ ||
     fail "containers do not have outbound HTTPS access"
   printf 'Preflight passed for %s\n' "${SELECTED_CLIS[*]}"
@@ -129,6 +138,9 @@ preflight() {
 }
 
 build_image() {
+  local proxy_name
+  local -a build_command=(docker buildx build)
+
   log "AgentCore image"
   if [ -n "${AGENTCORE_IMAGE:-}" ]; then
     IMAGE="$AGENTCORE_IMAGE"
@@ -138,12 +150,17 @@ build_image() {
     return
   fi
   IMAGE="aidlc-agentcore-e2e:$RUN_ID"
-  docker buildx build \
-    --platform linux/arm64 \
-    --load \
-    --tag "$IMAGE" \
-    --file "$ROOT/lambda/agentcore/Dockerfile" \
+  for proxy_name in $DOCKER_PROXY_VARIABLES; do
+    [ -n "${!proxy_name:-}" ] && build_command+=(--build-arg "$proxy_name")
+  done
+  build_command+=(
+    --platform linux/arm64
+    --load
+    --tag "$IMAGE"
+    --file "$ROOT/lambda/agentcore/Dockerfile"
     "$ROOT/lambda"
+  )
+  "${build_command[@]}"
 }
 
 write_secret_file() {
@@ -157,6 +174,8 @@ write_secret_file() {
 }
 
 container_args() {
+  local proxy_name
+
   printf '%s\n' \
     --platform linux/arm64 \
     --label "$LABEL" \
@@ -177,6 +196,9 @@ container_args() {
     --env "V2_QUESTION_PARK_GRACE_MS=300" \
     --env "E2E_SECRET_FILE=/run/secrets/aidlc-e2e.env" \
     --volume "$SECRET_FILE:/run/secrets/aidlc-e2e.env:ro"
+  for proxy_name in $DOCKER_PROXY_VARIABLES; do
+    [ -n "${!proxy_name:-}" ] && printf '%s\n' --env "$proxy_name"
+  done
 }
 
 start_services() {

--- a/scripts/deploy-terraform.sh
+++ b/scripts/deploy-terraform.sh
@@ -64,6 +64,21 @@ if [[ "$PLAN_FILE" != /* ]]; then
     PLAN_FILE="$(pwd)/$PLAN_FILE"
 fi
 
+configure_docker_build_args() {
+    if [[ -n "${TF_VAR_docker_build_args+x}" ]]; then
+        return
+    fi
+
+    local detected_build_args
+    detected_build_args="$(node "$SCRIPT_DIR/docker-proxy-build-args.mjs")"
+    if [[ "$detected_build_args" == "{}" ]]; then
+        return
+    fi
+
+    export TF_VAR_docker_build_args="$detected_build_args"
+    echo "Forwarding detected proxy settings to Docker image builds."
+}
+
 tfvar_string() {
     local name="$1"
     local file="$2"
@@ -201,6 +216,8 @@ fi
 echo "Deploying environment: $ENVIRONMENT ($PHASE)"
 
 if [[ "$PHASE" == "plan" || "$PHASE" == "all" ]]; then
+    configure_docker_build_args
+
     if [[ "${AIDLC_SKIP_NPM_CI:-0}" != "1" ]]; then
         echo "Installing root npm dependencies..."
         (cd "$SCRIPT_DIR/.." && npm ci)

--- a/scripts/docker-proxy-build-args.mjs
+++ b/scripts/docker-proxy-build-args.mjs
@@ -1,0 +1,20 @@
+const proxyVariableNames = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'FTP_PROXY',
+  'NO_PROXY',
+  'ALL_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'ftp_proxy',
+  'no_proxy',
+  'all_proxy',
+];
+
+const buildArgs = Object.fromEntries(
+  proxyVariableNames
+    .filter((name) => typeof process.env[name] === 'string' && process.env[name].length > 0)
+    .map((name) => [name, process.env[name]]),
+);
+
+process.stdout.write(JSON.stringify(buildArgs));

--- a/scripts/test/agent-e2e-proxy.test.mjs
+++ b/scripts/test/agent-e2e-proxy.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const e2eScript = join(root, 'scripts/agent-e2e-testing.sh');
+const proxyVariableNames = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'FTP_PROXY',
+  'NO_PROXY',
+  'ALL_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'ftp_proxy',
+  'no_proxy',
+  'all_proxy',
+];
+
+const runHarness = (proxyEnv) => {
+  const fixture = mkdtempSync(join(tmpdir(), 'aidlc-e2e-proxy-'));
+  const bin = join(fixture, 'bin');
+  const dockerLog = join(fixture, 'docker.log');
+  mkdirSync(bin);
+
+  const docker = join(bin, 'docker');
+  writeFileSync(
+    docker,
+    `#!/usr/bin/env bash
+first="\${1:-}"
+second="\${2:-}"
+{
+  printf '%s' "$first"
+  shift || true
+  for arg in "$@"; do printf '\\t%s' "$arg"; done
+  printf '\\n'
+} >> "$DOCKER_LOG"
+if [[ "$first" == "logs" && "$second" == *"-gremlin-"* ]]; then
+  printf 'Channel started at port 8182\\n'
+fi
+`,
+  );
+  chmodSync(docker, 0o755);
+
+  const node = join(bin, 'node');
+  writeFileSync(node, '#!/usr/bin/env bash\nexit 0\n');
+  chmodSync(node, 0o755);
+
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    DOCKER_LOG: dockerLog,
+    E2E_CLIS: 'kiro',
+    E2E_OUTPUT_DIR: join(fixture, 'output'),
+    KIRO_API_KEY: 'test-key',
+    TMPDIR: fixture,
+  };
+  for (const name of proxyVariableNames) delete env[name];
+  Object.assign(env, proxyEnv);
+
+  const result = spawnSync('bash', [e2eScript], {
+    cwd: root,
+    encoding: 'utf8',
+    env,
+    timeout: 30_000,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return readFileSync(dockerLog, 'utf8');
+};
+
+test('E2E harness forwards proxy names without putting values in Docker arguments', () => {
+  const log = runHarness({
+    HTTP_PROXY: 'http://proxy.example.com:8080',
+    no_proxy: 'localhost,127.0.0.1',
+  });
+
+  assert.match(log, /^buildx\tbuild\t--build-arg\tHTTP_PROXY\t--build-arg\tno_proxy\t/m);
+  assert.match(log, /\t--env\tHTTP_PROXY(?:\t|\n)/);
+  assert.match(log, /\t--env\tno_proxy(?:\t|\n)/);
+  assert.doesNotMatch(log, /proxy\.example\.com|localhost,127\.0\.0\.1/);
+});
+
+test('E2E harness adds no proxy arguments without proxy variables', () => {
+  const log = runHarness({});
+  assert.doesNotMatch(log, /--build-arg/);
+  assert.doesNotMatch(log, /\t--env\t(?:HTTP_PROXY|no_proxy)(?:\t|\n)/);
+});

--- a/scripts/test/docker-proxy-build-args.test.mjs
+++ b/scripts/test/docker-proxy-build-args.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = join(dirname(fileURLToPath(import.meta.url)), '..', 'docker-proxy-build-args.mjs');
+
+const collectBuildArgs = (env) =>
+  JSON.parse(execFileSync(process.execPath, [script], { encoding: 'utf8', env }));
+
+test('returns an empty map when no proxy variables are set', () => {
+  assert.deepEqual(collectBuildArgs({}), {});
+});
+
+test('forwards non-empty uppercase and lowercase proxy variables', () => {
+  assert.deepEqual(
+    collectBuildArgs({
+      HTTP_PROXY: 'http://proxy.example.com:8080',
+      HTTPS_PROXY: '',
+      NO_PROXY: 'localhost,127.0.0.1',
+      http_proxy: 'http://lower-proxy.example.com:8080',
+      npm_config_proxy: 'http://ignored.example.com:8080',
+    }),
+    {
+      HTTP_PROXY: 'http://proxy.example.com:8080',
+      NO_PROXY: 'localhost,127.0.0.1',
+      http_proxy: 'http://lower-proxy.example.com:8080',
+    },
+  );
+});
+
+test('emits JSON-safe proxy values without modification', () => {
+  const proxy = 'http://proxy.example.com/a"b\\c';
+  assert.deepEqual(collectBuildArgs({ ALL_PROXY: proxy }), { ALL_PROXY: proxy });
+});

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -421,6 +421,7 @@ module "yjs_server" {
   project_name                  = var.project_name
   environment                   = var.environment
   aws_region                    = var.aws_region
+  docker_build_args             = var.docker_build_args
   vpc_id                        = module.networking.vpc_id
   private_subnet_ids            = module.networking.private_subnet_ids
   cognito_user_pool_id          = module.auth.user_pool_id
@@ -442,6 +443,7 @@ module "agentcore" {
   project_name                = var.project_name
   environment                 = var.environment
   aws_region                  = var.aws_region
+  docker_build_args           = var.docker_build_args
   neptune_endpoint            = module.neptune.cluster_endpoint
   neptune_cluster_resource_id = module.neptune.cluster_resource_id
   artifacts_bucket_name       = module.s3.artifacts_bucket_name

--- a/terraform/modules/compute/agentcore/main.tf
+++ b/terraform/modules/compute/agentcore/main.tf
@@ -166,8 +166,9 @@ module "agentcore_docker_build" {
   source_path      = local.agentcore_source_path
   docker_file_path = "${local.agentcore_source_path}/agentcore/Dockerfile"
   # AgentCore Runtime runs arm64 only.
-  platform = "linux/arm64"
-  builder  = "default"
+  platform   = "linux/arm64"
+  builder    = "default"
+  build_args = var.docker_build_args
 
   triggers = {
     dir_sha = local.agentcore_files_sha

--- a/terraform/modules/compute/agentcore/variables.tf
+++ b/terraform/modules/compute/agentcore/variables.tf
@@ -13,6 +13,13 @@ variable "aws_region" {
   type        = string
 }
 
+variable "docker_build_args" {
+  description = "Optional arguments passed to the AgentCore Docker build"
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
 variable "neptune_endpoint" {
   description = "Neptune cluster endpoint"
   type        = string

--- a/terraform/modules/realtime/yjs-server/main.tf
+++ b/terraform/modules/realtime/yjs-server/main.tf
@@ -94,7 +94,8 @@ module "yjs_docker_build" {
   platform         = "linux/amd64"
   # BuildKit session path instead of the provider's legacy tar.gz streaming —
   # see the agents module for rationale.
-  builder = "default"
+  builder    = "default"
+  build_args = var.docker_build_args
 
   triggers = {
     dir_sha = local.yjs_files_sha

--- a/terraform/modules/realtime/yjs-server/variables.tf
+++ b/terraform/modules/realtime/yjs-server/variables.tf
@@ -13,6 +13,13 @@ variable "aws_region" {
   type        = string
 }
 
+variable "docker_build_args" {
+  description = "Optional arguments passed to the Yjs server Docker build"
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
 variable "vpc_id" {
   description = "VPC ID"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,6 +34,13 @@ variable "aidlc_repo_ref" {
   default     = "83ed7a812c4024904f2c5e4d744e28077e0a5acd"
 }
 
+variable "docker_build_args" {
+  description = "Optional arguments for local Docker image builds, such as HTTP_PROXY, HTTPS_PROXY, and NO_PROXY. Sensitive values are hidden in CLI output but remain stored in Terraform state."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}
+
 # ---------------------------------------------------------------------------
 # Custom domain (optional)
 #
@@ -85,4 +92,3 @@ variable "route53_zone_id" {
   type        = string
   default     = ""
 }
-


### PR DESCRIPTION
## Summary

- detect non-empty standard proxy variables inherited through the central `scripts/install.sh` workflow and pass them as sensitive Terraform Docker build arguments
- forward build arguments to both AgentCore and Yjs Buildx builds while keeping the default non-proxy path unchanged and allowing explicit `TF_VAR_docker_build_args` overrides
- make the local AgentCore E2E harness proxy-aware and document managed-install, manual-deployment, state, and E2E behavior
- add focused coverage for proxy and non-proxy environments without exposing proxy values in Docker command arguments

## Testing

- `node --test scripts/test/docker-proxy-build-args.test.mjs scripts/test/agent-e2e-proxy.test.mjs` (5 passed)
- live `E2E_CLIS=claude,opencode ./scripts/agent-e2e-testing.sh` (Claude passed, OpenCode passed; Kiro not selected because no key was available)
- Terraform validation using a backend-free copy
- `terraform fmt -check -recursive terraform`
- `bash -n scripts/deploy-terraform.sh scripts/agent-e2e-testing.sh scripts/install.sh`
- `npm run lint`
- `npm run format:check`
- `npm run secretlint`
- `git diff --check`

`npm run test:release` has one unrelated existing failure: the release test expects a `TBD` changelog date while the current changelog entry is dated. The pre-commit npm audit also reports existing dependency advisories; staged lint, format, and secret checks passed.

Fixes #347