### PR TITLE
fix(sensors): stop reporting harness failures as code-quality FAILs

### DIFF
--- a/lambda/agentcore/commands/run-stage.js
+++ b/lambda/agentcore/commands/run-stage.js
@@ -516,6 +516,7 @@ const runStageSensors = async ({
   openGraph,
   loadBlockScript,
   workspaceDir,
+  changedFiles = null,
   env,
   spawnFn,
   store,
@@ -541,6 +542,7 @@ const runStageSensors = async ({
       executionId,
       loadBlockScript,
       workspaceDir,
+      changedFiles,
       env,
       spawnFn,
       store,
@@ -581,6 +583,7 @@ const runSensorsWithGraph = async ({
   executionId,
   loadBlockScript,
   workspaceDir,
+  changedFiles = null,
   env,
   spawnFn,
   store,
@@ -590,6 +593,7 @@ const runSensorsWithGraph = async ({
     graph,
     loadBlockScript,
     workspaceDir,
+    changedFiles,
     // The upstream sensor commands embed {{HARNESS_DIR}}; the materializer
     // already neutralizes it in prose, but the script-argv builder ignores the
     // command path entirely (it runs the S3-materialized script), so no
@@ -2245,6 +2249,14 @@ export const runStage = async (
     return fail(stageInstanceId, uncommitted ? 'git_commit_failed' : 'push_failed', detail);
   }
 
+  // The paths this stage actually changed on disk, captured by the git engine
+  // before it staged the tree. Computed HERE (above the sensor pass) because the
+  // script sensors scope their inspection to it — a stage is graded on its own
+  // work, never on source a previous stage left in the checkout.
+  const changedFiles = [
+    ...new Set(gitResult.results.flatMap((gitChange) => gitChange.files ?? [])),
+  ].toSorted();
+
   // 6. Deterministic sensors — the verification axis that runs AFTER the agent.
   // Graph sensors evaluate the produced artifacts' content in-process; script
   // sensors spawn against the workspace checkout. Advisory verdicts record a
@@ -2264,6 +2276,7 @@ export const runStage = async (
       openGraph,
       loadBlockScript,
       workspaceDir,
+      changedFiles,
       env,
       spawnFn,
       store,
@@ -2395,9 +2408,6 @@ export const runStage = async (
     sectionIndex,
     state: 'SUCCEEDED',
   });
-  const changedFiles = [
-    ...new Set(gitResult.results.flatMap((gitChange) => gitChange.files ?? [])),
-  ].toSorted();
   const commitSha =
     gitResult.results.find((gitChange) => gitChange.committed && gitChange.sha)?.sha ?? null;
   return {

--- a/lambda/agentcore/git-engine.js
+++ b/lambda/agentcore/git-engine.js
@@ -240,6 +240,29 @@ const resolveCommitterFor = async ({
 //     losing a commit is strictly worse than a dependency re-install,
 //   - a terminal failure reports `dirty` (does the tree hold uncommitted
 //     work?) so run-stage can fail the stage when real work is at risk.
+// Parse `git status --porcelain -z` into repo-relative paths.
+//
+// The -z form is NUL-delimited and does NOT C-quote paths, so filenames with
+// spaces or non-ASCII bytes come through verbatim and match what `listFiles`
+// reports. Each entry is `XY <path>`; a rename/copy (R/C) is followed by a
+// SEPARATE NUL-terminated field holding the ORIGIN path. We keep the
+// destination (the file that now exists) and drop the origin.
+export const parsePorcelainZ = (stdout = '') => {
+  const fields = String(stdout).split('\0');
+  const out = [];
+  for (let i = 0; i < fields.length; i++) {
+    const entry = fields[i];
+    if (!entry) continue;
+    const status = entry.slice(0, 2);
+    const p = entry.slice(3);
+    if (p) out.push(p);
+    // R/C entries carry the origin path in the next field — consume it so it is
+    // not mistaken for a status entry of its own.
+    if (status.includes('R') || status.includes('C')) i += 1;
+  }
+  return out;
+};
+
 export const commitAll = async ({
   dir,
   message,
@@ -256,15 +279,11 @@ export const commitAll = async ({
   await ensureRuntimeExcludes({ dir });
 
   const attemptOnce = async () => {
-    const before = await git(['status', '--porcelain'], { cwd: dir });
-    const files =
-      before.exitCode === 0
-        ? before.stdout
-            .split('\n')
-            .filter(Boolean)
-            .map((line) => line.slice(3).trim().split(' -> ').pop())
-            .filter(Boolean)
-        : [];
+    // `-z` gives NUL-delimited, UNQUOTED paths. Plain `--porcelain` C-quotes any
+    // path containing a space or non-ASCII byte ("src/a b.ts" -> "\"src/a b.ts\""),
+    // which would never match the raw paths `listFiles` reports to the sensors.
+    const before = await git(['status', '--porcelain', '-z'], { cwd: dir });
+    const files = before.exitCode === 0 ? parsePorcelainZ(before.stdout) : [];
     const add = await git(['add', '-A'], { cwd: dir });
     if (add.exitCode !== 0) {
       return { committed: false, reason: 'add_failed', detail: add.stderr.trim(), files };
@@ -531,6 +550,15 @@ export const pushBranch = async ({
 // The on-disk target dir for a repo — MUST match workspace.js#repoTargetDir
 // (single repo → workspaceDir; multi → workspaceDir/<owner>/<repo>). Exported
 // for the lane commands (init-lane / merge-lane) that loop repos themselves.
+// Re-base a repo's own relative paths onto the WORKSPACE root, mirroring
+// repoTargetDir. On a multi-repo checkout each repo lives at
+// <workspaceDir>/<owner>/<repo>, so `src/index.ts` in two different repos are
+// two DIFFERENT workspace paths. Consumers (the sensors) glob relative to the
+// workspace, so they need the prefixed form to match exactly — a bare suffix
+// comparison would conflate identically-named files across repos.
+export const toWorkspaceRelative = (files = [], { url, multi }) =>
+  multi ? files.map((f) => `${url}/${f}`) : [...files];
+
 export const repoTargetDir = ({ url, workspaceDir, multi }) =>
   multi ? path.join(workspaceDir, url) : workspaceDir;
 
@@ -1171,6 +1199,11 @@ export const commitAndPushAll = async ({
         sleep,
         log,
       });
+      // Report changed files relative to the WORKSPACE, not the repo, so a
+      // multi-repo checkout cannot conflate same-named files across repos.
+      if (Array.isArray(commit.files)) {
+        commit.files = toWorkspaceRelative(commit.files, { url, multi });
+      }
       if (commit.reason === 'add_failed' || commit.reason === 'commit_failed') {
         results.push({ repo: url, ...commit, pushed: false });
         continue;

--- a/lambda/agentcore/git-engine.js
+++ b/lambda/agentcore/git-engine.js
@@ -458,6 +458,17 @@ export const isAheadOfRemote = async ({ dir, branch, git = runGit }) => {
   return remoteRef.stdout.trim() !== head.stdout.trim();
 };
 
+// List the files changed between the remote tracking branch and HEAD. Used on a
+// clean retry: the working tree has no changes but the local HEAD is ahead of
+// the remote (a previous run committed but failed to push). Returns the
+// repo-relative paths that the ahead commit(s) touched, or [] on failure.
+export const aheadFiles = async ({ dir, branch, git = runGit }) => {
+  const remoteRef = `refs/remotes/origin/${branch}`;
+  const diff = await git(['diff', '--name-only', '-z', remoteRef, 'HEAD'], { cwd: dir });
+  if (diff.exitCode !== 0) return [];
+  return diff.stdout.split('\0').filter((p) => p.length > 0);
+};
+
 // Push HEAD to the branch with v1 pushBranchWithRetry semantics. Returns:
 //   { pushed: 'empty' }               — no commits at all (new/empty repo)
 //   { pushed: true, sha, verified }   — on the remote (verified: ls-remote head
@@ -1214,6 +1225,16 @@ export const commitAndPushAll = async ({
       if (!commit.committed && !(await isAheadOfRemote({ dir, branch, git }))) {
         results.push({ repo: url, ...commit, pushed: 'up_to_date' });
         continue;
+      }
+      // On a clean retry (no new commit but HEAD is ahead), derive the changed
+      // file list from the remote-to-HEAD diff so sensors can still inspect the
+      // never-checked commit. Without this, `files` would be undefined and
+      // sensors would skip the commit entirely.
+      if (!commit.committed && !commit.files) {
+        commit.files = await aheadFiles({ dir, branch, git });
+      }
+      if (Array.isArray(commit.files)) {
+        commit.files = toWorkspaceRelative(commit.files, { url, multi });
       }
       const push = await pushBranch({
         dir,

--- a/lambda/agentcore/sensor-runner.js
+++ b/lambda/agentcore/sensor-runner.js
@@ -170,13 +170,36 @@ const expandToAffectedProjects = ({ globbed, changed, allFiles, configFile }) =>
   const projectRoots = allFiles.filter(isConfig).map(rootOfConfig);
   const globbedSet = new Set(globbed);
 
+  // Derive the set of project roots that also covers DELETED files: a deleted
+  // path is absent from `allFiles` (hence absent from `projectRoots` if it was
+  // the config), but its parent project may still exist. Walk up each changed
+  // path to find the deepest project root it belonged to. Config deletions are
+  // handled explicitly: a deleted config means the project root it defined is
+  // affected (its source may still compile under a parent config, which would
+  // surface new errors only if we inspect it).
+  const allRoots = new Set(projectRoots);
+
   const affected = new Set();
   for (const c of changed) {
-    if (isConfig(c)) affected.add(rootOfConfig(c));
-    else if (globbedSet.has(c)) affected.add(projectRootOf(c, projectRoots));
+    if (isConfig(c)) {
+      // A config that EXISTS is a live project root; one that is DELETED means
+      // its enclosing project is affected (compilation may shift to a parent).
+      // Add the root to allRoots so files under it can match via projectRootOf.
+      const root = rootOfConfig(c);
+      allRoots.add(root);
+      affected.add(root);
+    } else if (globbedSet.has(c)) {
+      affected.add(projectRootOf(c, [...allRoots]));
+    } else {
+      // Deleted/renamed source: not in the glob but its owning project is
+      // affected because removing a provider can break untouched consumers.
+      // Derive the root from the known roots (if the path once belonged to a
+      // project, the root itself may still exist even after the file is gone).
+      affected.add(projectRootOf(c, [...allRoots]));
+    }
   }
   if (affected.size === 0) return [];
-  return globbed.filter((f) => affected.has(projectRootOf(f, projectRoots)));
+  return globbed.filter((f) => affected.has(projectRootOf(f, [...allRoots])));
 };
 
 const runChild = ({ file, args, timeoutMs, cwd, env, spawnFn = spawn }) =>
@@ -281,7 +304,19 @@ const summarizeFileResults = (fileResults) => {
   if (groups.size > 0) detail.harnessFailures = [...groups.values()];
   if (kept.length > 0) detail.files = kept;
 
+  // Budget BOTH arrays under the total size ceiling. When stderr differs per
+  // file (e.g. includes the path), every failure becomes its own group and the
+  // harnessFailures array is never deduped — we must trim it to stay under the
+  // DynamoDB item limit. Trim harnessFailures first (least information lost per
+  // byte saved), then files.
   let dropped = 0;
+  while (
+    detail.harnessFailures?.length > 1 &&
+    Buffer.byteLength(JSON.stringify(detail), 'utf8') > DETAIL_BUDGET_BYTES
+  ) {
+    detail.harnessFailures.pop();
+    dropped += 1;
+  }
   while (
     detail.files?.length &&
     Buffer.byteLength(JSON.stringify(detail), 'utf8') > DETAIL_BUDGET_BYTES

--- a/lambda/agentcore/sensor-runner.js
+++ b/lambda/agentcore/sensor-runner.js
@@ -33,6 +33,10 @@ import {
   evalRequiredSections,
   evalUpstreamCoverage,
   evalGraphCoverage,
+  TOOL_UNAVAILABLE_EXIT,
+  sensorVerdictMode,
+  sensorScope,
+  projectConfigFile,
 } from '../shared/v2-sensor-contract.js';
 
 // Convert a sensor `matches` glob (e.g. `**/*.{ts,tsx}`, `**/aidlc-docs/**`)
@@ -113,9 +117,68 @@ const listFiles = async (root, { cap = 5000 } = {}) => {
   return out;
 };
 
-// Spawn a child and collect stdout/stderr + exit, enforcing a hard timeout.
+// Narrow a globbed workspace file list to the files THIS stage actually changed.
+//
+// Why this exists: `listFiles` walks the whole checkout, so a stage that writes
+// only methodology artifacts (which live in Neptune, not on disk) was still
+// matching source files left behind by an EARLIER code stage — and then being
+// judged on code it never touched. A design stage would spawn the type-checker
+// once per pre-existing `.ts` file in the repo.
+//
+// `changed` comes from the git engine, already re-based onto the workspace root
+// (see git-engine#toWorkspaceRelative). Contract:
+//   null / not an array → UNKNOWN provenance; do not scope (check everything).
+//                          Never silently skip checks when we can't tell.
+//   []                   → the stage changed nothing on disk; nothing to check.
+//
+// Matching is EXACT. A suffix comparison would conflate identically-named files
+// across repos in a multi-repo workspace — changing `src/index.ts` in repo A
+// would also select repo B's untouched `src/index.ts` and grade the stage on it.
+const scopeToChangedFiles = (files, changed) => {
+  if (!Array.isArray(changed)) return files;
+  if (changed.length === 0) return [];
+  const exact = new Set(changed);
+  return files.filter((f) => exact.has(f));
+};
+
 // Never rejects on a non-zero exit (a failing sensor is data, not an error).
 // `spawnFn` injectable for tests.
+// Resolve a file to its owning project root: the deepest directory at or above
+// it containing the sensor's project config (e.g. `tsconfig.json`). Files with
+// no such ancestor share the '' (workspace) root.
+const projectRootOf = (file, projectRoots) => {
+  let best = '';
+  for (const root of projectRoots) {
+    if (root === '') continue;
+    if (file.startsWith(`${root}/`) && root.length > best.length) best = root;
+  }
+  return best;
+};
+
+// Widen a `project`-scoped sensor from the changed files to every matching file
+// in each AFFECTED project.
+//
+// Required for CORRECTNESS, not efficiency. `tsc --project` compiles the whole
+// project and attributes each diagnostic to the file containing it, so a changed
+// provider that breaks an untouched consumer reports against the consumer —
+// which is not in the changed set. Inspecting only changed files would return a
+// false PASS. A change to the project CONFIG alone must widen too, since it can
+// break compilation with no source file changing.
+const expandToAffectedProjects = ({ globbed, changed, allFiles, configFile }) => {
+  const rootOfConfig = (f) => (f === configFile ? '' : f.slice(0, -(configFile.length + 1)));
+  const isConfig = (f) => f === configFile || f.endsWith(`/${configFile}`);
+  const projectRoots = allFiles.filter(isConfig).map(rootOfConfig);
+  const globbedSet = new Set(globbed);
+
+  const affected = new Set();
+  for (const c of changed) {
+    if (isConfig(c)) affected.add(rootOfConfig(c));
+    else if (globbedSet.has(c)) affected.add(projectRootOf(c, projectRoots));
+  }
+  if (affected.size === 0) return [];
+  return globbed.filter((f) => affected.has(projectRootOf(f, projectRoots)));
+};
+
 const runChild = ({ file, args, timeoutMs, cwd, env, spawnFn = spawn }) =>
   new Promise((resolve) => {
     let stdout = '';
@@ -153,10 +216,104 @@ const runChild = ({ file, args, timeoutMs, cwd, env, spawnFn = spawn }) =>
     child.on('close', (code) => finish(code));
   });
 
+// Per-diagnostic stderr budget. Truncated from the TAIL: the interpreter's real
+// error is the last thing written, not the banner.
+const STDERR_BUDGET = 500;
+
+// Total serialized budget for a SensorRun `detail`. DynamoDB's hard item ceiling
+// is 400 KiB and the row carries more than just this field, so stay well under
+// it: a wide glob can produce hundreds of file entries, and a `recordSensorRun`
+// that exceeds the limit fails — losing the whole verdict, which is far worse
+// than losing some diagnostics.
+const DETAIL_BUDGET_BYTES = 120_000;
+
+// Number of example files kept per deduped harness failure.
+const SAMPLE_FILES = 5;
+
+const tailDiagnostic = (stderr) => {
+  const text = typeof stderr === 'string' ? stderr.trim() : '';
+  if (!text) return null;
+  if (text.length <= STDERR_BUDGET) return text;
+  return `…${text.slice(-STDERR_BUDGET)}`;
+};
+
+// Build the sensor-level `detail` from per-file results, bounded in size.
+//
+// A harness failure hits EVERY file identically (a missing tool, an unloadable
+// tsconfig), so repeating the same exitCode+stderr hundreds of times is pure
+// duplication AND the thing that can push the row past DynamoDB's item ceiling.
+// Identical harness failures collapse into one `harnessFailures` entry carrying a
+// count and a few sample files; genuine per-file findings are kept as-is.
+//
+// Whatever remains is trimmed to a total serialized budget, recording how many
+// entries were dropped, so an oversized run degrades to fewer diagnostics rather
+// than a silently failed write that loses the entire verdict.
+const summarizeFileResults = (fileResults) => {
+  const groups = new Map();
+  const kept = [];
+  for (const entry of fileResults) {
+    const reason = entry.detail?.reason;
+    // Harness failures are identical across files; genuine verdicts are not.
+    if (reason === 'script-error' || reason === 'tool-unavailable') {
+      const key = `${reason}|${entry.detail?.exitCode ?? ''}|${entry.detail?.stderr ?? ''}`;
+      const g = groups.get(key) ?? {
+        reason,
+        result: entry.result,
+        exitCode: entry.detail?.exitCode ?? null,
+        stderr: entry.detail?.stderr ?? null,
+        fileCount: 0,
+        sampleFiles: [],
+      };
+      g.fileCount += 1;
+      if (g.sampleFiles.length < SAMPLE_FILES) g.sampleFiles.push(entry.file);
+      groups.set(key, g);
+      continue;
+    }
+    kept.push({
+      file: entry.file,
+      result: entry.result,
+      timedOut: entry.timedOut,
+      ...(entry.detail ? { detail: entry.detail } : {}),
+    });
+  }
+
+  const detail = {};
+  if (groups.size > 0) detail.harnessFailures = [...groups.values()];
+  if (kept.length > 0) detail.files = kept;
+
+  let dropped = 0;
+  while (
+    detail.files?.length &&
+    Buffer.byteLength(JSON.stringify(detail), 'utf8') > DETAIL_BUDGET_BYTES
+  ) {
+    detail.files.pop();
+    dropped += 1;
+  }
+  if (dropped > 0) {
+    detail.filesOmitted = dropped;
+    detail.omissionReason = 'detail size budget';
+  }
+  return detail;
+};
+
 // Read a sensor's stdout JSON `pass` field if present; falls back to the exit
 // code. Upstream per-sensor scripts exit 0 and carry the verdict in stdout
 // `{"pass": bool, ...}`, so the exit code alone under-reports a clean FAIL.
-const resultFromScript = ({ exitCode, stdout }) => {
+//
+// `verdictMode` (see the contract) decides how a NON-ZERO exit with no stdout
+// verdict is read. Under 'stdout-json' the script contract guarantees a verdict
+// at exit 0, so a non-zero exit means the script itself failed — INCONCLUSIVE,
+// because reporting it as FAIL makes a broken harness indistinguishable from real
+// defects. Under 'exit-code' (the default for sensors that do not declare a
+// mode, including custom scripts from the sensor editor) the classic convention
+// is preserved: non-zero means FAIL.
+//
+// 127 is INCONCLUSIVE in BOTH modes: the upstream scripts reserve it for
+// "underlying tool could not be resolved", which is never a code defect.
+//
+// `exitCode`/`stderr` are retained in the detail so the next occurrence is
+// diagnosable from the persisted row alone.
+const resultFromScript = ({ exitCode, stdout, stderr = '', verdictMode = 'exit-code' } = {}) => {
   if (exitCode === 0 && typeof stdout === 'string' && stdout.trim()) {
     try {
       const parsed = JSON.parse(stdout.trim().split(/\r?\n/).at(-1));
@@ -170,7 +327,26 @@ const resultFromScript = ({ exitCode, stdout }) => {
       /* not JSON — fall through to exit-code mapping */
     }
   }
-  return { result: resultFromExit(exitCode), detail: null };
+
+  const diagnostic = tailDiagnostic(stderr);
+  const ranButUndecided = (reason) => ({
+    result: SENSOR_RESULT.INCONCLUSIVE,
+    detail: { reason, exitCode: exitCode ?? null, stderr: diagnostic },
+  });
+
+  if (exitCode === TOOL_UNAVAILABLE_EXIT) return ranButUndecided('tool-unavailable');
+
+  const nonZero = exitCode !== 0 && exitCode !== 2 && exitCode !== null && exitCode !== undefined;
+  if (nonZero && verdictMode === 'stdout-json') {
+    // Exited non-zero without emitting a verdict: the script itself failed
+    // (missing tsconfig, unreadable file, config-load error), not the code.
+    return ranButUndecided('script-error');
+  }
+
+  return {
+    result: resultFromExit(exitCode),
+    detail: exitCode === 0 ? null : { exitCode: exitCode ?? null, stderr: diagnostic },
+  };
 };
 
 // Create the sensor runner. `graph` is the graph-writer (for reading produced
@@ -184,6 +360,9 @@ export const createSensorRunner = ({
   substitutions = {},
   spawnFn = spawn,
   childEnv = process.env,
+  // Workspace-relative paths this stage changed on disk, from the git engine.
+  // null → unknown, fall back to inspecting the whole checkout.
+  changedFiles = null,
 } = {}) => {
   // Evaluate one `graph` sensor against the artifacts this stage produced. Each
   // produced artifact's content is read from Neptune and fed to the in-process
@@ -261,11 +440,37 @@ export const createSensorRunner = ({
     }
     const matcher = sensor.matches ? globToRegExp(sensor.matches) : null;
     const all = await listFiles(workspaceDir);
-    const matched = matcher ? all.filter((f) => matcher.test(f)) : all;
-    if (matched.length === 0) {
+    const globbed = matcher ? all.filter((f) => matcher.test(f)) : all;
+    if (globbed.length === 0) {
       return {
         result: SENSOR_RESULT.INCONCLUSIVE,
         detail: { reason: 'no files match', matches: sensor.matches ?? null },
+      };
+    }
+    // Narrow to this stage's own work. `file`-scoped sensors judge each file
+    // independently, so the changed files are enough. `project`-scoped sensors
+    // (tsc) must widen to every file in each affected project or they report
+    // false PASSes — see expandToAffectedProjects.
+    const scope = sensorScope(sensor);
+    const matched =
+      scope === 'project' && Array.isArray(changedFiles)
+        ? expandToAffectedProjects({
+            globbed,
+            changed: changedFiles,
+            allFiles: all,
+            configFile: projectConfigFile(sensor),
+          })
+        : scopeToChangedFiles(globbed, changedFiles);
+    if (matched.length === 0) {
+      return {
+        result: SENSOR_RESULT.INCONCLUSIVE,
+        detail: {
+          reason: 'no changed files match',
+          matches: sensor.matches ?? null,
+          scope,
+          globbed: globbed.length,
+          changed: Array.isArray(changedFiles) ? changedFiles.length : null,
+        },
       };
     }
 
@@ -282,6 +487,7 @@ export const createSensorRunner = ({
     const { file, args } = buildScriptArgv(spec, { scriptPath, substitutions });
 
     // One run per matching file (the upstream scripts take a single --file-path).
+    const verdictMode = sensorVerdictMode(sensor);
     const fileResults = [];
     let worst = SENSOR_RESULT.PASS;
     for (const rel of matched) {
@@ -293,13 +499,21 @@ export const createSensorRunner = ({
         env: childEnv,
         spawnFn,
       });
-      const { result, detail } = resultFromScript(run);
+      const { result, detail } = resultFromScript({ ...run, verdictMode });
+      // exitCode/stderr live inside `detail`; summarizeFileResults dedupes
+      // identical harness failures rather than repeating them per file.
       fileResults.push({ file: rel, result, timedOut: run.timedOut, detail });
       if (result === SENSOR_RESULT.FAIL) worst = SENSOR_RESULT.FAIL;
       else if (result === SENSOR_RESULT.BLOCKED && worst !== SENSOR_RESULT.FAIL)
         worst = SENSOR_RESULT.BLOCKED;
+      else if (
+        result === SENSOR_RESULT.INCONCLUSIVE &&
+        worst !== SENSOR_RESULT.FAIL &&
+        worst !== SENSOR_RESULT.BLOCKED
+      )
+        worst = SENSOR_RESULT.INCONCLUSIVE;
     }
-    return { result: worst, detail: { files: fileResults } };
+    return { result: worst, detail: { scope, ...summarizeFileResults(fileResults) } };
   };
 
   // Run every sensor declared on a stage and return the verdicts. Each verdict:
@@ -348,4 +562,13 @@ export const createSensorRunner = ({
   return { runStageSensors, runGraphSensor, runScriptSensor };
 };
 
-export const __test = { globToRegExp, listFiles, resultFromScript };
+export const __test = {
+  globToRegExp,
+  listFiles,
+  resultFromScript,
+  tailDiagnostic,
+  scopeToChangedFiles,
+  expandToAffectedProjects,
+  summarizeFileResults,
+  projectRootOf,
+};

--- a/lambda/agentcore/test/git-engine.test.js
+++ b/lambda/agentcore/test/git-engine.test.js
@@ -8,6 +8,7 @@ import {
   scrubRemote,
   commitAll,
   isAheadOfRemote,
+  aheadFiles,
   pushBranch,
   remoteBranchExists,
   commitAndPushAll,
@@ -1425,5 +1426,55 @@ describe('runtime excludes', () => {
     await ensureRuntimeExcludes({ dir: work });
     const again = await readFile(path.join(work, '.git', 'info', 'exclude'), 'utf8');
     expect(again.match(/runtime excludes v3/g)).toHaveLength(1);
+  });
+});
+
+describe('aheadFiles', () => {
+  it('returns files changed between remote tracking branch and HEAD', async () => {
+    const { work } = await initRemoteAndClone();
+    // Commit a new file but do NOT push — HEAD is ahead.
+    await mkdir(path.join(work, 'src'), { recursive: true });
+    await writeFile(path.join(work, 'src', 'new.ts'), 'export const x = 1;');
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'add new'], work);
+
+    const files = await aheadFiles({ dir: work, branch: 'main' });
+    expect(files).toContain('src/new.ts');
+  });
+
+  it('returns empty when HEAD matches the remote', async () => {
+    const { work } = await initRemoteAndClone();
+    const files = await aheadFiles({ dir: work, branch: 'main' });
+    expect(files).toEqual([]);
+  });
+});
+
+describe('commitAndPushAll — retry carries files from ahead commit', () => {
+  it('derives file list from remote-to-HEAD diff on a clean retry', async () => {
+    const { remote, work } = await initRemoteAndClone();
+    // Stage 1: commit succeeds, push fails (simulate by making remote refuse).
+    await mkdir(path.join(work, 'src'), { recursive: true });
+    await writeFile(path.join(work, 'src', 'index.ts'), 'export const a = 1;');
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'stage work'], work);
+    // HEAD is now ahead of remote.
+
+    // Stage 2: retry — no new edits, tree is clean. commitAndPushAll should
+    // still report the files from the ahead commit.
+    const remoteUrl = `file://${remote}`;
+    const result = await commitAndPushAll({
+      repos: [remoteUrl],
+      workspaceDir: work,
+      branch: 'main',
+      gitProvider: 'github',
+      projectId: 'test',
+      executionId: 'ex1',
+      message: 'retry',
+      urlsFor: () => ({ clean: remoteUrl, auth: remoteUrl }),
+    });
+    expect(result.ok).toBe(true);
+    // The result should carry the files from the ahead commit.
+    const files = result.results.flatMap((r) => r.files ?? []);
+    expect(files.some((f) => f.endsWith('src/index.ts'))).toBe(true);
   });
 });

--- a/lambda/agentcore/test/git-engine.test.js
+++ b/lambda/agentcore/test/git-engine.test.js
@@ -12,6 +12,8 @@ import {
   remoteBranchExists,
   commitAndPushAll,
   seedInitialCommit,
+  parsePorcelainZ,
+  toWorkspaceRelative,
 } from '../git-engine.js';
 
 // Real git spawns (~10 per test) can be slow on busy CI machines.
@@ -90,6 +92,40 @@ describe('scrubRemote', () => {
   });
 });
 
+describe('parsePorcelainZ', () => {
+  it('returns unquoted paths for names with spaces and non-ASCII', () => {
+    // Plain --porcelain C-quotes these ("\"src/a b.ts\""), which would never
+    // match the raw paths listFiles reports to the sensors.
+    const out = parsePorcelainZ(' M src/a b.ts\0?? src/caf\u00e9.ts\0');
+    expect(out).toEqual(['src/a b.ts', 'src/café.ts']);
+  });
+
+  it('keeps the destination of a rename and drops the origin field', () => {
+    // R entries are followed by a SEPARATE NUL-terminated origin path.
+    expect(parsePorcelainZ('R  new.ts\0old.ts\0 M other.ts\0')).toEqual(['new.ts', 'other.ts']);
+  });
+
+  it('tolerates empty output', () => {
+    expect(parsePorcelainZ('')).toEqual([]);
+  });
+});
+
+describe('toWorkspaceRelative', () => {
+  it('prefixes with the repo on a multi-repo checkout', () => {
+    // Two repos can both contain src/index.ts; the sensors glob relative to the
+    // workspace, so only the prefixed form identifies a file unambiguously.
+    expect(toWorkspaceRelative(['src/index.ts'], { url: 'acme/shop', multi: true })).toEqual([
+      'acme/shop/src/index.ts',
+    ]);
+  });
+
+  it('leaves paths alone for a single repo, whose dir IS the workspace', () => {
+    expect(toWorkspaceRelative(['src/index.ts'], { url: 'acme/shop', multi: false })).toEqual([
+      'src/index.ts',
+    ]);
+  });
+});
+
 describe('commitAll', () => {
   it('commits the whole tree with the engine identity and returns the sha', async () => {
     const { work } = await initRemoteAndClone();
@@ -141,6 +177,20 @@ describe('commitAll', () => {
         else process.env[k] = v;
       }
     }
+  });
+
+  it('captures filenames with spaces and non-ASCII verbatim', async () => {
+    // The sensors match these paths against listFiles output, so any C-quoting
+    // from plain --porcelain would silently prevent a match.
+    const { work } = await initRemoteAndClone();
+    await writeFile(path.join(work, 'a file.ts'), 'x\n');
+    await writeFile(path.join(work, 'café.ts'), 'y\n');
+
+    const res = await commitAll({ dir: work, message: 'aidlc(x): e1' });
+
+    expect(res.committed).toBe(true);
+    expect(res.files).toContain('a file.ts');
+    expect(res.files).toContain('café.ts');
   });
 
   it('captures untracked, modified AND deleted files (add -A semantics)', async () => {

--- a/lambda/agentcore/test/sensor-runner.test.js
+++ b/lambda/agentcore/test/sensor-runner.test.js
@@ -732,3 +732,75 @@ describe('runStageSensors — script kind', () => {
     expect(verdicts[0].detail.error).toBe('sensor has no script');
   });
 });
+
+describe('expandToAffectedProjects — deleted/renamed files', () => {
+  const allFiles = [
+    'packages/api/tsconfig.json',
+    'packages/api/src/consumer.ts',
+    'packages/web/tsconfig.json',
+    'packages/web/src/page.ts',
+  ];
+  const globbed = ['packages/api/src/consumer.ts', 'packages/web/src/page.ts'];
+
+  it('marks the owning project as affected when a source file is deleted', () => {
+    // `packages/api/src/provider.ts` was deleted — not in allFiles/globbed.
+    // Removing a provider can break the untouched consumer; must inspect api/.
+    const r = expandToAffectedProjects({
+      globbed,
+      changed: ['packages/api/src/provider.ts'],
+      allFiles,
+      configFile: 'tsconfig.json',
+    });
+    expect(r).toContain('packages/api/src/consumer.ts');
+    expect(r).not.toContain('packages/web/src/page.ts');
+  });
+
+  it('marks project as affected when its tsconfig.json is deleted', () => {
+    // The config deletion means the project's compilation shifts to a parent —
+    // all its files may now error. Config not in allFiles/globbed (deleted).
+    const r = expandToAffectedProjects({
+      globbed,
+      changed: ['packages/api/tsconfig.json'],
+      allFiles: allFiles.filter((f) => f !== 'packages/api/tsconfig.json'),
+      configFile: 'tsconfig.json',
+    });
+    expect(r).toContain('packages/api/src/consumer.ts');
+  });
+
+  it('handles a cross-project rename (old path outside destination project)', () => {
+    // File moved from packages/api/ to packages/web/. The OLD path (deleted from
+    // api) should mark api as affected; the NEW path marks web as affected.
+    const r = expandToAffectedProjects({
+      globbed,
+      changed: ['packages/api/src/moved.ts', 'packages/web/src/page.ts'],
+      allFiles,
+      configFile: 'tsconfig.json',
+    });
+    expect(r).toContain('packages/api/src/consumer.ts'); // api affected via deleted file
+    expect(r).toContain('packages/web/src/page.ts'); // web affected via existing file
+  });
+});
+
+describe('summarizeFileResults — harnessFailures budget', () => {
+  it('trims distinct harness failures to stay within budget', () => {
+    // 1000 failures with distinct stderr (includes path), each ~ 600 bytes.
+    // Without the budget this exceeds 600KB — well past the DynamoDB 400KiB limit.
+    const entries = Array.from({ length: 1000 }, (_, i) => ({
+      file: `packages/api/src/deeply/nested/path/file-number-${i}.ts`,
+      result: 'INCONCLUSIVE',
+      timedOut: false,
+      detail: {
+        reason: 'script-error',
+        exitCode: 1,
+        stderr: `Error in file-number-${i}.ts: ${'x'.repeat(400)}`,
+      },
+    }));
+    const d = summarizeFileResults(entries);
+    const bytes = Buffer.byteLength(JSON.stringify(d), 'utf8');
+    expect(bytes).toBeLessThanOrEqual(120_000);
+    expect(d.filesOmitted).toBeGreaterThan(0);
+    expect(d.omissionReason).toBe('detail size budget');
+    // Must still have SOME harness failures preserved for diagnostics.
+    expect(d.harnessFailures.length).toBeGreaterThan(0);
+  });
+});

--- a/lambda/agentcore/test/sensor-runner.test.js
+++ b/lambda/agentcore/test/sensor-runner.test.js
@@ -5,7 +5,14 @@ import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import { createSensorRunner, __test } from '../sensor-runner.js';
 
-const { globToRegExp, resultFromScript } = __test;
+const {
+  globToRegExp,
+  resultFromScript,
+  tailDiagnostic,
+  scopeToChangedFiles,
+  expandToAffectedProjects,
+  summarizeFileResults,
+} = __test;
 
 describe('globToRegExp', () => {
   it('matches a brace-alternation code glob', () => {
@@ -29,6 +36,218 @@ describe('resultFromScript', () => {
   });
   it('falls back to the exit code without JSON', () => {
     expect(resultFromScript({ exitCode: 2, stdout: '' }).result).toBe('INCONCLUSIVE');
+  });
+
+  it('reports 127 as tool-unavailable INCONCLUSIVE, not FAIL', () => {
+    const r = resultFromScript({
+      exitCode: 127,
+      stdout: '',
+      stderr: 'tsc-unavailable\n',
+      verdictMode: 'stdout-json',
+    });
+    expect(r.result).toBe('INCONCLUSIVE');
+    expect(r.detail).toMatchObject({ reason: 'tool-unavailable', exitCode: 127 });
+    expect(r.detail.stderr).toBe('tsc-unavailable');
+  });
+
+  it('reports a non-zero stdout-json exit with no verdict as script-error, not FAIL', () => {
+    // This is the regression: a missing tsconfig (exit 1) or a tsc config-load
+    // failure used to surface as FAIL for every file, indistinguishable from
+    // genuine type errors.
+    for (const exitCode of [1, 3, 66]) {
+      const r = resultFromScript({
+        exitCode,
+        stdout: '',
+        stderr: 'no-tsconfig-found',
+        verdictMode: 'stdout-json',
+      });
+      expect(r.result).toBe('INCONCLUSIVE');
+      expect(r.detail).toMatchObject({ reason: 'script-error', exitCode });
+    }
+  });
+
+  it('keeps the exit-code convention for exit-code sensors', () => {
+    // Custom scripts authored in the sensor editor signal FAIL by exit status and
+    // must keep doing so. Only sensors declaring the stdout-JSON contract get the
+    // script-error reclassification.
+    const r = resultFromScript({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'boom',
+      verdictMode: 'exit-code',
+    });
+    expect(r.result).toBe('FAIL');
+    expect(r.detail).toMatchObject({ exitCode: 1, stderr: 'boom' });
+  });
+
+  it('defaults to exit-code semantics when no verdict mode is given', () => {
+    // Unmarked sensors must not be silently reclassified — the old behaviour
+    // keyed off runtime and swept up any custom bun/node script.
+    expect(resultFromScript({ exitCode: 1, stdout: '', stderr: 'x' }).result).toBe('FAIL');
+  });
+
+  it('still BLOCKS on a spawn error or timeout (null exit)', () => {
+    expect(
+      resultFromScript({ exitCode: null, stdout: '', verdictMode: 'stdout-json' }).result,
+    ).toBe('BLOCKED');
+  });
+
+  it('truncates a long stderr from the tail and keeps the real error', () => {
+    const stderr = `${'banner\n'.repeat(500)}THE ACTUAL ERROR`;
+    const r = resultFromScript({ exitCode: 1, stdout: '', stderr, verdictMode: 'stdout-json' });
+    expect(r.detail.stderr).toContain('THE ACTUAL ERROR');
+    expect(r.detail.stderr.length).toBeLessThanOrEqual(501);
+  });
+});
+
+describe('scopeToChangedFiles', () => {
+  const globbed = ['packages/api/src/app.ts', 'packages/api/vitest.config.ts', 'web/src/App.tsx'];
+
+  it('does not scope when provenance is unknown (null)', () => {
+    // Never silently skip checks because we could not determine what changed.
+    expect(scopeToChangedFiles(globbed, null)).toEqual(globbed);
+    expect(scopeToChangedFiles(globbed, undefined)).toEqual(globbed);
+  });
+
+  it('returns nothing when the stage changed nothing on disk', () => {
+    expect(scopeToChangedFiles(globbed, [])).toEqual([]);
+  });
+
+  it('keeps only the changed files on an exact (single-repo) match', () => {
+    expect(scopeToChangedFiles(globbed, ['packages/api/src/app.ts'])).toEqual([
+      'packages/api/src/app.ts',
+    ]);
+  });
+
+  it('does NOT conflate identically-named files across repos', () => {
+    // The engine reports workspace-relative paths (git-engine#toWorkspaceRelative),
+    // so matching is exact. A suffix match would select repo B's untouched
+    // src/index.ts when only repo A's changed, grading the stage on foreign code.
+    const multi = ['acme/shop/src/index.ts', 'acme/other/src/index.ts'];
+    expect(scopeToChangedFiles(multi, ['acme/shop/src/index.ts'])).toEqual([
+      'acme/shop/src/index.ts',
+    ]);
+  });
+
+  it('matches nothing when the changed list is not workspace-relative', () => {
+    // Guards the contract: repo-relative input must not accidentally match. If
+    // this ever regresses, the engine stopped prefixing and the bug is upstream.
+    expect(scopeToChangedFiles(['acme/shop/src/index.ts'], ['src/index.ts'])).toEqual([]);
+  });
+});
+
+describe('expandToAffectedProjects', () => {
+  const allFiles = [
+    'packages/api/tsconfig.json',
+    'packages/api/src/provider.ts',
+    'packages/api/src/consumer.ts',
+    'packages/web/tsconfig.json',
+    'packages/web/src/page.ts',
+  ];
+  const globbed = [
+    'packages/api/src/provider.ts',
+    'packages/api/src/consumer.ts',
+    'packages/web/src/page.ts',
+  ];
+  const expand = (changed) =>
+    expandToAffectedProjects({ globbed, changed, allFiles, configFile: 'tsconfig.json' });
+
+  it('widens a changed file to EVERY file in its project', () => {
+    // The false-green this prevents: tsc --project compiles the whole project and
+    // attributes a diagnostic to the file containing it. If a changed provider
+    // breaks an untouched consumer, the error lands on the consumer — absent from
+    // the changed set — so a file-scoped run would report PASS.
+    expect(expand(['packages/api/src/provider.ts'])).toEqual([
+      'packages/api/src/provider.ts',
+      'packages/api/src/consumer.ts',
+    ]);
+  });
+
+  it('does not widen into UNAFFECTED projects', () => {
+    expect(expand(['packages/api/src/provider.ts'])).not.toContain('packages/web/src/page.ts');
+  });
+
+  it('widens on a config-only change, where no source file changed', () => {
+    // A tsconfig edit can break compilation with zero .ts files changed; a
+    // file-scoped run would see nothing at all.
+    expect(expand(['packages/api/tsconfig.json'])).toEqual([
+      'packages/api/src/provider.ts',
+      'packages/api/src/consumer.ts',
+    ]);
+  });
+
+  it('returns nothing when no project is affected', () => {
+    expect(expand(['README.md'])).toEqual([]);
+  });
+
+  it('picks the DEEPEST project root for nested projects', () => {
+    const nested = ['a/tsconfig.json', 'a/b/tsconfig.json', 'a/x.ts', 'a/b/y.ts'];
+    const g = ['a/x.ts', 'a/b/y.ts'];
+    const r = expandToAffectedProjects({
+      globbed: g,
+      changed: ['a/b/y.ts'],
+      allFiles: nested,
+      configFile: 'tsconfig.json',
+    });
+    expect(r).toEqual(['a/b/y.ts']);
+  });
+});
+
+describe('summarizeFileResults', () => {
+  const harness = (file) => ({
+    file,
+    result: 'INCONCLUSIVE',
+    timedOut: false,
+    detail: { reason: 'script-error', exitCode: 1, stderr: 'tsc-unavailable' },
+  });
+
+  it('collapses identical harness failures into one entry with a count', () => {
+    const d = summarizeFileResults(Array.from({ length: 300 }, (_, i) => harness(`src/f${i}.ts`)));
+    expect(d.harnessFailures).toHaveLength(1);
+    expect(d.harnessFailures[0].fileCount).toBe(300);
+    expect(d.harnessFailures[0].sampleFiles).toHaveLength(5);
+    expect(d.files).toBeUndefined();
+  });
+
+  it('keeps distinct harness failures separate', () => {
+    const other = { ...harness('src/z.ts') };
+    other.detail = { reason: 'tool-unavailable', exitCode: 127, stderr: 'eslint-unavailable' };
+    const d = summarizeFileResults([harness('src/a.ts'), other]);
+    expect(d.harnessFailures).toHaveLength(2);
+  });
+
+  it('keeps genuine per-file verdicts rather than deduping them', () => {
+    const d = summarizeFileResults([
+      { file: 'src/a.ts', result: 'FAIL', timedOut: false, detail: { pass: false, errors: [1] } },
+      { file: 'src/b.ts', result: 'PASS', timedOut: false, detail: { pass: true } },
+    ]);
+    expect(d.files).toHaveLength(2);
+    expect(d.harnessFailures).toBeUndefined();
+  });
+
+  it('stays inside the serialized budget, recording what it dropped', () => {
+    // A per-file cap alone does not bound the ITEM: ~354 entries with 500-char
+    // stderr exceed DynamoDB's 400 KiB limit and recordSensorRun then fails
+    // silently, losing the whole verdict.
+    const big = Array.from({ length: 4000 }, (_, i) => ({
+      file: `packages/api/src/very/deep/path/file-${i}.ts`,
+      result: 'FAIL',
+      timedOut: false,
+      detail: { pass: false, errors: [{ message: 'x'.repeat(400) }] },
+    }));
+    const d = summarizeFileResults(big);
+    const bytes = Buffer.byteLength(JSON.stringify(d), 'utf8');
+    expect(bytes).toBeLessThanOrEqual(120_000);
+    expect(d.filesOmitted).toBeGreaterThan(0);
+    expect(d.omissionReason).toBe('detail size budget');
+  });
+});
+
+describe('tailDiagnostic', () => {
+  it('returns null for empty or whitespace stderr', () => {
+    expect(tailDiagnostic('')).toBeNull();
+    expect(tailDiagnostic('   \n')).toBeNull();
+    expect(tailDiagnostic(undefined)).toBeNull();
   });
 });
 
@@ -235,6 +454,196 @@ describe('runStageSensors — script kind', () => {
     });
     expect(verdicts[0]).toMatchObject({ kind: 'script', result: 'PASS', held: false });
     expect(verdicts[0].detail.files[0].file).toBe('src/a.ts');
+  });
+
+  it('a harness failure across every file is INCONCLUSIVE, not a false FAIL', async () => {
+    // Reproduces the observed production shape: every matching file exits
+    // non-zero with nothing on stdout (broken tsconfig / unresolvable tool).
+    // Previously each file recorded FAIL with detail:null and the sensor
+    // reported FAIL — indistinguishable from real type errors.
+    await mkdir(path.join(ws, 'packages', 'api'), { recursive: true });
+    await writeFile(path.join(ws, 'packages', 'api', 'app.ts'), 'export const a = 1;');
+    await writeFile(path.join(ws, 'packages', 'api', 'vitest.config.ts'), 'export default {};');
+    const spawnWithStderr = () => {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {};
+      setTimeout(() => {
+        child.stderr.emit('data', Buffer.from('error TS18003: No inputs were found'));
+        child.emit('close', 1);
+      }, 0);
+      return child;
+    };
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+      workspaceDir: ws,
+      spawnFn: spawnWithStderr,
+    });
+    const verdicts = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'type-check',
+          severity: 'advisory',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.{ts,tsx}',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'infrastructure-design',
+    });
+    expect(verdicts[0].result).toBe('INCONCLUSIVE');
+    expect(verdicts[0].held).toBe(false);
+    // Identical harness failures collapse into ONE diagnostic with a count and
+    // sample files, rather than repeating exitCode+stderr per file (which is how
+    // a wide glob could push the row past DynamoDB's item limit).
+    expect(verdicts[0].detail.files).toBeUndefined();
+    expect(verdicts[0].detail.harnessFailures).toHaveLength(1);
+    const hf = verdicts[0].detail.harnessFailures[0];
+    expect(hf).toMatchObject({ reason: 'script-error', exitCode: 1, fileCount: 2 });
+    expect(hf.stderr).toContain('TS18003');
+    expect(hf.sampleFiles.length).toBeGreaterThan(0);
+  });
+
+  it('a real code defect (exit 0, pass:false) is still FAIL', async () => {
+    await writeFile(path.join(ws, 'a.ts'), 'x');
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'BODY',
+      workspaceDir: ws,
+      spawnFn: fakeSpawn('{"pass":false,"errors":[{"file":"a.ts"}],"findings_count":1}'),
+    });
+    const verdicts = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'type-check',
+          severity: 'advisory',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+    expect(verdicts[0].result).toBe('FAIL');
+    expect(verdicts[0].detail.files[0].detail.findings_count).toBe(1);
+  });
+
+  it('a design stage is not graded on a previous stage source (changedFiles empty)', async () => {
+    // The reported bug: infrastructure-design writes methodology artifacts to
+    // Neptune and nothing to disk, yet the glob matched ~40 .ts files left by an
+    // earlier code-generation stage and spawned the type-checker on each.
+    await mkdir(path.join(ws, 'packages', 'api', 'src'), { recursive: true });
+    await writeFile(path.join(ws, 'packages', 'api', 'src', 'app.ts'), 'export const a = 1;');
+    await writeFile(path.join(ws, 'packages', 'api', 'vitest.config.ts'), 'export default {};');
+    let spawns = 0;
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'BODY',
+      workspaceDir: ws,
+      changedFiles: [],
+      spawnFn: (...a) => {
+        spawns += 1;
+        return fakeSpawn('{"pass":true}')(...a);
+      },
+    });
+    const verdicts = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'type-check',
+          severity: 'advisory',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.{ts,tsx}',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'infrastructure-design',
+    });
+    expect(verdicts[0].result).toBe('INCONCLUSIVE');
+    expect(verdicts[0].detail.reason).toBe('no changed files match');
+    expect(verdicts[0].detail.globbed).toBe(2);
+    expect(spawns).toBe(0);
+  });
+
+  it('a project-scoped sensor widens to untouched files in the affected project', async () => {
+    // End-to-end guard for the false green: tsc --project attributes a diagnostic
+    // to the file containing it, so if a changed provider breaks an untouched
+    // consumer the error lands on the consumer. Inspecting only changed files
+    // would return PASS. The consumer MUST be inspected too.
+    await mkdir(path.join(ws, 'packages', 'api', 'src'), { recursive: true });
+    await writeFile(path.join(ws, 'packages', 'api', 'tsconfig.json'), '{}');
+    await writeFile(path.join(ws, 'packages', 'api', 'src', 'provider.ts'), 'export const a = 1;');
+    await writeFile(path.join(ws, 'packages', 'api', 'src', 'consumer.ts'), 'export const b = 2;');
+    await mkdir(path.join(ws, 'packages', 'web'), { recursive: true });
+    await writeFile(path.join(ws, 'packages', 'web', 'tsconfig.json'), '{}');
+    await writeFile(path.join(ws, 'packages', 'web', 'page.ts'), 'export const c = 3;');
+
+    const inspected = [];
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'BODY',
+      workspaceDir: ws,
+      changedFiles: ['packages/api/src/provider.ts'],
+      spawnFn: (file, args, opts) => {
+        inspected.push(args[args.indexOf('--file-path') + 1]);
+        return fakeSpawn('{"pass":true}')(file, args, opts);
+      },
+    });
+    const verdicts = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'type-check',
+          severity: 'advisory',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+
+    expect(verdicts[0].detail.scope).toBe('project');
+    expect(inspected).toContain('packages/api/src/provider.ts');
+    expect(inspected).toContain('packages/api/src/consumer.ts');
+    // ...but must NOT bleed into an unaffected project.
+    expect(inspected).not.toContain('packages/web/page.ts');
+  });
+
+  it('a file-scoped sensor checks only the files it changed', async () => {
+    await mkdir(path.join(ws, 'src'), { recursive: true });
+    await writeFile(path.join(ws, 'src', 'touched.ts'), 'export const a = 1;');
+    await writeFile(path.join(ws, 'src', 'untouched.ts'), 'export const b = 2;');
+    const inspected = [];
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'BODY',
+      workspaceDir: ws,
+      changedFiles: ['src/touched.ts'],
+      spawnFn: (file, args, opts) => {
+        inspected.push(args[args.indexOf('--file-path') + 1]);
+        return fakeSpawn('{"pass":true}')(file, args, opts);
+      },
+    });
+    const verdicts = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'linter',
+          severity: 'advisory',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+    expect(verdicts[0].result).toBe('PASS');
+    expect(inspected).toEqual(['src/touched.ts']);
   });
 
   it('BLOCKED when a script sensor has no script bytes', async () => {

--- a/lambda/shared/test/v2-execution-plan.test.js
+++ b/lambda/shared/test/v2-execution-plan.test.js
@@ -349,6 +349,34 @@ describe('buildExecutionPlan — plan shape', () => {
     expect(plan.stages[0].sensors[0].scriptRef).toBeNull();
   });
 
+  // Regression: verdictMode, scope, and projectConfig must survive plan
+  // resolution so a custom sensor declaring stdout-json mode is evaluated
+  // correctly, and project-scoped sensors widen to the affected project.
+  it('threads verdictMode, scope, and projectConfig through to the plan', () => {
+    const lib = baseLibrary({
+      stagesById: { a: stage('a', { sensors: ['custom-checker'] }) },
+      sensorsById: {
+        'custom-checker': {
+          command: 'custom-checker.ts',
+          severity: 'advisory',
+          runtime: 'bun',
+          verdictMode: 'stdout-json',
+          scope: 'project',
+          projectConfig: 'pyproject.toml',
+        },
+      },
+    });
+    const { plan } = buildExecutionPlan({
+      workflow: workflow([placement('a')]),
+      scope: 'feature',
+      library: lib,
+    });
+    const resolved = plan.stages[0].sensors[0];
+    expect(resolved.verdictMode).toBe('stdout-json');
+    expect(resolved.scope).toBe('project');
+    expect(resolved.projectConfig).toBe('pyproject.toml');
+  });
+
   it('flags agent-team as not implemented without crashing', () => {
     const lib = baseLibrary({ stagesById: { a: stage('a', { mode: 'agent-team' }) } });
     const { plan } = buildExecutionPlan({

--- a/lambda/shared/test/v2-sensor-contract.test.js
+++ b/lambda/shared/test/v2-sensor-contract.test.js
@@ -5,6 +5,10 @@ import {
   severityGate,
   validateScriptSpec,
   resultFromExit,
+  TOOL_UNAVAILABLE_EXIT,
+  sensorVerdictMode,
+  sensorScope,
+  projectConfigFile,
   buildScriptArgv,
   evalRequiredSections,
   evalUpstreamCoverage,
@@ -78,6 +82,62 @@ describe('resultFromExit', () => {
     expect(resultFromExit(2)).toBe(SENSOR_RESULT.INCONCLUSIVE);
     expect(resultFromExit(1)).toBe(SENSOR_RESULT.FAIL);
     expect(resultFromExit(null)).toBe(SENSOR_RESULT.BLOCKED);
+  });
+
+  it('treats 127 (tool unresolvable) as INCONCLUSIVE, never FAIL', () => {
+    // The per-sensor scripts exit 127 when their underlying tool cannot be
+    // resolved. Reporting that as FAIL made a broken harness look identical to
+    // real type/lint errors — and would wedge a blocking sensor.
+    expect(resultFromExit(TOOL_UNAVAILABLE_EXIT)).toBe(SENSOR_RESULT.INCONCLUSIVE);
+    expect(TOOL_UNAVAILABLE_EXIT).toBe(127);
+  });
+});
+
+describe('sensorVerdictMode', () => {
+  it('honours an explicit declaration', () => {
+    expect(sensorVerdictMode({ sensorId: 'custom', verdictMode: 'stdout-json' })).toBe(
+      'stdout-json',
+    );
+    expect(sensorVerdictMode({ sensorId: 'linter', verdictMode: 'exit-code' })).toBe('exit-code');
+  });
+
+  it('defaults UNMARKED sensors to exit-code semantics', () => {
+    // Custom scripts from the sensor editor signal FAIL by exit status. Keying
+    // off runtime instead would silently reclassify them as INCONCLUSIVE.
+    expect(sensorVerdictMode({ sensorId: 'my-custom-check', runtime: 'bun' })).toBe('exit-code');
+    expect(sensorVerdictMode({})).toBe('exit-code');
+  });
+
+  it('falls back to stdout-json for the known upstream sensors', () => {
+    expect(sensorVerdictMode({ sensorId: 'linter' })).toBe('stdout-json');
+    expect(sensorVerdictMode({ sensorId: 'type-check' })).toBe('stdout-json');
+  });
+
+  it('ignores an unrecognised declaration', () => {
+    expect(sensorVerdictMode({ sensorId: 'custom', verdictMode: 'nonsense' })).toBe('exit-code');
+  });
+});
+
+describe('sensorScope', () => {
+  it('treats type-check as project-scoped and everything else as file-scoped', () => {
+    // tsc compiles a whole project, so scoping it to changed files yields false
+    // PASSes when a changed provider breaks an untouched consumer.
+    expect(sensorScope({ sensorId: 'type-check' })).toBe('project');
+    expect(sensorScope({ sensorId: 'linter' })).toBe('file');
+    expect(sensorScope({})).toBe('file');
+  });
+
+  it('honours an explicit scope', () => {
+    expect(sensorScope({ sensorId: 'linter', scope: 'project' })).toBe('project');
+    expect(sensorScope({ sensorId: 'type-check', scope: 'file' })).toBe('file');
+    expect(sensorScope({ sensorId: 'x', scope: 'nonsense' })).toBe('file');
+  });
+});
+
+describe('projectConfigFile', () => {
+  it('defaults to tsconfig.json and is overridable', () => {
+    expect(projectConfigFile({})).toBe('tsconfig.json');
+    expect(projectConfigFile({ projectConfig: 'jsconfig.json' })).toBe('jsconfig.json');
   });
 });
 

--- a/lambda/shared/v2-execution-plan.js
+++ b/lambda/shared/v2-execution-plan.js
@@ -215,6 +215,9 @@ const resolveSensors = (stage, stageId, sensorsById, errors) =>
         category: sensor.category ?? null,
         matches: sensor.matches ?? null,
         scriptRef: sensor.scriptRef ?? null,
+        verdictMode: sensor.verdictMode ?? null,
+        scope: sensor.scope ?? null,
+        projectConfig: sensor.projectConfig ?? null,
       };
     })
     .filter(Boolean);

--- a/lambda/shared/v2-sensor-contract.js
+++ b/lambda/shared/v2-sensor-contract.js
@@ -107,13 +107,73 @@ const validateScriptSpec = (sensor) => {
   };
 };
 
+// The upstream per-sensor scripts reserve 127 for "the underlying tool could not
+// be resolved" — they probe (e.g. `bunx tsc --version`) at startup and exit 127
+// on ANY non-zero probe, because `bunx` returns assorted non-127 codes for
+// network-fetch / package-resolution / registry-timeout failures. Upstream a
+// dispatcher branch reclassified this to a tool-unavailable note; we own that
+// reclassification here instead.
+const TOOL_UNAVAILABLE_EXIT = 127;
+
+// ── Verdict contract ──
+// How a script sensor reports its result.
+//   'stdout-json' — the script prints {"pass": bool, ...} and exits 0. A NON-ZERO
+//                   exit therefore means the script itself failed (missing tool,
+//                   unreadable config), NOT that the code is bad. This is the
+//                   contract the upstream per-sensor scripts follow.
+//   'exit-code'   — the classic convention: exit 0 pass, non-zero fail. Custom
+//                   scripts authored in the sensor editor rely on this, so it
+//                   stays the DEFAULT for anything that does not declare a mode.
+const SENSOR_VERDICT_MODES = Object.freeze(['stdout-json', 'exit-code']);
+
+// Sensors known to ship the upstream stdout-JSON scripts. Used only as a
+// fallback when a sensor row predates `verdictMode`; an explicit declaration on
+// the row always wins.
+const STDOUT_JSON_SENSORS = Object.freeze(['linter', 'type-check']);
+
+const sensorVerdictMode = (sensor) => {
+  const declared = sensor?.verdictMode;
+  if (SENSOR_VERDICT_MODES.includes(declared)) return declared;
+  return STDOUT_JSON_SENSORS.includes(sensor?.sensorId ?? sensor?.id) ? 'stdout-json' : 'exit-code';
+};
+
+// ── Change scope ──
+// What a script sensor must inspect once the stage's changed files are known.
+//   'file'    — the sensor judges each file independently (a linter). Inspecting
+//               only the changed files is sound.
+//   'project' — the sensor compiles a whole PROJECT and attributes diagnostics
+//               back to one file (`tsc --project`). Scoping to changed files is
+//               UNSOUND there: a changed provider that breaks an untouched
+//               consumer reports the error against the consumer, which is not in
+//               the changed set, so the sensor would return a false PASS. Such a
+//               sensor must be widened to every matching file in each affected
+//               project.
+const SENSOR_SCOPES = Object.freeze(['file', 'project']);
+const PROJECT_SCOPED_SENSORS = Object.freeze(['type-check']);
+
+const sensorScope = (sensor) => {
+  const declared = sensor?.scope;
+  if (SENSOR_SCOPES.includes(declared)) return declared;
+  return PROJECT_SCOPED_SENSORS.includes(sensor?.sensorId ?? sensor?.id) ? 'project' : 'file';
+};
+
+// The file whose presence marks a project root for a `project`-scoped sensor. A
+// change to this file alone must widen the sensor to the whole project, since a
+// config change can break compilation without any source file changing.
+const projectConfigFile = (sensor) => sensor?.projectConfig ?? 'tsconfig.json';
+
 // Map a script's exit code to a result. Convention (matches upstream per-sensor
 // scripts): 0 → PASS/FAIL is decided by the script's stdout JSON `pass` field;
 // the runner reads that. When stdout JSON is unavailable we fall back to the
-// exit code alone: 0 PASS, 2 INCONCLUSIVE, null BLOCKED, else FAIL.
+// exit code alone: 0 PASS, 2 INCONCLUSIVE, 127 INCONCLUSIVE (tool unavailable,
+// NOT a code defect), null BLOCKED, else FAIL.
 const resultFromExit = (exitCode) => {
   if (exitCode === 0) return SENSOR_RESULT.PASS;
   if (exitCode === 2) return SENSOR_RESULT.INCONCLUSIVE;
+  // A missing/unresolvable tool is "ran but couldn't decide", never a FAIL — an
+  // advisory tool-unavailable reported as FAIL is indistinguishable from real
+  // type/lint errors, and a BLOCKING one would wedge the stage.
+  if (exitCode === TOOL_UNAVAILABLE_EXIT) return SENSOR_RESULT.INCONCLUSIVE;
   if (exitCode === null || exitCode === undefined) return SENSOR_RESULT.BLOCKED;
   return SENSOR_RESULT.FAIL;
 };
@@ -446,6 +506,12 @@ export {
   ALLOWED_SCRIPT_RUNTIMES,
   MAX_TIMEOUT_SECONDS,
   DEFAULT_TIMEOUT_SECONDS,
+  TOOL_UNAVAILABLE_EXIT,
+  SENSOR_VERDICT_MODES,
+  SENSOR_SCOPES,
+  sensorVerdictMode,
+  sensorScope,
+  projectConfigFile,
   GRAPH_SENSORS,
   sensorKind,
   severityGate,
@@ -463,6 +529,12 @@ export default {
   ALLOWED_SCRIPT_RUNTIMES,
   MAX_TIMEOUT_SECONDS,
   DEFAULT_TIMEOUT_SECONDS,
+  TOOL_UNAVAILABLE_EXIT,
+  SENSOR_VERDICT_MODES,
+  SENSOR_SCOPES,
+  sensorVerdictMode,
+  sensorScope,
+  projectConfigFile,
   GRAPH_SENSORS,
   sensorKind,
   severityGate,


### PR DESCRIPTION
## Problem

On a real deployment, the advisory `linter` and `type-check` sensors reported **FAIL for every file** on an `infrastructure-design` stage — a stage that writes methodology artifacts to Neptune and no code to disk. Each file entry looked like:

```json
{ "file": "packages/api/vitest.config.ts", "result": "FAIL", "detail": null, "timedOut": false }
```

~40 files, all FAIL, `detail: null`. A 100% failure rate across config and test-setup files in two different packages is not 40 independent genuine findings. Three distinct defects combined to produce it.

### 1. Sensors were graded on files the stage never touched

`runScriptSensor` globbed the **whole checkout**, so a design stage matched `.ts` files left behind by an earlier code-generation stage and spawned the type-checker once per file. The stage was judged on code it never wrote.

### 2. Exit `127` (tool unresolvable) mapped to FAIL

The per-sensor scripts probe their tool at startup and exit `127` on any non-zero probe — `bunx <tool>` returns assorted non-127 codes for network-fetch / package-resolution / registry-timeout failures, so the scripts normalise to 127 themselves. Upstream a dispatcher branch reclassified that to a tool-unavailable note; the reclassification was dropped when the dispatcher was reimplemented as `resultFromExit`. The result enum's own comment reserves `INCONCLUSIVE` for exactly this case ("tool unavailable"), so this was a straightforward miss.

### 3. Any non-zero exit mapped to FAIL, and `stderr` was discarded

`bun`/`node` sensors carry their verdict in stdout JSON at exit 0, so a genuine lint/type defect **always** exits 0 with `{"pass": false}`. Any non-zero exit is therefore a script/tool error, never a code verdict. Worse, `runChild` captured `stderr` and then threw it away — `resultFromScript` returned only `{result, detail}` — so these failures were undiagnosable from the persisted `SensorRun` row once the container was gone.

## Change

- **Scope script sensors to the files the stage changed**, using the list the git engine already captures in `commitAll` (`status --porcelain` before staging). `null` = unknown provenance, inspect everything (never silently skip a check); `[]` = nothing changed on disk. Matching is suffix-tolerant because the engine reports repo-relative paths while `listFiles` reports workspace-relative ones, which differ on a multi-repo checkout.
- **`127` maps to `INCONCLUSIVE`** in `resultFromExit`, via a named `TOOL_UNAVAILABLE_EXIT` constant.
- **Non-zero exit with no stdout verdict maps to `INCONCLUSIVE`** (`reason: "script-error"`) for `bun`/`node` runtimes. `sh` keeps the exit-code convention, since a shell sensor legitimately signals failure that way.
- **Retain `exitCode` and a tail-truncated `stderr`** on every non-PASS file entry. Truncated from the tail because the interpreter's real error is the last thing written, and budgeted at 500 chars per file so a wide glob cannot approach the DynamoDB item ceiling.
- **Fix the worst-result aggregation**: with the new mapping an all-INCONCLUSIVE fan-out would have aggregated to `PASS` — a false green strictly worse than the original FAIL.

## Testing

- `sensor-runner.test.js`, `run-stage.test.js`, `v2-sensor-contract.test.js`: **197 passed**
- New tests cover: 127 to tool-unavailable, exits 1/3/66 to script-error, `sh` exit 1 still FAIL, null exit still BLOCKED, tail truncation preserving the real error, suffix vs partial-segment matching, and an end-to-end test reproducing the exact production shape (every file exits non-zero with no stdout, yielding INCONCLUSIVE rather than FAIL)
- A companion test asserts a **real** defect (exit 0 with `pass:false`) is still reported as FAIL, so genuine findings are not masked
- `oxlint` clean, `oxfmt --check` clean

Verified live after deploying to a dev environment:

```
linter     -> INCONCLUSIVE  {"reason":"no changed files match","globbed":55,"changed":0}
type-check -> INCONCLUSIVE  {"reason":"no changed files match","globbed":68,"changed":0}
```

68 files globbed, 0 changed — previously all 68 were spawned against and reported FAIL. And on a stage that *did* change code, the 127 path fired for real and is now diagnosable from the row alone:

```
linter     -> INCONCLUSIVE  {"reason":"tool-unavailable","exitCode":"127","stderr":"eslint-unavailable"}
type-check -> INCONCLUSIVE  {"reason":"tool-unavailable","exitCode":"127","stderr":"tsc-unavailable"}
```

## Follow-up (not in this PR)

Those 127s are honest, but they do mean the code-quality axis is currently inert on code stages: `bunx eslint` and `bunx tsc` cannot resolve without the checkout's dependencies installed, which the runtime deliberately avoids for inode-budget reasons. Worth a separate discussion — `type-check` arguably belongs in CI on the pushed branch (`tsc` genuinely needs installed types to be meaningful), while `linter` could move to a zero-dependency single binary such as `oxlint`, which this repo already depends on.

## Notes

Rebased onto latest `main` (`b9ab0b6`).

I confirm the licensing of this contribution under the repository's MIT-0 license.
