### PR TITLE
feat: link generated PRs back to AI-DLC intents

### DIFF
--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -49,6 +49,7 @@ import {
   fanoutGateAddendum,
 } from './section.js';
 import { runQuorumEdit } from './quorum-edit.js';
+import { buildIntentAttribution } from './pr-attribution.js';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const lambda = new LambdaClient({});
@@ -904,6 +905,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
       deriveEnrichment,
       prStrategy: meta.prStrategy ?? 'intent-pr',
       unitPrProvider,
+      applicationUrl,
       stageInstanceIdFor: (stageId, slug, sectionIndex = null) =>
         planStageInstanceId(namespace, stageId, slug, sectionIndex),
     };
@@ -1631,13 +1633,13 @@ const validationPrompt = (
 };
 
 // ── WP6: open the fan-in PR(s) (intent-pr strategy) ─────────────────────────
-// One PR per repo from the intent branch onto the base branch. NEVER throws —
-// every outcome (opened / already-open / no-changes / guard-conflict / error)
-// becomes a timeline event the caller records. The PR body carries
-// the execution id and an HONEST unit summary: lanes that were skipped after
-// failure are named, so the reviewer knows what the increment does NOT
-// contain (the human explicitly chose to continue without them — the fan-in
-// gate is the decision record, the PR body is its mirror).
+// One PR per repo from the intent branch onto the base branch. Provider outcomes
+// (opened / already-open / no-changes / guard-conflict / error) become timeline
+// events the caller records. The PR body links back to the intent and carries
+// an HONEST unit summary: lanes that were skipped after failure are named, so
+// the reviewer knows what the increment does NOT contain (the human explicitly
+// chose to continue without them — the fan-in gate is the decision record, the
+// PR body is its mirror).
 const openIntentPrs = async ({
   openPr,
   comparePrBranches = null,
@@ -1702,12 +1704,11 @@ const openIntentPrs = async ({
   }
 
   const title = meta.title || `AI-DLC: ${branch}`;
-  const intentUrl = applicationUrl
-    ? `${applicationUrl.replace(/\/+$/, '')}/space/${encodeURIComponent(
-        meta.projectId,
-      )}/intent/${encodeURIComponent(meta.intentId ?? executionId)}`
-    : null;
-  const aidlcAttribution = intentUrl ? `[AI-DLC](${intentUrl})` : 'AI-DLC';
+  const aidlcAttribution = buildIntentAttribution({
+    applicationUrl,
+    projectId: meta.projectId,
+    intentId: meta.intentId ?? executionId,
+  });
   const body = [
     `Automated ${gitProvider === 'gitlab' ? 'MR' : 'PR'} created by ${aidlcAttribution} (strategy: ${strategy})`,
     ...unitLines,

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -58,6 +58,7 @@ const defaultStore = createProcessStore({ ddb });
 const RUNTIME_ARN = () => process.env.AGENTCORE_RUNTIME_ARN;
 const BLOCKS_TABLE = () => process.env.BLOCKS_TABLE;
 const SOURCE_CONTROL_FN = () => process.env.SOURCE_CONTROL_FUNCTION;
+const APPLICATION_URL = () => process.env.APPLICATION_URL;
 const DURABLE_EXECUTION_TIMEOUT_SECONDS = () =>
   Number(process.env.DURABLE_EXECUTION_TIMEOUT_SECONDS || 31622400);
 const DURABLE_GATE_DEADLINE_MARGIN_SECONDS = () =>
@@ -197,6 +198,7 @@ const defaultDeps = () => ({
       operation: 'compare',
       args: { base, head },
     }),
+  applicationUrl: APPLICATION_URL(),
   unitPrProvider: {
     compare: ({ projectId, gitProvider, repoId, base, head }) =>
       defaultSourceControlOperation({
@@ -287,6 +289,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
     openPr,
     comparePrBranches,
     unitPrProvider,
+    applicationUrl,
   } = deps;
   const { intentId, executionId } = event;
   // Quorum-supported artifact edit (post-hoc document editing): its own small
@@ -1355,6 +1358,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         meta,
         executionId,
         gitProvider,
+        applicationUrl,
         log: (m) => ctx.logger?.info?.(m, { intentId }),
       }),
     );
@@ -1641,6 +1645,7 @@ const openIntentPrs = async ({
   meta,
   executionId,
   gitProvider,
+  applicationUrl,
   log,
 }) => {
   const repos = meta.repos ?? [];
@@ -1697,11 +1702,14 @@ const openIntentPrs = async ({
   }
 
   const title = meta.title || `AI-DLC: ${branch}`;
+  const intentUrl = applicationUrl
+    ? `${applicationUrl.replace(/\/+$/, '')}/space/${encodeURIComponent(
+        meta.projectId,
+      )}/intent/${encodeURIComponent(meta.intentId ?? executionId)}`
+    : null;
+  const aidlcAttribution = intentUrl ? `[AI-DLC](${intentUrl})` : 'AI-DLC';
   const body = [
-    `Automated ${gitProvider === 'gitlab' ? 'MR' : 'PR'} created by AI-DLC (strategy: ${strategy})`,
-    '',
-    `Execution ID: ${executionId}`,
-    `Project: ${meta.projectId}`,
+    `Automated ${gitProvider === 'gitlab' ? 'MR' : 'PR'} created by ${aidlcAttribution} (strategy: ${strategy})`,
     ...unitLines,
   ].join('\n');
 

--- a/lambda/v2-orchestrator/pr-attribution.js
+++ b/lambda/v2-orchestrator/pr-attribution.js
@@ -1,0 +1,6 @@
+export const buildIntentAttribution = ({ applicationUrl, projectId, intentId }) => {
+  const intentUrl = `${applicationUrl.replace(/\/+$/, '')}/space/${encodeURIComponent(
+    projectId,
+  )}/intent/${encodeURIComponent(intentId)}`;
+  return `[AI-DLC](${intentUrl})`;
+};

--- a/lambda/v2-orchestrator/section.js
+++ b/lambda/v2-orchestrator/section.js
@@ -51,6 +51,7 @@
 
 import processKeysPkg from '../shared/v2-process-keys.js';
 import { stageIsNoopForUnit } from '../shared/unit-kind-pruning.js';
+import { buildIntentAttribution } from './pr-attribution.js';
 
 const { CONSTRUCTION_AUTONOMY_MODES } = processKeysPkg;
 
@@ -381,6 +382,7 @@ export const runParallelSection = async (segment, toolkit) => {
     tierModels = null,
     prStrategy = 'intent-pr',
     unitPrProvider = null,
+    applicationUrl,
     runId = null,
     // Derive-time enrichment mode ('off'|'llm'), snapshotted on META — rides
     // the lane derive-artifacts dispatches like the once-per-workflow hook.
@@ -502,8 +504,13 @@ export const runParallelSection = async (segment, toolkit) => {
   const ensureDraftPullRequests = async (laneCtx, slug, unitBranch, rTag) =>
     laneCtx.step(`unit-pr-drafts-${sk}-${slug}${rTag}`, async () => {
       const title = `${slug}: ${toolkit.ids.intentId}`;
+      const aidlcAttribution = buildIntentAttribution({
+        applicationUrl,
+        projectId,
+        intentId,
+      });
       const body = [
-        `AI-DLC unit review for ${slug}`,
+        `${aidlcAttribution} unit review for ${slug}`,
         '',
         `Execution: ${executionId}`,
         `Section: ${segment.index}`,

--- a/lambda/v2-orchestrator/test/orchestrator-replay.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator-replay.test.js
@@ -103,6 +103,7 @@ const makeWorld = ({ stages = [{ stageId: 'a' }, { stageId: 'b' }] } = {}) => {
     resolveToken: async () => 'tok',
     stopSession: async () => ({ stopped: true }),
     broadcast: async () => {},
+    applicationUrl: 'https://aidlc.example.test/',
   };
   return world;
 };

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -128,6 +128,7 @@ beforeEach(() => {
     broadcast: vi.fn(async () => {}),
     openPr: vi.fn(async () => ({ skipped: true, reason: 'no_changes' })),
     comparePrBranches: vi.fn(async () => ({ status: 'unknown' })),
+    applicationUrl: 'https://aidlc.example.test/',
   };
   deps.invokeRuntime = makeRuntime(ctx, okScript);
 });
@@ -1535,6 +1536,9 @@ describe('PR per unit delivery', () => {
     const result = await start();
     expect(result.ok).toBe(true);
     expect(deps.unitPrProvider.createDraft).toHaveBeenCalledOnce();
+    expect(deps.unitPrProvider.createDraft.mock.calls[0][0].body).toContain(
+      '[AI-DLC](https://aidlc.example.test/space/p1/intent/i1) unit review for auth',
+    );
     expect(deps.unitPrProvider.setDraft).toHaveBeenCalledWith(
       expect.objectContaining({ number: 7, draft: false }),
     );

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -2367,6 +2367,7 @@ describe('WP6 — PR opened on SUCCEEDED (intent-pr)', () => {
       { slug: 'auth', state: 'MERGED' },
       { slug: 'billing', state: 'MERGED' },
     ]);
+    deps.applicationUrl = 'https://aidlc.example.test/';
     deps.openPr = vi.fn(async ({ repoId }) => ({
       prUrl: `https://github.com/${repoId}/pull/7`,
       prNumber: 7,
@@ -2383,7 +2384,9 @@ describe('WP6 — PR opened on SUCCEEDED (intent-pr)', () => {
       baseBranch: 'main',
       title: 'Bookstore API',
     });
-    expect(deps.openPr.mock.calls[0][0].body).toContain('Execution ID: i1');
+    expect(deps.openPr.mock.calls[0][0].body).toContain(
+      'created by [AI-DLC](https://aidlc.example.test/space/p1/intent/i1)',
+    );
     expect(deps.openPr.mock.calls[0][0].body).toContain('strategy: intent-pr');
     expect(deps.openPr.mock.calls[0][0].body).toContain('2 total, 2 merged');
     const opened = events().filter((e) => e.type === 'v2.pr.opened');

--- a/lambda/v2-orchestrator/test/section-integration.test.js
+++ b/lambda/v2-orchestrator/test/section-integration.test.js
@@ -286,6 +286,7 @@ const makeWorld = ({ remote, unitPlan, fileFor, beforeStage = null, conflictAgen
     resolveToken: async () => '',
     stopSession: async () => ({ stopped: true }),
     broadcast: async () => {},
+    applicationUrl: 'https://aidlc.example.test/',
   };
   return world;
 };

--- a/lambda/v2-orchestrator/test/stage-skip.test.js
+++ b/lambda/v2-orchestrator/test/stage-skip.test.js
@@ -127,6 +127,7 @@ beforeEach(() => {
     resolveToken: vi.fn(async () => 'tok'),
     stopSession: vi.fn(async () => ({ stopped: true })),
     broadcast: vi.fn(async () => {}),
+    applicationUrl: 'https://aidlc.example.test/',
   };
   deps.invokeRuntime = makeRuntime(ctx, okScript);
 });

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -353,6 +353,7 @@ module "lambda" {
 
   project_name                = var.project_name
   environment                 = var.environment
+  application_url             = local.app_url
   vpc_id                      = module.networking.vpc_id
   private_subnet_ids          = module.networking.private_subnet_ids
   neptune_endpoint            = module.neptune.cluster_endpoint

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -2405,6 +2405,7 @@ module "v2_orchestrator_lambda" {
 
   environment_variables = {
     ENVIRONMENT             = var.environment
+    APPLICATION_URL         = var.application_url
     V2_PROCESS_TABLE        = var.v2_executions_table_name
     BLOCKS_TABLE            = var.blocks_table_name
     AGENTCORE_RUNTIME_ARN   = var.agentcore_runtime_arn

--- a/terraform/modules/api/lambda/variables.tf
+++ b/terraform/modules/api/lambda/variables.tf
@@ -8,6 +8,11 @@ variable "environment" {
   type        = string
 }
 
+variable "application_url" {
+  description = "Canonical public URL for links back to the application"
+  type        = string
+}
+
 variable "vpc_id" {
   description = "VPC ID for Lambda functions"
   type        = string


### PR DESCRIPTION
## Summary
- link the AI-DLC attribution in generated PR and MR bodies back to the originating intent
- pass the canonical application URL to the v2 orchestrator
- remove redundant project and execution ID lines

## Testing
- deployed and verified that generated GitHub PRs link correctly to their AI-DLC intents
- 124 repository hook tests passed
- orchestrator suite: 88 tests passed
- formatting, lint, and secret scanning passed