### PR TITLE
ci: enable ARM64 emulation for demo deploy

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -82,6 +82,10 @@ jobs:
             package-lock.json
             frontend/package-lock.json
 
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: '1.15.0'

--- a/scripts/test/release-tools.test.mjs
+++ b/scripts/test/release-tools.test.mjs
@@ -54,6 +54,8 @@ test('release deployment uses the protected demo environment and GitHub OIDC', (
   assert.match(deployment, /TF_ENVIRONMENT: prod/);
   assert.match(deployment, /role-to-assume: \$\{\{ vars\.AWS_ROLE_ARN \}\}/);
   assert.match(deployment, /TF_STATE_BUCKET: \$\{\{ vars\.TF_STATE_BUCKET \}\}/);
+  assert.match(deployment, /docker\/setup-qemu-action@[0-9a-f]{40}/);
+  assert.match(deployment, /platforms: arm64/);
   assert.match(deployment, /deploy-terraform\.sh "\$TF_ENVIRONMENT"/);
   assert.match(deployment, /deploy-frontend\.sh "\$TF_ENVIRONMENT"/);
   assert.match(deployment, /git merge-base --is-ancestor "\$tag_commit" "\$main_commit"/);
@@ -63,6 +65,11 @@ test('release deployment uses the protected demo environment and GitHub OIDC', (
     deployment.indexOf('git merge-base --is-ancestor') <
       deployment.indexOf('aws-actions/configure-aws-credentials'),
     'release ancestry must be verified before AWS credentials are configured',
+  );
+  assert.ok(
+    deployment.indexOf('docker/setup-qemu-action') <
+      deployment.indexOf('deploy-terraform.sh "$TF_ENVIRONMENT"'),
+    'ARM64 emulation must be configured before Terraform builds the AgentCore image',
   );
 });
 


### PR DESCRIPTION
Configure QEMU ARM64 emulation before Terraform builds the AgentCore image in the protected demo deployment. Includes regression assertions for action pinning, platform selection, and step ordering.