### PR TITLE
ci(docs): queue Pages deploys instead of cancelling, extend deploy timeout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -52,3 +52,5 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          timeout: 1800000


### PR DESCRIPTION
Today's docs deploys on main failed (run 31105206015, 4 attempts). Root cause analysis:

1. #383 merged at 13:15 UTC, #382 merged 74 seconds later. With `cancel-in-progress: true`, the second run killed the first Pages deployment mid-flight ("higher priority waiting request for pages exists").
2. That mid-flight cancellation wedged the Pages deployment queue: the next attempt sat in `deployment_queued` for the full 10-minute timeout, and retries were cancelled server-side within seconds.
3. After cancelling the stale deployment via the API and re-running, the deploy progressed normally (`deployment_in_progress`) but exceeded the action's 10-minute default timeout — GitHub Pages is degraded today (actions/deploy-pages#406).

Two changes to `.github/workflows/docs.yml`:

- `cancel-in-progress: false` — new runs queue behind an active deployment instead of killing it. Matches GitHub's official Pages starter workflow. The build job stays fast; only the deploy is serialized.
- `timeout: 1800000` (30 min) on `actions/deploy-pages` — survives slow Pages backend days instead of failing a healthy deployment.

The docs build itself never failed; content is unaffected. After merge, this workflow run will also publish the pending #383 `site_url` fix.