### PR TITLE
fix(deps): resolve Dependabot alerts #149 (dompurify) and #150 (@hono/node-server)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5396,9 +5396,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1564,10 +1564,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
     "@aws/durable-execution-sdk-js-testing": {
       "@aws/durable-execution-sdk-js": "^2.0.0"
     },
+    "@modelcontextprotocol/sdk": {
+      "@hono/node-server": "^2.0.5"
+    },
     "archiver-utils": {
       "glob": "^13.0.6"
     },


### PR DESCRIPTION
Fixes #351

Resolves the two remaining open Dependabot alerts:

- **Alert 150** (medium): `@hono/node-server` < 2.0.5 — path traversal in `serve-static` on Windows ([GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9)). Transitive via `@modelcontextprotocol/sdk` in `lambda/agentcore`, which pins `^1.19.9` — no in-range 1.x fix exists, so this adds an npm `overrides` entry forcing `^2.0.5` (resolves to 2.0.11).
- **Alert 149** (low): `dompurify` <= 3.4.11 — `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements`. Transitive via `mermaid` in `frontend/`; in-range bump to 3.4.12.

## Why the @hono/node-server major bump is safe

- The MCP SDK only imports `getRequestListener` (in `server/streamableHttp.js`), whose export and signature are unchanged in 2.x.
- The vulnerable `serve-static` module is never imported by the SDK.
- 2.x requires Node >= 20; agentcore runs on Node 24.

## Verification

- `npm run audit:prod` and `npm run audit:prod:frontend`: 0 vulnerabilities
- Full test suite passes via pre-commit hook (119 files, 2346 tests)
- Smoke-tested `@modelcontextprotocol/sdk/server/streamableHttp.js` import