### PR TITLE
chore: upgrade to React Router 8

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,6 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@radix-ui/react-visually-hidden": "^1.2.4",
         "@tailwindcss/typography": "^0.5.19",
-        "@types/react-router-dom": "^5.3.3",
         "aws-amplify": "^6.17.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -41,7 +40,7 @@
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.11.2",
-        "react-router-dom": "^7.18.1",
+        "react-router": "^8.3.0",
         "react-syntax-highlighter": "^16.1.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.6.0",
@@ -67,6 +66,9 @@
         "typescript": "~6.0.3",
         "vite": "^8.0.16",
         "vitest": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=22.22.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4080,12 +4082,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4140,27 +4136,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-syntax-highlighter": {
@@ -4705,18 +4680,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
@@ -7648,41 +7616,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -7923,12 +7874,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/siginfo": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,6 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "@tailwindcss/typography": "^0.5.19",
-    "@types/react-router-dom": "^5.3.3",
     "aws-amplify": "^6.17.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -50,7 +49,7 @@
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.11.2",
-    "react-router-dom": "^7.18.1",
+    "react-router": "^8.3.0",
     "react-syntax-highlighter": "^16.1.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",
@@ -76,5 +75,8 @@
     "typescript": "~6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
+  },
+  "engines": {
+    "node": ">=22.22.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import {
   Navigate,
   useLocation,
   useParams,
-} from 'react-router-dom';
+} from 'react-router';
 import { AuthProvider } from './contexts/AuthContext';
 import { ThemeProvider } from './components/theme/ThemeProvider';
 import { ProtectedRoute } from './components/ProtectedRoute';

--- a/frontend/src/components/OAuthCallbackShell.tsx
+++ b/frontend/src/components/OAuthCallbackShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 type Status = 'loading' | 'success' | 'error' | 'custom';
 

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 import { useAuth } from '../contexts/AuthContext';
 
 interface ProtectedRouteProps {

--- a/frontend/src/components/TrackerIssueListPanel.tsx
+++ b/frontend/src/components/TrackerIssueListPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';

--- a/frontend/src/components/admin/tabs/TrackersTab.tsx
+++ b/frontend/src/components/admin/tabs/TrackersTab.tsx
@@ -4,7 +4,7 @@
 // pointing at the Source Control tab. Tracker data migration lives at the
 // bottom.
 
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ArrowRight, Link2 } from 'lucide-react';
 import { getTrackerProvider } from '@/lib/trackerProviders';

--- a/frontend/src/components/discussion/DiscussionProvider.test.tsx
+++ b/frontend/src/components/discussion/DiscussionProvider.test.tsx
@@ -4,8 +4,8 @@ import { render, screen } from '@testing-library/react';
 const listMembers = vi.hoisted(() => vi.fn());
 const listDiscussions = vi.hoisted(() => vi.fn());
 
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
   return {
     ...actual,
     useParams: () => ({ projectId: 'project-1', intentId: 'intent-1' }),

--- a/frontend/src/components/discussion/DiscussionProvider.tsx
+++ b/frontend/src/components/discussion/DiscussionProvider.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 import type { ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { discussionsService } from '@/services/discussions';
 import type { Discussion, DiscussionEntityType, DiscussionScope } from '@/services/discussions';
 import { projectsService } from '@/services/projects';

--- a/frontend/src/components/intent/GateCard.tsx
+++ b/frontend/src/components/intent/GateCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { GateAnswer, IntentGate } from '@/services/intents';
 import { useIntent } from '@/contexts/IntentContext';
 import QuestionEditor from '@/components/QuestionEditor';

--- a/frontend/src/components/layout/ActivityPanel.tsx
+++ b/frontend/src/components/layout/ActivityPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { X, Bot, Clock, ChevronDown, Wrench, Check, AlertTriangle, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { formatTimelineTimestamp } from '@/lib/timeAgo';

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router';
 import {
   PanelLeftClose,
   PanelLeftOpen,

--- a/frontend/src/components/layout/AppShell.test.tsx
+++ b/frontend/src/components/layout/AppShell.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 import { shouldDefaultOpen } from './AppShell';
 

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useParams, useLocation } from 'react-router-dom';
+import { Outlet, useParams, useLocation } from 'react-router';
 import { cn } from '@/lib/utils';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { AppSidebar } from '@/components/layout/AppSidebar';

--- a/frontend/src/components/layout/AppSidebar.test.tsx
+++ b/frontend/src/components/layout/AppSidebar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({ isPlatformAdmin: false }),

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { useNavigate, useLocation, useParams } from 'react-router';
 import { useMemo, useState } from 'react';
 import {
   Activity,

--- a/frontend/src/components/layout/CommandPalette.tsx
+++ b/frontend/src/components/layout/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useEffect, useCallback } from 'react';
 import {
   CommandDialog,

--- a/frontend/src/components/layout/IntentPipelineBar.test.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.test.tsx
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return { ...actual, useNavigate: () => vi.fn() };
 });
 

--- a/frontend/src/components/layout/IntentPipelineBar.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { CheckCircle2, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Progress } from '@/components/ui/progress';

--- a/frontend/src/components/layout/SprintLayout.tsx
+++ b/frontend/src/components/layout/SprintLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { SprintProvider } from '@/contexts/SprintContext';
 
 /**

--- a/frontend/src/components/layout/SprintPipelineBar.tsx
+++ b/frontend/src/components/layout/SprintPipelineBar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { useNavigate, useLocation, useParams } from 'react-router';
 import { useEffect, useState, useCallback } from 'react';
 import {
   ArrowLeft,

--- a/frontend/src/components/observability/IntentStatusCards.tsx
+++ b/frontend/src/components/observability/IntentStatusCards.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
 import { Loader2, MessageCircleQuestion, CheckCircle2, XCircle } from 'lucide-react';

--- a/frontend/src/contexts/IntentContext.test.tsx
+++ b/frontend/src/contexts/IntentContext.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, act, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 // Capture the realtime callback so tests can push events into the provider.
 let capturedOnEvent: ((e: Record<string, unknown>) => void) | null = null;

--- a/frontend/src/contexts/IntentContext.tsx
+++ b/frontend/src/contexts/IntentContext.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from 'react';
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   intentsService,
   type GateAnswer,

--- a/frontend/src/contexts/SprintContext.tsx
+++ b/frontend/src/contexts/SprintContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import type { ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type { Sprint } from '@/services/sprints';
 import type { Requirement } from '@/services/requirements';
 import type { UserStory } from '@/services/userStories';

--- a/frontend/src/hooks/useQuestionAnchor.ts
+++ b/frontend/src/hooks/useQuestionAnchor.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router';
 import { scrollToQuestion, questionAnchorId } from '@/lib/questionAnchor';
 
 /**

--- a/frontend/src/pages/AgentPage.tsx
+++ b/frontend/src/pages/AgentPage.tsx
@@ -9,7 +9,7 @@ import { AgentStatusBadge } from '@/components/domain/AgentStatusBadge';
 import { AgentStreamPanel } from '@/components/AgentStreamPanel';
 import { TimelinePanel } from '@/components/TimelinePanel';
 import { Bot, ArrowLeft, MessageCircleQuestion } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/frontend/src/pages/AuthCallback.test.tsx
+++ b/frontend/src/pages/AuthCallback.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import {
   SsoAccessDeniedError,
   SsoLoginTimeoutError,

--- a/frontend/src/pages/AuthCallback.tsx
+++ b/frontend/src/pages/AuthCallback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { Loader2, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';

--- a/frontend/src/pages/BlockEditor.tsx
+++ b/frontend/src/pages/BlockEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import {
   blocksService,
   BLOCK_TYPES,

--- a/frontend/src/pages/BlockLibrary.tsx
+++ b/frontend/src/pages/BlockLibrary.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import {
   blocksService,
   BLOCK_TYPES,

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 
 vi.mock('@/services/projects', () => ({
   projectsService: { list: vi.fn().mockResolvedValue([]) },

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { projectsService } from '@/services/projects';
 import { useProjectsCache, projectLastActivityAt } from '@/hooks/useProjectsCache';
 import { CreateProjectModal } from '@/components/CreateProjectModal';

--- a/frontend/src/pages/GitOAuthCallback.tsx
+++ b/frontend/src/pages/GitOAuthCallback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { OAuthCallbackShell } from '@/components/OAuthCallbackShell';
 import { getTrackerProvider } from '@/lib/trackerProviders';
 

--- a/frontend/src/pages/IntentAuditPage.tsx
+++ b/frontend/src/pages/IntentAuditPage.tsx
@@ -8,7 +8,7 @@
 // from IntentContext, the audit DTO fetched lazily with a tiny module cache.
 
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useIntent } from '@/contexts/IntentContext';
 import { intentsService, type IntentAudit } from '@/services/intents';
 import { useProjectCache } from '@/hooks/useProjectsCache';

--- a/frontend/src/pages/IntentComposePage.test.tsx
+++ b/frontend/src/pages/IntentComposePage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 beforeEach(() => {
   window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);

--- a/frontend/src/pages/IntentComposePage.tsx
+++ b/frontend/src/pages/IntentComposePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useAuth } from '@/contexts/AuthContext';
 import { useIntent } from '@/contexts/IntentContext';
 import { useProjectCache } from '@/hooks/useProjectsCache';

--- a/frontend/src/pages/IntentNavigation.test.tsx
+++ b/frontend/src/pages/IntentNavigation.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 
 vi.mock('@/hooks/useIntentEvents', () => ({ useIntentEvents: () => {} }));
 vi.mock('@/contexts/AuthContext', () => ({

--- a/frontend/src/pages/IntentObservabilityPage.test.tsx
+++ b/frontend/src/pages/IntentObservabilityPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 vi.mock('@/hooks/useIntentEvents', () => ({ useIntentEvents: () => {} }));
 vi.mock('@/contexts/AuthContext', () => ({

--- a/frontend/src/pages/IntentObservabilityPage.tsx
+++ b/frontend/src/pages/IntentObservabilityPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useIntent, stageRowKey, type IntentStageRow } from '@/contexts/IntentContext';
 import type { StageState } from '@/services/intents';
 import type { CompiledWorkflow } from '@/services/workflows';

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 const yjsMock = vi.hoisted(() => ({ docs: new Map<string, unknown>() }));
 const projectCacheMock = vi.hoisted(() => ({ role: 'owner' as 'owner' | 'admin' | 'member' }));

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Navigate, useNavigate, useParams } from 'react-router';
 import { intentsService } from '@/services/intents';
 import { useIntent } from '@/contexts/IntentContext';
 import { useAuth } from '@/contexts/AuthContext';

--- a/frontend/src/pages/JiraCallback.tsx
+++ b/frontend/src/pages/JiraCallback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { trackersService, type JiraPendingChoice } from '@/services/trackers';
 import { OAuthCallbackShell } from '@/components/OAuthCallbackShell';
 import { getTrackerProvider } from '@/lib/trackerProviders';

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { AuthMode, SsoProvider } from '@/services/auth';
 
 const mocks = vi.hoisted(() => ({

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 import { useAuth } from '@/contexts/AuthContext';
 import { authConfiguration } from '@/services/auth';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';

--- a/frontend/src/pages/NewIntentPage.test.tsx
+++ b/frontend/src/pages/NewIntentPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 // Radix Select relies on pointer-capture / scrollIntoView APIs jsdom doesn't
 // implement — polyfill just enough for the trigger/option interaction below.

--- a/frontend/src/pages/NewIntentPage.tsx
+++ b/frontend/src/pages/NewIntentPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useProjectCache } from '@/hooks/useProjectsCache';
 import { intentsService } from '@/services/intents';
 import { trackersService, type TrackerIssue } from '@/services/trackers';

--- a/frontend/src/pages/ObservabilityLayout.tsx
+++ b/frontend/src/pages/ObservabilityLayout.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useMemo, useEffect, useCallback } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useObservability } from '@/hooks/useObservability';
 import { IterationDetailView } from '@/components/observability/IterationDetailView';
 import ObservabilityDashboard from './ObservabilityDashboard';

--- a/frontend/src/pages/PlatformAdmin.test.tsx
+++ b/frontend/src/pages/PlatformAdmin.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 // The page is exercised with mocked services and stubbed heavy cards — these
 // tests cover PlatformAdmin's OWN logic: tab rendering, URL <-> tab sync, and

--- a/frontend/src/pages/PlatformAdmin.tsx
+++ b/frontend/src/pages/PlatformAdmin.tsx
@@ -14,7 +14,7 @@
 // setting: it is shown on every tab because the canonical hostname it reports
 // is what the OAuth callback URLs on two of them are built from.
 
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { Bot, ClipboardList, GitBranch, Users } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useTrackerProviders } from '@/hooks/useTrackerProviders';

--- a/frontend/src/pages/Project.test.tsx
+++ b/frontend/src/pages/Project.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 const useProjectCache = vi.fn();
 vi.mock('@/hooks/useProjectsCache', () => ({

--- a/frontend/src/pages/Project.tsx
+++ b/frontend/src/pages/Project.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { cn } from '@/lib/utils';
 import { getTimeAgo } from '@/lib/timeAgo';
 import { useProjectCache, useProjectSprintsCache } from '@/hooks/useProjectsCache';

--- a/frontend/src/pages/ProjectSettings.test.tsx
+++ b/frontend/src/pages/ProjectSettings.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 
 // Heavy tab components are stubbed — these tests cover the page's OWN logic:
 // project loading, v2 redirect, tab rendering, and URL <-> tab sync.

--- a/frontend/src/pages/ProjectSettings.tsx
+++ b/frontend/src/pages/ProjectSettings.tsx
@@ -5,7 +5,7 @@
 // between tabs.
 
 import { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router';
 import { projectsService, type Project } from '@/services/projects';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';

--- a/frontend/src/pages/SprintGraph.tsx
+++ b/frontend/src/pages/SprintGraph.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { sprintGraphService, type GraphNode, type GraphEdge } from '@/services/sprintGraph';
 import { useSprint } from '@/contexts/SprintContext';
 import { GraphCanvas } from '@/components/graph/GraphCanvas';

--- a/frontend/src/pages/WorkflowComposer.tsx
+++ b/frontend/src/pages/WorkflowComposer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import {
   workflowsService,
   type Workflow,

--- a/frontend/src/pages/WorkflowList.tsx
+++ b/frontend/src/pages/WorkflowList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   workflowsService,
   type WorkflowSummary,

--- a/frontend/src/pages/composer/BlockPalette.tsx
+++ b/frontend/src/pages/composer/BlockPalette.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/frontend/src/pages/composer/StageEditModal.tsx
+++ b/frontend/src/pages/composer/StageEditModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   Dialog,
   DialogContent,


### PR DESCRIPTION
## Summary

- replace `react-router-dom` 7.x with `react-router` 8.3.0
- remove the obsolete `@types/react-router-dom` dependency
- migrate application and test imports to the React Router 8 entry point
- declare the new Node.js minimum of 22.22.0
- regenerate the frontend lockfile

## Verification

- `npm run typecheck`
- `npm test` (69 files, 452 tests)
- `npm run build`
- `npm run lint`
- `npm run format:check`
- repository pre-commit suite (121 files, 2,411 tests)

This is stacked on #366 and targets `feat/enterprise-sso` to keep the change isolated from the SSO work.

Closes #373