### PR TITLE
fix(git-engine): never run the cloned repo's git hooks (core.hooksPath)

### DIFF
--- a/lambda/agentcore/git-engine.js
+++ b/lambda/agentcore/git-engine.js
@@ -128,6 +128,34 @@ const sanitizedGitEnv = (overrides = {}) => {
 // argv-based git runner: captures stdout/stderr, resolves { exitCode, stdout,
 // stderr }, never rejects (spawn errors → exitCode null). Mirrors
 // cli/spawn.js#captureChild but is git-scoped and dependency-free.
+// Engine-owned git invocations must NEVER execute the cloned repository's hooks.
+//
+// Two reasons, both observed in production:
+//
+//  1. CORRECTNESS. A repo using husky + lint-staged installs hooks that shell
+//     out to npm/npx. The runtime deliberately never installs the checkout's
+//     dependencies (see the inode-budget notes in workspace.js), so the hook
+//     exits non-zero and the commit fails — losing a stage's completed work for
+//     a reason unrelated to that work. Seen as a `git_commit_failed` whose only
+//     detail was npm's "Unknown project config" warnings.
+//
+//  2. SECURITY. Repo hooks are arbitrary, untrusted code. They would run inside
+//     the agent runtime, and pushes carry a short-lived credential in the
+//     environment — a `pre-push` hook could read it, abort the push, and surface
+//     the value in the error detail. Running customer hooks is an attack
+//     surface, not a safeguard.
+//
+// `--no-verify` is NOT sufficient: it covers `pre-commit` and `commit-msg` only,
+// leaving `prepare-commit-msg` able to abort a commit and `pre-push` able to run
+// on every push. Setting `core.hooksPath` to a directory with no hooks disables
+// EVERY hook for the invocation, uniformly, and without mutating the
+// repository's own configuration (unlike `git config core.hooksPath`).
+//
+// Applied here, in the single choke point every engine git call passes through,
+// so operations added later inherit the policy automatically.
+export const NO_HOOKS_PATH = '/dev/null';
+const hooksDisabledArgs = () => ['-c', `core.hooksPath=${NO_HOOKS_PATH}`];
+
 export const runGit = (args, { cwd, env = {}, spawnFn = spawn } = {}) =>
   new Promise((resolve) => {
     let settled = false;
@@ -137,7 +165,7 @@ export const runGit = (args, { cwd, env = {}, spawnFn = spawn } = {}) =>
         resolve(v);
       }
     };
-    const child = spawnFn('git', args, {
+    const child = spawnFn('git', [...hooksDisabledArgs(), ...args], {
       cwd,
       shell: false,
       env: sanitizedGitEnv(env),

--- a/lambda/agentcore/test/git-engine.test.js
+++ b/lambda/agentcore/test/git-engine.test.js
@@ -155,6 +155,102 @@ describe('commitAll', () => {
   });
 });
 
+// The engine must never execute the CLONED REPO's hooks. Two reasons:
+// correctness (hooks that shell out to npm cannot work — the runtime never
+// installs the checkout's dependencies, so a stage lost completed work to a
+// husky/lint-staged pre-commit) and security (hooks are arbitrary untrusted code
+// and pushes carry a credential in the environment).
+//
+// `--no-verify` is insufficient: it covers pre-commit and commit-msg only. These
+// cases pin the hooks via `core.hooksPath` — the strongest form, because it
+// proves the engine's own `-c core.hooksPath` overrides a hooksPath the
+// repository configured for itself, not just the default `.git/hooks`.
+describe('engine git ignores repository hooks', () => {
+  // Install a hook that records that it ran and then fails the operation.
+  const installHook = async (work, name, { viaConfig = false, body } = {}) => {
+    const dir = viaConfig ? path.join(work, '.custom-hooks') : path.join(work, '.git', 'hooks');
+    await mkdir(dir, { recursive: true });
+    const marker = path.join(work, `${name}-ran.txt`);
+    await writeFile(
+      path.join(dir, name),
+      body ?? `#!/bin/sh\necho ran > "${marker}"\necho "${name} rejected" >&2\nexit 1\n`,
+      { mode: 0o755 },
+    );
+    if (viaConfig) await git(['config', 'core.hooksPath', dir], work);
+    return marker;
+  };
+  const ran = async (marker) => {
+    try {
+      await readFile(marker, 'utf8');
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  for (const hook of ['pre-commit', 'commit-msg', 'prepare-commit-msg']) {
+    it(`commits with a failing ${hook} hook configured via core.hooksPath`, async () => {
+      const { work } = await initRemoteAndClone();
+      const marker = await installHook(work, hook, { viaConfig: true });
+      await writeFile(path.join(work, 'agent-work.txt'), 'artifacts the agent produced\n');
+
+      const res = await commitAll({ dir: work, message: 'aidlc(functional-design): e1' });
+
+      expect(res.committed).toBe(true);
+      expect(res.sha).toMatch(/^[0-9a-f]{40}$/);
+      expect(await ran(marker)).toBe(false);
+      const show = await git(['show', '--stat', '--format='], work);
+      expect(show.stdout).toContain('agent-work.txt');
+    });
+  }
+
+  it('does not leave a dirty tree when prepare-commit-msg would abort', async () => {
+    // prepare-commit-msg is the gap --no-verify left open: it can abort a commit,
+    // which previously returned commit_failed with the work still uncommitted.
+    const { work } = await initRemoteAndClone();
+    await installHook(work, 'prepare-commit-msg', { viaConfig: true });
+    await writeFile(path.join(work, 'agent-work.txt'), 'work\n');
+
+    const res = await commitAll({ dir: work, message: 'aidlc(x): e1' });
+
+    expect(res.committed).toBe(true);
+    expect(res.dirty).toBeFalsy();
+    const status = await git(['status', '--porcelain'], work);
+    expect(status.stdout.trim()).toBe('');
+  });
+
+  it('does not run pre-push, so a hook cannot read the push credential', async () => {
+    // A pre-push hook runs with the push environment, which carries
+    // AIDLC_GIT_PASSWORD. If it executed it could exfiltrate the token, abort the
+    // push, and surface the value in the returned error detail.
+    const { work, remote } = await initRemoteAndClone();
+    const leak = path.join(work, 'leaked-credential.txt');
+    await installHook(work, 'pre-push', {
+      viaConfig: true,
+      body: `#!/bin/sh\nprintf '%s' "$AIDLC_GIT_PASSWORD" > "${leak}"\necho "pre-push rejected" >&2\nexit 1\n`,
+    });
+    await writeFile(path.join(work, 'agent-work.txt'), 'work\n');
+    await commitAll({ dir: work, message: 'aidlc(x): e1' });
+
+    const res = await pushBranch({
+      dir: work,
+      repo: 'o/r',
+      branch: 'main',
+      urls: { clean: remote, tokenized: remote },
+      withGitCredential: async (_o, fn) =>
+        fn({ AIDLC_GIT_PASSWORD: 'super-secret-token', GIT_TERMINAL_PROMPT: '0' }),
+      log: () => {},
+    });
+
+    expect(res.pushed).toBe(true);
+    expect(await ran(leak)).toBe(false);
+    expect(JSON.stringify(res)).not.toContain('super-secret-token');
+    // The commit really reached the remote.
+    const remoteHead = await git(['rev-parse', 'refs/heads/main'], remote);
+    expect(remoteHead.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
+  });
+});
+
 describe('seedInitialCommit', () => {
   it('roots history on the BASE branch and forks the intent branch off it (empty repo)', async () => {
     const { work } = await initRemoteAndClone({ withInitialCommit: false });


### PR DESCRIPTION
## Problem

A stage that had **already produced all its artifacts** died with `git_commit_failed`, losing the work. The only detail captured was npm's warnings:

```
git_commit_failed: <org>/<repo>: commit_failed —
  npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
  npm warn Unknown project config "auto-install-peers".
Unit walking-skeleton failed at functional-design: git_commit_failed
```

The cause is the **user repo's own pre-commit hook**. A project using husky + lint-staged installs hooks that shell out to `npm`/`npx`. The AgentCore runtime deliberately never installs the checkout's dependencies (see the inode-budget comments in `workspace.js` and `run-stage.js`), so the hook exits non-zero and the stage's completed work is lost for a reason that has nothing to do with that work.

Observed on a real deployment: the agent successfully created `Business Rules`, `Domain Entities`, and `Frontend Components`, then lost the whole stage on the commit.

## Change

Set `core.hooksPath` to a hook-free path for every engine-owned git invocation, applied in `runGit` — the single choke point all of them pass through, so operations added later inherit the policy automatically.

Two reasons the engine must not execute the cloned repo's hooks:

- **Correctness** — the failure above. Hooks that assume an installed dependency tree cannot work in this runtime.
- **Security** — repo hooks are arbitrary untrusted code running inside the agent runtime, and pushes carry a short-lived credential in the environment. A `pre-push` hook could read `AIDLC_GIT_PASSWORD`, abort the push, and surface the value in the returned error detail.

`--no-verify` would **not** have been sufficient, and an earlier revision of this PR that used it left the same class of bug open: it covers `pre-commit` and `commit-msg` only, so `prepare-commit-msg` can still abort a commit and `pre-push` runs on every push. `-c core.hooksPath=...` disables every hook for the invocation without mutating the repository's own configuration.

## Testing

Tests drive **real git** in throwaway repos and pin the hooks via `core.hooksPath` rather than `.git/hooks`. That is the stronger assertion: it proves the engine's own `-c core.hooksPath` overrides a hooksPath the *repository configured for itself*, not merely the default location.

| Case | Asserted |
|---|---|
| Failing `pre-commit` | commit succeeds, hook never ran, work committed |
| Failing `commit-msg` | commit succeeds, hook never ran |
| Failing `prepare-commit-msg` | commit succeeds, hook never ran, **tree left clean** |
| Credential-bearing `pre-push` | push succeeds, hook never ran, token appears nowhere in the result, commit reached the remote |

Each hook writes a marker file, so "never ran" is asserted by the marker's absence rather than inferred. **All five cases fail without the change** — verified by reverting the one-line `runGit` edit and re-running.

- `git-engine.test.js`, `lane.test.js`, `resolve-conflict.test.js`, `run-stage.test.js`: **222 passed**
- `oxlint` clean, `oxfmt --check` clean
- Verified live on a dev deployment: the previously failing stage now reports `Engine committed + pushed work for code-generation [unit walking-skeleton]`, and the execution ran to completion through ~30 stages and opened its PR with zero git failures.

## Follow-up worth its own issue

The platform does **no secret scanning of agent-authored content**. This change correctly stops depending on customer hooks, but it does not close that gap — the runtime should scan what its agents commit rather than relying on a hook that may not exist, may not run, or may itself be hostile.

## Notes

Rebased onto latest `main` (`b9ab0b6`).

I confirm the licensing of this contribution under the repository's MIT-0 license.
