### PR TITLE
fix(ci): stabilize demo Lambda deployment

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -38,6 +38,9 @@ jobs:
       TF_ENVIRONMENT: prod
       TF_INPUT: 'false'
       TF_IN_AUTOMATION: 'true'
+      # Clean runners do not have archives recorded in remote Terraform state.
+      # Do not turn that expected absence into timestamp-driven Lambda rebuilds.
+      TF_RECREATE_MISSING_LAMBDA_PACKAGE: 'false'
       TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
       TF_STATE_KEY: ${{ vars.TF_STATE_KEY }}
       TF_STATE_REGION: ${{ vars.TF_STATE_REGION }}

--- a/docs/development/demo-deployment.md
+++ b/docs/development/demo-deployment.md
@@ -49,6 +49,13 @@ The workflow generates `prod.tfvars` and `prod.s3.tfbackend` in the runner's
 temporary directory. It never runs `bootstrap.sh` and therefore never creates
 or selects a new state bucket.
 
+The job also sets `TF_RECREATE_MISSING_LAMBDA_PACKAGE=false`. GitHub-hosted
+runners start without the Lambda archives referenced by remote Terraform state;
+the Lambda module otherwise treats every missing local archive as a
+timestamp-driven rebuild. Disabling that clean-workspace trigger keeps Lambda
+source hashes stable between the saved plan and its apply. Source changes still
+produce a new content-addressed archive and deploy normally.
+
 ## Protect release tags
 
 Open **Settings → Rules → Rulesets**, create a tag ruleset for `v*`, and set

--- a/scripts/test/release-tools.test.mjs
+++ b/scripts/test/release-tools.test.mjs
@@ -52,6 +52,7 @@ test('release deployment uses the protected demo environment and GitHub OIDC', (
   assert.match(deployment, /name: demo/);
   assert.match(deployment, /id-token: write/);
   assert.match(deployment, /TF_ENVIRONMENT: prod/);
+  assert.match(deployment, /TF_RECREATE_MISSING_LAMBDA_PACKAGE: 'false'/);
   assert.match(deployment, /role-to-assume: \$\{\{ vars\.AWS_ROLE_ARN \}\}/);
   assert.match(deployment, /TF_STATE_BUCKET: \$\{\{ vars\.TF_STATE_BUCKET \}\}/);
   assert.match(deployment, /docker\/setup-qemu-action@[0-9a-f]{40}/);


### PR DESCRIPTION
## Summary

- disable missing-package recreation on clean GitHub-hosted runners using the Lambda module’s supported CI setting
- document why the setting is required for saved plan/apply deployments
- add a release workflow regression assertion

## Root cause

The Lambda module treats archives that are absent from a clean runner as timestamp-driven rebuilds. During saved-plan apply, the rebuilt archives can produce a different `source_code_hash` from the value in the plan, matching terraform-aws-lambda issue #753.

This PR intentionally performs no Terraform import or other state reconciliation. The two existing Lambda functions missing from remote state require a one-time operator import before the demo deployment is rerun.

## Testing

- `npm run test:release` (45 passed)
- `npm run format:check -- .github/workflows/deploy-demo.yml docs/development/demo-deployment.md scripts/test/release-tools.test.mjs`