### PR TITLE
fix(husky): make dependency audits non-fatal in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,7 +17,7 @@ fi
 # SCA on production deps. Root deps come with `npm install`, so this always
 # runs. Frontend has its own package.json outside workspaces — skip silently
 # if its node_modules don't exist.
-# Audit failures are advisory here; CI remains the enforcement layer.
+# Audit failures are advisory in this local hook; findings remain visible.
 if ! npm audit --omit=dev --audit-level=high; then
   echo "npm audit reported high-severity findings; continuing commit."
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,9 +17,14 @@ fi
 # SCA on production deps. Root deps come with `npm install`, so this always
 # runs. Frontend has its own package.json outside workspaces — skip silently
 # if its node_modules don't exist.
-npm audit --omit=dev --audit-level=high
+# Audit failures are advisory here; CI remains the enforcement layer.
+if ! npm audit --omit=dev --audit-level=high; then
+  echo "npm audit reported high-severity findings; continuing commit."
+fi
 if [ -d frontend/node_modules ]; then
-  npm --prefix frontend audit --omit=dev --audit-level=high
+  if ! npm --prefix frontend audit --omit=dev --audit-level=high; then
+    echo "frontend npm audit reported high-severity findings; continuing commit."
+  fi
 fi
 
 # Frontend type-check: only if frontend TS/TSX is staged AND deps are installed.


### PR DESCRIPTION
## Problem

The pre-commit hook runs both production dependency audits under `set -e`. The frontend audit now exits non-zero for GHSA-qwww-vcr4-c8h2, so contributors cannot commit locally without bypassing the hook. The advisory was published after an unchanged commit began failing, making the hook dependent on runtime advisory data.

## Change

Keep both audit commands and their reports visible, but treat their exit status as advisory in the local hook. The repository's existing CI checks and Dependabot security-update automation remain unchanged; this PR does not claim that CI runs `npm audit` as a blocking check.

The advisory is not clearable with a safe patch on the current React Router 7.x line:

- The affected range is `>=7.12.0, <8.3.0`, with the first patched version at `8.3.0`.
- `react-router-dom@7.18.2` pins `react-router` to exactly `7.18.2`; reaching `8.3.0` requires a major migration, which is out of scope here. `npm audit fix --force` proposes the unrelated downgrade to `react-router-dom@7.11.0`.

This PR fixes the local hook blockage only. The underlying advisory and the future React Router migration remain tracked in #367.

Refs #367
