### PR TITLE
fix: include issue permissions in GitHub App read tokens

### DIFF
--- a/lambda/shared/source-control-credentials.js
+++ b/lambda/shared/source-control-credentials.js
@@ -214,7 +214,12 @@ const resolveBindingCredential = async ({
       repositories: [binding.repo],
       permissions:
         requiredAccess === 'read'
-          ? { contents: 'read', metadata: 'read' }
+          ? {
+              contents: 'read',
+              metadata: 'read',
+              issues: 'read',
+              pull_requests: 'read',
+            }
           : {
               contents: 'write',
               pull_requests: 'write',

--- a/lambda/shared/test/source-control-credentials.test.js
+++ b/lambda/shared/test/source-control-credentials.test.js
@@ -163,6 +163,26 @@ describe('resolveBindingCredential app-binding permission scoping', () => {
     getInstallationToken.mockResolvedValue('ghs_token');
   });
 
+  it('requests issue and pull-request permissions for read operations', async () => {
+    await resolveBindingCredential({
+      ddb: {},
+      ssm: {},
+      secrets: {},
+      binding: { ...base, capabilities: { repositoryWrite: true, workflows: 'none' } },
+      requiredAccess: 'read',
+    });
+    expect(getInstallationToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        permissions: {
+          contents: 'read',
+          metadata: 'read',
+          issues: 'read',
+          pull_requests: 'read',
+        },
+      }),
+    );
+  });
+
   it('omits workflows:write for a binding verified without it', async () => {
     await resolveBindingCredential({
       ddb: {},


### PR DESCRIPTION
## Summary
- include `issues:read` and `pull_requests:read` when minting read-only GitHub App installation tokens
- prevent tracker issue imports from failing with `provider_forbidden` and invalidating an otherwise valid project binding
- add regression coverage for the read permission set

## Testing
- `lambda/shared/test/source-control-credentials.test.js` (12 tests)
- source-control suite (5 tests)
- commit hooks (150 tests)