### PR TITLE
fix(orchestrator): reconcile crashed stage rows

### DIFF
--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -226,6 +226,45 @@ describe('createProcessStore', () => {
     expect(input.UpdateExpression).not.toContain('parkedAt');
   });
 
+  it('failRunningStageAttempt conditionally fails only its callback-owned RUNNING row', async () => {
+    ddb.on(UpdateCommand).resolves({ Attributes: { state: 'FAILED' } });
+    const result = await store.failRunningStageAttempt({
+      executionId: 'e1',
+      stageInstanceId: 'si-1',
+      stageCallbackId: 'cb-1',
+      runtimeError: 'stage_callback_failed',
+    });
+    expect(result).toEqual({ state: 'FAILED' });
+    const input = ddb.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.ConditionExpression).toBe(
+      'attribute_exists(pk) AND #state = :running AND stageCallbackId = :callbackId',
+    );
+    expect(input.ExpressionAttributeValues).toMatchObject({
+      ':running': 'RUNNING',
+      ':failed': 'FAILED',
+      ':callbackId': 'cb-1',
+      ':ts': 'T',
+      ':err': 'stage_callback_failed',
+    });
+    expect(input.ExpressionAttributeValues[':g2sk']).toBe(
+      executionTypeStateIndex({ executionId: 'e1', type: 'STAGE', state: 'FAILED', id: 'si-1' })
+        .GSI2SK,
+    );
+  });
+
+  it('failRunningStageAttempt returns null when a retry or terminal state wins the race', async () => {
+    ddb
+      .on(UpdateCommand)
+      .rejects(Object.assign(new Error('cas'), { name: 'ConditionalCheckFailedException' }));
+    await expect(
+      store.failRunningStageAttempt({
+        executionId: 'e1',
+        stageInstanceId: 'si-1',
+        stageCallbackId: 'stale-callback',
+      }),
+    ).resolves.toBeNull();
+  });
+
   it('resumeStageRow folds the open park window into waitMs, clears parkedAt, preserves startedAt/attempt', async () => {
     // A resume PATCHES the parked row — rebuilding it (putStage) was the
     // "stage duration resets when a question is answered" bug.

--- a/lambda/shared/v2-process-store.js
+++ b/lambda/shared/v2-process-store.js
@@ -447,6 +447,52 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     return Attributes;
   };
 
+  // Reconcile a detached stage job that the orchestrator has declared failed.
+  // The callback id is the attempt ownership token: a delayed callback timeout
+  // from an older attempt must never overwrite a retry/resume that has already
+  // refreshed the row. Returning null means the row was absent, terminal, or
+  // owned by a different callback.
+  const failRunningStageAttempt = async ({
+    executionId,
+    stageInstanceId,
+    stageCallbackId,
+    runtimeError = 'stage_failed',
+  }) => {
+    if (!stageCallbackId) throw new Error('failRunningStageAttempt requires stageCallbackId');
+    const ts = now();
+    try {
+      const { Attributes } = await ddb.send(
+        new UpdateCommand({
+          TableName: table(),
+          Key: stageKey(executionId, stageInstanceId),
+          ConditionExpression:
+            'attribute_exists(pk) AND #state = :running AND stageCallbackId = :callbackId',
+          UpdateExpression:
+            'SET #state = :failed, updatedAt = :ts, completedAt = :ts, GSI2SK = :g2sk, runtimeError = :err',
+          ExpressionAttributeNames: { '#state': 'state' },
+          ExpressionAttributeValues: {
+            ':running': 'RUNNING',
+            ':failed': 'FAILED',
+            ':callbackId': stageCallbackId,
+            ':ts': ts,
+            ':g2sk': executionTypeStateIndex({
+              executionId,
+              type: 'STAGE',
+              state: 'FAILED',
+              id: stageInstanceId,
+            }).GSI2SK,
+            ':err': runtimeError,
+          },
+          ReturnValues: 'ALL_NEW',
+        }),
+      );
+      return Attributes;
+    } catch (error) {
+      if (error?.name === 'ConditionalCheckFailedException') return null;
+      throw error;
+    }
+  };
+
   // Flip a parked stage (WAITING_FOR_HUMAN) back to RUNNING on resume WITHOUT
   // rebuilding the row: startedAt and attempt are preserved (the wall-clock
   // duration spans the whole stage including waits), the open park window
@@ -2182,6 +2228,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     putStage,
     getStage,
     updateStageState,
+    failRunningStageAttempt,
     resumeStageRow,
     appendEvent,
     listEvents,

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -694,6 +694,11 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         stage,
         unitSlug,
         sectionIndex,
+        stageInstanceId: unitSlug
+          ? planStageInstanceId(namespace, stage.stageId, unitSlug, sectionIndex)
+          : (stage.stageInstanceId ??
+            planStageInstanceId(namespace, stage.stageId, unitSlug, sectionIndex)),
+        store,
         suffix,
         ids: { projectId, intentId, executionId },
         workflowId,
@@ -1442,6 +1447,11 @@ const runStage = async (
     cloneInputs,
     resumeFrom,
     reviewFeedback = null,
+    // Expected process-row identity for this attempt. The orchestrator already
+    // has the resolved plan, so it can reconcile a dead worker even when no
+    // callback result arrives to report the id.
+    stageInstanceId,
+    store,
   },
 ) => {
   // The attempt key names every durable identity for this stage attempt. It
@@ -1458,6 +1468,19 @@ const runStage = async (
     timeout: STAGE_CALLBACK_TIMEOUT,
     heartbeatTimeout: STAGE_CALLBACK_HEARTBEAT_TIMEOUT,
   });
+
+  const reconcileFailure = async (result) => {
+    if (result?.state !== 'FAILED' || !stageInstanceId) return result;
+    await ctx.step(`reconcile-stage-${attemptKey}`, () =>
+      store.failRunningStageAttempt({
+        executionId: ids.executionId,
+        stageInstanceId,
+        stageCallbackId,
+        runtimeError: result.reason ?? 'stage_failed',
+      }),
+    );
+    return result;
+  };
 
   const dispatch = await ctx.step(`run-${attemptKey}`, async () =>
     invokeRuntime(
@@ -1505,12 +1528,12 @@ const runStage = async (
   // an old container, duplicate job, missing fields) fails the stage HERE; the
   // verdict for an accepted job always travels through the callback.
   if (!dispatch || dispatch.ok === false || dispatch.error) {
-    return {
+    return reconcileFailure({
       ok: false,
       state: 'FAILED',
       reason: dispatch?.reason ?? 'stage_dispatch_failed',
       detail: dispatch?.detail ?? dispatch?.error ?? null,
-    };
+    });
   }
 
   try {
@@ -1521,25 +1544,29 @@ const runStage = async (
     const raw = await stageDone;
     const result = typeof raw === 'string' ? JSON.parse(raw) : raw;
     if (!result || typeof result !== 'object') {
-      return { ok: false, state: 'FAILED', reason: 'stage_bad_callback_result' };
+      return reconcileFailure({
+        ok: false,
+        state: 'FAILED',
+        reason: 'stage_bad_callback_result',
+      });
     }
-    return result;
+    return reconcileFailure(result);
   } catch (err) {
     if (err instanceof SyntaxError) {
-      return {
+      return reconcileFailure({
         ok: false,
         state: 'FAILED',
         reason: 'stage_bad_callback_result',
         detail: err.message,
-      };
+      });
     }
     // Callback timeout / heartbeat expiry (dead container) / explicit failure.
-    return {
+    return reconcileFailure({
       ok: false,
       state: 'FAILED',
       reason: 'stage_callback_failed',
       detail: err?.message ?? String(err),
-    };
+    });
   }
 };
 

--- a/lambda/v2-orchestrator/test/orchestrator-replay.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator-replay.test.js
@@ -69,6 +69,7 @@ const makeWorld = ({ stages = [{ stageId: 'a' }, { stageId: 'b' }] } = {}) => {
     invokes: [],
     events: [],
     statusWrites: [],
+    failedStageAttempts: [],
   };
   world.deps = {
     store: {
@@ -86,6 +87,10 @@ const makeWorld = ({ stages = [{ stageId: 'a' }, { stageId: 'b' }] } = {}) => {
       appendEvent: async (e) => {
         world.events.push(e.type);
         return {};
+      },
+      failRunningStageAttempt: async (input) => {
+        world.failedStageAttempts.push(input);
+        return null;
       },
     },
     loadPlan: async () => ({ valid: true, plan: { stages } }),
@@ -178,7 +183,7 @@ describe('orchestrator on the real durable runner (replay semantics)', () => {
   });
 
   it('a stage verdict of FAILED delivered through the callback fails the run after replay', async () => {
-    const world = makeWorld({ stages: [{ stageId: 'a' }] });
+    const world = makeWorld({ stages: [{ stageId: 'a', stageInstanceId: 'si-a' }] });
     const handler = withDurableExecution((event, ctx) => __durableHandler(event, ctx, world.deps));
     const runner = new LocalDurableTestRunner({ handlerFunction: handler });
 
@@ -199,6 +204,15 @@ describe('orchestrator on the real durable runner (replay semantics)', () => {
     expect(world.events).toContain('v2.execution.failed');
     // Only one dispatch — the failure verdict was not retried implicitly.
     expect(world.invokes.filter((p) => p.command === 'run-stage-start')).toHaveLength(1);
+    // The callback-owned reconciliation is checkpointed exactly once across replay.
+    expect(world.failedStageAttempts).toEqual([
+      {
+        executionId: 'i1',
+        stageInstanceId: 'si-a',
+        stageCallbackId: expect.any(String),
+        runtimeError: 'sensor_blocked',
+      },
+    ]);
   });
 
   it('a cancel sentinel on the gate callback retires the run without terminal writes', async () => {

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -115,6 +115,7 @@ beforeEach(() => {
       // Default: gate is answered (not pending) by the time we re-read it.
       getHumanTask: vi.fn(async () => ({ status: 'answered' })),
       appendEvent: vi.fn(async () => ({})),
+      failRunningStageAttempt: vi.fn(async () => null),
       listUnits: vi.fn(async () => []),
       getUnit: vi.fn(async () => null),
     },
@@ -522,9 +523,12 @@ describe('orchestrator durable handler', () => {
   });
 
   it('fails the execution when a stage fails (verdict via callback)', async () => {
-    deps.loadPlan.mockResolvedValue({ valid: true, plan: { stages: [{ stageId: 'a' }] } });
+    deps.loadPlan.mockResolvedValue({
+      valid: true,
+      plan: { stages: [{ stageId: 'a', stageInstanceId: 'si-a' }] },
+    });
     deps.invokeRuntime = makeRuntime(ctx, (payload, n) =>
-      n === 1 ? { ok: true } : { ok: false, state: 'FAILED', reason: 'sensor_blocked' },
+      n === 1 ? { ok: true } : { ok: false, state: 'FAILED', reason: 'stage_job_crashed' },
     );
     const res = await __durableHandler(
       { action: 'start', intentId: 'i1', executionId: 'i1' },
@@ -534,6 +538,12 @@ describe('orchestrator durable handler', () => {
     expect(res.ok).toBe(false);
     expect(res.reason).toBe('stage_failed');
     expect(deps.store.updateExecution.mock.calls.map((c) => c[0].status)).toContain('FAILED');
+    expect(deps.store.failRunningStageAttempt).toHaveBeenCalledWith({
+      executionId: 'i1',
+      stageInstanceId: 'si-a',
+      stageCallbackId: 'cb-stage-cb-a',
+      runtimeError: 'stage_job_crashed',
+    });
   });
 
   it('fails the stage when the container REFUSES the dispatch (accept-time failure)', async () => {
@@ -602,7 +612,10 @@ describe('orchestrator durable handler', () => {
 
   it('fails the stage (not the whole run silently) when the stage callback rejects', async () => {
     // Callback timeout / heartbeat expiry: the container died mid-stage.
-    deps.loadPlan.mockResolvedValue({ valid: true, plan: { stages: [{ stageId: 'a' }] } });
+    deps.loadPlan.mockResolvedValue({
+      valid: true,
+      plan: { stages: [{ stageId: 'a', stageInstanceId: 'si-a' }] },
+    });
     const dead = makeCtx({
       createCallback: async (name) => {
         if (String(name).startsWith('stage-cb-')) {
@@ -625,6 +638,12 @@ describe('orchestrator durable handler', () => {
     expect(res.reason).toBe('stage_failed');
     const failCall = deps.store.updateExecution.mock.calls.find((c) => c[0].status === 'FAILED');
     expect(failCall[0].failureReason).toContain('stage_callback_failed');
+    expect(deps.store.failRunningStageAttempt).toHaveBeenCalledWith({
+      executionId: 'i1',
+      stageInstanceId: 'si-a',
+      stageCallbackId: 'cb-stage-cb-a',
+      runtimeError: 'stage_callback_failed',
+    });
   });
 
   it('emits workspace lifecycle events so init-ws is visible in the feed', async () => {


### PR DESCRIPTION
## Summary

- reconcile terminal stage callback failures into the corresponding process row
- condition the `RUNNING` to `FAILED` transition on `stageCallbackId` ownership so stale callbacks cannot overwrite retries or resumes
- cover explicit worker crashes, callback timeout/heartbeat failure, CAS races, and durable replay

## Testing

- `npm test` (120 files, 2,394 tests)
- commit hook targeted suite (11 files, 537 tests)
- `oxfmt --check`
- `oxlint`
- `secretlint`

Closes #377