### PR TITLE
feat: show initial prompt on intent overview

### DIFF
--- a/docs/using-the-platform/intent-observability.md
+++ b/docs/using-the-platform/intent-observability.md
@@ -31,6 +31,7 @@ The default intent view is the **workbench** — the working surface for humans:
 
 The **Observability** button opens the intent's execution dashboard:
 
+- **Initial prompt** — the final user-authored draft that started the intent, preserved read-only with a copy action.
 - **Usage & activity** — aggregated token usage, a context-window gauge, and cost for the whole intent. Costs are computed per stage from live model pricing; Kiro runs show estimated cost derived from credits.
 - **Execution progress** — the stage pipeline in three switchable views (your choice is remembered):
   - **Diagram** — a phase-grouped flow diagram with per-phase progress.

--- a/frontend/src/pages/IntentObservabilityPage.test.tsx
+++ b/frontend/src/pages/IntentObservabilityPage.test.tsx
@@ -21,6 +21,7 @@ const deleteIntent = vi.fn();
 const graph = vi.fn();
 const compiled = vi.fn();
 const workflowGet = vi.fn();
+const writeText = vi.fn();
 vi.mock('@/services/intents', () => ({
   intentsService: {
     get: (...a: unknown[]) => get(...a),
@@ -100,6 +101,11 @@ const renderPage = () =>
 beforeEach(() => {
   vi.clearAllMocks();
   clearIntentCache();
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  writeText.mockResolvedValue(undefined);
   graph.mockResolvedValue({ nodes: [], edges: [] });
   compiled.mockResolvedValue({ graph: { nodes: [], edges: [] } });
   workflowGet.mockResolvedValue({ id: 'w', name: 'wf', version: 1, stages: [] });
@@ -190,6 +196,34 @@ describe('IntentObservabilityPage — Header simplification', () => {
     expect(screen.queryByText(/^Space:/)).not.toBeInTheDocument();
     expect(screen.getByText('Test Intent')).toBeInTheDocument();
     expect(screen.getByLabelText('Back to space')).toBeInTheDocument();
+  });
+});
+
+describe('IntentObservabilityPage — Initial prompt', () => {
+  it('shows the final user draft and copies it verbatim', async () => {
+    const prompt = 'Add account recovery.\n\nKeep existing sessions active.';
+    get.mockResolvedValue(baseDetail({ prompt }));
+    renderPage();
+
+    expect(
+      await screen.findByText(
+        (_, element) =>
+          element?.classList.contains('select-text') === true && element.textContent === prompt,
+      ),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy initial prompt' }));
+
+    expect(writeText).toHaveBeenCalledWith(prompt);
+    expect(screen.getByRole('button', { name: 'Initial prompt copied' })).toBeInTheDocument();
+  });
+
+  it('shows an empty state and disables copy when no prompt was recorded', async () => {
+    get.mockResolvedValue(baseDetail({ prompt: null }));
+    renderPage();
+
+    expect(await screen.findByText('No initial prompt recorded')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy initial prompt' })).toBeDisabled();
   });
 });
 

--- a/frontend/src/pages/IntentObservabilityPage.tsx
+++ b/frontend/src/pages/IntentObservabilityPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useIntent, stageRowKey, type IntentStageRow } from '@/contexts/IntentContext';
 import type { StageState } from '@/services/intents';
@@ -32,7 +32,17 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { ArrowLeft, Loader2, MoreHorizontal, ScrollText, Trash2, X, XCircle } from 'lucide-react';
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  Loader2,
+  MoreHorizontal,
+  ScrollText,
+  Trash2,
+  X,
+  XCircle,
+} from 'lucide-react';
 
 type ObsView = 'diagram' | 'graph' | 'list';
 const VALID_VIEWS: ReadonlySet<ObsView> = new Set(['diagram', 'graph', 'list']);
@@ -134,6 +144,24 @@ export default function IntentObservabilityPage() {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [promptCopied, setPromptCopied] = useState(false);
+
+  useEffect(() => {
+    if (!promptCopied) return;
+    const timeout = window.setTimeout(() => setPromptCopied(false), 2_000);
+    return () => window.clearTimeout(timeout);
+  }, [promptCopied]);
+
+  const handleCopyPrompt = async () => {
+    const prompt = detail?.intent.prompt;
+    if (!prompt?.trim()) return;
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setPromptCopied(true);
+    } catch {
+      setActionError('Failed to copy initial prompt');
+    }
+  };
 
   const handleCancel = async () => {
     const message =
@@ -396,6 +424,40 @@ export default function IntentObservabilityPage() {
             {actionError}
           </div>
         )}
+
+        {/* ── INITIAL USER PROMPT ───────────────────────────────────── */}
+        <Card>
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between gap-3">
+              <CardTitle className="text-sm">Initial prompt</CardTitle>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                aria-label={promptCopied ? 'Initial prompt copied' : 'Copy initial prompt'}
+                title={promptCopied ? 'Copied' : 'Copy initial prompt'}
+                disabled={!intent.prompt?.trim()}
+                onClick={() => void handleCopyPrompt()}
+              >
+                {promptCopied ? (
+                  <Check className="h-3.5 w-3.5 text-agent-success" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" />
+                )}
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {intent.prompt?.trim() ? (
+              <div className="max-h-72 overflow-y-auto whitespace-pre-wrap break-words text-sm leading-6 text-foreground select-text">
+                {intent.prompt}
+              </div>
+            ) : (
+              <span className="text-xs text-muted-foreground">No initial prompt recorded</span>
+            )}
+          </CardContent>
+        </Card>
 
         {/* ── USAGE & COST + RUNNING AGENTS ──────────────────────────── */}
         <Card>

--- a/frontend/src/pages/IntentObservabilityPage.tsx
+++ b/frontend/src/pages/IntentObservabilityPage.tsx
@@ -155,6 +155,7 @@ export default function IntentObservabilityPage() {
   const handleCopyPrompt = async () => {
     const prompt = detail?.intent.prompt;
     if (!prompt?.trim()) return;
+    setActionError(null);
     try {
       await navigator.clipboard.writeText(prompt);
       setPromptCopied(true);


### PR DESCRIPTION
## Summary

- show the final user-authored prompt at the top of the intent Overview
- preserve multiline content and support selection, scrolling, and exact clipboard copying with success feedback
- handle intents without a recorded prompt and document the new Overview section

## Testing

- `npm --prefix frontend test` (409 tests passed)
- `npm --prefix frontend run build`
- `npm --prefix frontend run lint` (passes with pre-existing warnings)

Closes #354