### PR TITLE
fix(ci): build Lambda packages before demo plan

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -159,7 +159,65 @@ jobs:
           echo "AIDLC_CONFIG_DIR=$config_dir" >> "$GITHUB_ENV"
           echo "AIDLC_PLAN_FILE=$plan_file" >> "$GITHUB_ENV"
 
+      - name: Prepare Lambda package plans
+        run: |
+          ./scripts/deploy-terraform.sh "$TF_ENVIRONMENT" \
+            --phase plan \
+            --plan-file "$AIDLC_PLAN_FILE"
+
+      - name: Build Lambda packages
+        run: |
+          set -euo pipefail
+
+          package_script="$(
+            find "$PWD/terraform/.terraform/modules" \
+              -type f -name package.py -print -quit
+          )"
+          if [[ -z "$package_script" ]]; then
+            echo "Lambda module package.py was not found after Terraform init." >&2
+            exit 1
+          fi
+
+          mapfile -d '' -t package_plans < <(
+            find "$PWD/terraform/builds" \
+              -maxdepth 1 -type f -name '*.plan.json' -print0
+          )
+          if (( ${#package_plans[@]} == 0 )); then
+            echo "Terraform did not generate any Lambda package plans." >&2
+            exit 1
+          fi
+
+          for package_plan in "${package_plans[@]}"; do
+            relative_plan="builds/$(basename "$package_plan")"
+            echo "Building Lambda package from $relative_plan"
+            (
+              cd terraform
+              python3 "$package_script" build --timestamp 0 "$relative_plan"
+            )
+
+            package_file="$(
+              node -e '
+                const fs = require("node:fs");
+                const plan = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                process.stdout.write(plan.filename);
+              ' "$package_plan"
+            )"
+            if [[ ! -s "terraform/$package_file" ]]; then
+              echo "Lambda package was not created: terraform/$package_file" >&2
+              exit 1
+            fi
+          done
+
+          # The package content hash includes the source directory. Remove
+          # generated bundles so the final plan hashes the clean release source
+          # and resolves to the ZIP files built above.
+          find lambda -mindepth 2 -maxdepth 2 -type d -name .build \
+            -prune -exec rm -rf -- {} +
+          rm -f "$AIDLC_PLAN_FILE"
+
       - name: Plan infrastructure
+        env:
+          AIDLC_SKIP_NPM_CI: '1'
         run: |
           ./scripts/deploy-terraform.sh "$TF_ENVIRONMENT" \
             --phase plan \

--- a/docs/development/demo-deployment.md
+++ b/docs/development/demo-deployment.md
@@ -52,9 +52,15 @@ or selects a new state bucket.
 The job also sets `TF_RECREATE_MISSING_LAMBDA_PACKAGE=false`. GitHub-hosted
 runners start without the Lambda archives referenced by remote Terraform state;
 the Lambda module otherwise treats every missing local archive as a
-timestamp-driven rebuild. Disabling that clean-workspace trigger keeps Lambda
-source hashes stable between the saved plan and its apply. Source changes still
-produce a new content-addressed archive and deploy normally.
+timestamp-driven rebuild.
+
+The workflow uses a draft plan to generate the Lambda module's package plans,
+builds every content-addressed ZIP, removes the generated `lambda/*/.build`
+directories, and then creates the final saved Terraform plan. The final plan
+therefore hashes the clean release source while the referenced ZIPs already
+exist. Apply reuses those exact packages, so neither missing files nor changed
+source hashes can invalidate the saved plan. Source changes still produce and
+deploy new content-addressed archives.
 
 ## Protect release tags
 

--- a/scripts/test/release-tools.test.mjs
+++ b/scripts/test/release-tools.test.mjs
@@ -57,9 +57,12 @@ test('release deployment uses the protected demo environment and GitHub OIDC', (
   assert.match(deployment, /TF_STATE_BUCKET: \$\{\{ vars\.TF_STATE_BUCKET \}\}/);
   assert.match(deployment, /docker\/setup-qemu-action@[0-9a-f]{40}/);
   assert.match(deployment, /platforms: arm64/);
+  assert.match(deployment, /python3 "\$package_script" build --timestamp 0/);
+  assert.match(deployment, /AIDLC_SKIP_NPM_CI: '1'/);
   assert.match(deployment, /deploy-terraform\.sh "\$TF_ENVIRONMENT"/);
   assert.match(deployment, /deploy-frontend\.sh "\$TF_ENVIRONMENT"/);
   assert.match(deployment, /git merge-base --is-ancestor "\$tag_commit" "\$main_commit"/);
+  assert.equal(deployment.match(/--phase plan/g)?.length, 2);
   assert.doesNotMatch(deployment, /inputs\.apply|plan-only/);
   assert.doesNotMatch(deployment, /AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY/);
   assert.ok(
@@ -71,6 +74,15 @@ test('release deployment uses the protected demo environment and GitHub OIDC', (
     deployment.indexOf('docker/setup-qemu-action') <
       deployment.indexOf('deploy-terraform.sh "$TF_ENVIRONMENT"'),
     'ARM64 emulation must be configured before Terraform builds the AgentCore image',
+  );
+  assert.ok(
+    deployment.indexOf('- name: Prepare Lambda package plans') <
+      deployment.indexOf('- name: Build Lambda packages') &&
+      deployment.indexOf('- name: Build Lambda packages') <
+        deployment.indexOf('- name: Plan infrastructure') &&
+      deployment.indexOf('- name: Plan infrastructure') <
+        deployment.indexOf('- name: Apply infrastructure'),
+    'Lambda packages must be built before the final saved plan is applied',
   );
 });
 


### PR DESCRIPTION
## Summary

- run a draft Terraform plan to generate Lambda package build plans
- build every planned Lambda ZIP before creating the final saved plan
- remove generated `.build` directories so the final content hashes match the clean release checkout
- apply only the final plan, with the exact referenced ZIPs already present

## Root cause

Run `31468442283` confirmed that allowing the module to build missing archives during apply changes `source_code_hash` after the saved plan. After the clean-runner trigger transition, run `31471243433` confirmed the inverse failure: suppressing archive recreation leaves the planned Lambda ZIP files absent when the provider updates function configuration.

The two-pass flow resolves both sides: the draft plan emits the module build metadata, the action builds the packages, and the final saved plan observes those exact package hashes and paths.

## Testing

- `npm run test:release` (45 passed)
- workflow YAML parsing
- extracted package-build shell syntax via `bash -n`
- `npm run format:check -- .github/workflows/deploy-demo.yml docs/development/demo-deployment.md scripts/test/release-tools.test.mjs`