### PR TITLE
fix(docs): point site_url at the GitHub Pages domain

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 site_name = "AIDLC Collaborative Documentation"
 site_description = "AIDLC Collaborative Workflow"
-site_url = "https://aidlc.dev/"
+site_url = "https://aws-samples.github.io/sample-collaborative-ai-dlc/"
 repo_url = "https://github.com/aws-samples/sample-collaborative-ai-dlc"
 repo_name = "aws-samples/sample-collaborative-ai-dlc"
 


### PR DESCRIPTION
zensical.toml still declared https://aidlc.dev/ as the canonical site URL, so every canonical link and sitemap entry on the docs site pointed at that unrelated domain. This sets the GitHub Pages URL the site is actually served from.

Only occurrence in the repo (checked toml/md/yml/json/html). Follow-up flagged in #382 review.