### PR TITLE
feat: update trackers after intent delivery

### DIFF
--- a/frontend/src/components/layout/IntentActivityPanel.test.tsx
+++ b/frontend/src/components/layout/IntentActivityPanel.test.tsx
@@ -9,7 +9,41 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/contexts/IntentContext', () => ({
   INTENT_OUTPUT_KEY: 'intent',
   useIntent: () => ({
-    detail: { intent: { id: 'i1' }, events: [] },
+    detail: {
+      intent: { id: 'i1' },
+      events: [
+        {
+          eventId: 'tracker-closed',
+          type: 'v2.tracker.closed',
+          summary: 'Closed Issue #42',
+          timestamp: '2026-08-11T10:00:00Z',
+        },
+        {
+          eventId: 'tracker-commented',
+          type: 'v2.tracker.commented',
+          summary: 'Added tracker delivery comment',
+          timestamp: '2026-08-11T09:59:00Z',
+        },
+        {
+          eventId: 'tracker-merged-commented',
+          type: 'v2.tracker.merged_commented',
+          summary: 'Added merged delivery comment',
+          timestamp: '2026-08-11T09:58:00Z',
+        },
+        {
+          eventId: 'tracker-failed',
+          type: 'v2.tracker.failed',
+          summary: 'Tracker write attempt failed',
+          timestamp: '2026-08-11T09:57:00Z',
+        },
+        {
+          eventId: 'tracker-blocked',
+          type: 'v2.tracker.blocked',
+          summary: 'Tracker synchronization stopped',
+          timestamp: '2026-08-11T09:56:00Z',
+        },
+      ],
+    },
     stageRows: [
       {
         stageId: 'requirements-analysis',
@@ -173,6 +207,27 @@ describe('IntentActivityPanel Agent tab', () => {
     expect(screen.getByText(/"mode": "full"/)).toBeInTheDocument();
     expect(screen.getByText(/No enforcement/)).toBeInTheDocument();
     expect(screen.getByText(/Running tool get_artifact/)).toBeInTheDocument();
+  });
+});
+
+describe('IntentActivityPanel Timeline tab', () => {
+  it('renders tracker events with semantic status colors', () => {
+    render(<IntentActivityPanel onClose={() => {}} />);
+
+    for (const summary of [
+      'Closed Issue #42',
+      'Added tracker delivery comment',
+      'Added merged delivery comment',
+    ]) {
+      const item = screen.getByText(summary).closest('.flex.gap-3.py-2');
+      expect(item?.querySelector('.bg-agent-success')).not.toBeNull();
+    }
+
+    const failed = screen.getByText('Tracker write attempt failed').closest('.flex.gap-3.py-2');
+    expect(failed?.querySelector('.bg-agent-error')).not.toBeNull();
+
+    const blocked = screen.getByText('Tracker synchronization stopped').closest('.flex.gap-3.py-2');
+    expect(blocked?.querySelector('.bg-agent-waiting')).not.toBeNull();
   });
 });
 

--- a/frontend/src/components/layout/IntentActivityPanel.tsx
+++ b/frontend/src/components/layout/IntentActivityPanel.tsx
@@ -357,6 +357,15 @@ function eventDotColor(type: string): string {
   if (type === 'v2.sensor.flagged') return 'bg-agent-waiting';
   if (type === 'v2.stage.resumed') return 'bg-agent-running';
   if (type === 'v2.pr.opened' || type === 'v2.pr.recorded') return 'bg-agent-success';
+  if (
+    type === 'v2.tracker.commented' ||
+    type === 'v2.tracker.merged_commented' ||
+    type === 'v2.tracker.closed'
+  ) {
+    return 'bg-agent-success';
+  }
+  if (type === 'v2.tracker.failed') return 'bg-agent-error';
+  if (type === 'v2.tracker.blocked') return 'bg-agent-waiting';
   if (type === 'v2.pr.failed' || type === 'v2.pr.record_failed') return 'bg-agent-error';
   if (type === 'v2.pr.skipped') return 'bg-agent-waiting';
   if (type.startsWith('v2.workspace.')) return 'bg-phase-inception';

--- a/frontend/src/lib/trackerProviders.tsx
+++ b/frontend/src/lib/trackerProviders.tsx
@@ -82,7 +82,7 @@ export const TRACKER_PROVIDERS: Record<string, TrackerProviderMeta> = {
       label: 'Atlassian Developer Console',
       steps: [
         'Open the Atlassian Developer Console → Create → OAuth 2.0 integration.',
-        'Under Permissions, add the Jira API and grant scopes: read:jira-work, read:jira-user, offline_access.',
+        'Under Permissions, add the Jira API and grant scopes: read:jira-work, read:jira-user, write:jira-work, offline_access.',
         'Under Authorization, set the Callback URL to the value shown below.',
         'Open the Settings tab and copy the Client ID and Client Secret, then paste both above.',
       ],

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -65,6 +65,7 @@ import {
   selectCanonicalArtifact,
 } from '../shared/artifact-versioning.js';
 import { parseLambdaPayload } from '../shared/lambda-payload.js';
+import { mapWithConcurrency } from '../shared/concurrency.js';
 import { fetchKnowledgeGraph } from './knowledge-graph.js';
 import { buildIntentAudit } from './audit.js';
 import { buildArtifactImpact, editBlockReason, activeQuorumEdit } from './impact.js';
@@ -233,20 +234,6 @@ const ingestAttachmentUpload = async (event) => {
       );
     return;
   }
-};
-const mapWithConcurrency = async (items, limit, worker) => {
-  const results = Array.from({ length: items.length });
-  let cursor = 0;
-  const workers = Array.from({ length: Math.min(Math.max(1, limit), items.length) }, async () => {
-    for (;;) {
-      const index = cursor;
-      cursor += 1;
-      if (index >= items.length) return;
-      results[index] = await worker(items[index], index);
-    }
-  });
-  await Promise.all(workers);
-  return results;
 };
 const composeReportPrefix = (intentId) => `compose-reports/${intentId}/`;
 const runtimeSessionIdFor = (intentId) => `aidlc-intent-${intentId}`.padEnd(33, '0');

--- a/lambda/shared/concurrency.js
+++ b/lambda/shared/concurrency.js
@@ -1,0 +1,18 @@
+// Runs at most `limit` workers concurrently while preserving input order in
+// the returned results. A worker rejection fails the whole operation.
+const mapWithConcurrency = async (items, limit, worker) => {
+  const results = Array.from({ length: items.length });
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(Math.max(1, limit), items.length) }, async () => {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+};
+
+export { mapWithConcurrency };

--- a/lambda/shared/git-providers/github.js
+++ b/lambda/shared/git-providers/github.js
@@ -365,6 +365,20 @@ const addIssueComment = async (ctx, repoId, issueNumber, body) => {
   return mapIssueDiscussionComment(data);
 };
 
+const closeIssue = async (ctx, repoId, issueNumber) => {
+  const { owner, repo } = splitOwnerRepo(repoId);
+  const res = await ghFetch(ctx, `${API_BASE}/repos/${owner}/${repo}/issues/${issueNumber}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ state: 'closed' }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data?.pull_request) {
+    throw new ProviderError(res.status || 404, data?.message || 'Failed to close issue');
+  }
+  return mapIssue(data);
+};
+
 // ---------------------------------------------------------------------------
 // PR comments
 // ---------------------------------------------------------------------------
@@ -938,6 +952,7 @@ export {
   getIssue,
   listIssueComments,
   addIssueComment,
+  closeIssue,
   listPRComments,
   addPRComment,
   getUnmergedConstructionTaskBranches,
@@ -976,6 +991,7 @@ export default {
   getIssue,
   listIssueComments,
   addIssueComment,
+  closeIssue,
   listPRComments,
   addPRComment,
   getUnmergedConstructionTaskBranches,

--- a/lambda/shared/git-providers/github.js
+++ b/lambda/shared/git-providers/github.js
@@ -326,7 +326,7 @@ const getIssue = async (ctx, repoId, issueNumber) => {
   const data = await res.json().catch(() => ({}));
   if (!res.ok || data?.pull_request) {
     throw new ProviderError(
-      res.status || 404,
+      data?.pull_request ? 404 : res.status || 404,
       data?.message || (data?.pull_request ? 'Not found' : 'Failed to fetch issue'),
     );
   }
@@ -367,14 +367,15 @@ const addIssueComment = async (ctx, repoId, issueNumber, body) => {
 
 const closeIssue = async (ctx, repoId, issueNumber) => {
   const { owner, repo } = splitOwnerRepo(repoId);
+  await getIssue(ctx, repoId, issueNumber);
   const res = await ghFetch(ctx, `${API_BASE}/repos/${owner}/${repo}/issues/${issueNumber}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ state: 'closed' }),
   });
   const data = await res.json().catch(() => ({}));
-  if (!res.ok || data?.pull_request) {
-    throw new ProviderError(res.status || 404, data?.message || 'Failed to close issue');
+  if (!res.ok) {
+    throw new ProviderError(res.status, data?.message || 'Failed to close issue');
   }
   return mapIssue(data);
 };

--- a/lambda/shared/git-providers/gitlab.js
+++ b/lambda/shared/git-providers/gitlab.js
@@ -401,6 +401,19 @@ const addIssueComment = async (ctx, repoId, issueNumber, body) => {
   return mapIssueDiscussionComment(data);
 };
 
+const closeIssue = async (ctx, repoId, issueNumber) => {
+  const project = encodeProject(repoId);
+  const res = await glFetch(ctx, `${API_BASE}/projects/${project}/issues/${issueNumber}`, {
+    method: 'PUT',
+    body: JSON.stringify({ state_event: 'close' }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new ProviderError(res.status, data?.message || 'Failed to close issue');
+  }
+  return mapIssue(data);
+};
+
 // ---------------------------------------------------------------------------
 // MR comments (notes + discussions)
 // ---------------------------------------------------------------------------
@@ -979,6 +992,7 @@ export {
   getIssue,
   listIssueComments,
   addIssueComment,
+  closeIssue,
   listPRComments,
   addPRComment,
   getUnmergedConstructionTaskBranches,
@@ -1016,6 +1030,7 @@ export default {
   getIssue,
   listIssueComments,
   addIssueComment,
+  closeIssue,
   listPRComments,
   addPRComment,
   getUnmergedConstructionTaskBranches,

--- a/lambda/shared/intent-url.js
+++ b/lambda/shared/intent-url.js
@@ -1,0 +1,6 @@
+const buildIntentUrl = ({ applicationUrl, projectId, intentId }) =>
+  `${String(applicationUrl || '').replace(/\/+$/, '')}/space/${encodeURIComponent(
+    projectId,
+  )}/intent/${encodeURIComponent(intentId)}`;
+
+export { buildIntentUrl };

--- a/lambda/shared/test/concurrency.test.js
+++ b/lambda/shared/test/concurrency.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { mapWithConcurrency } from '../concurrency.js';
+
+describe('mapWithConcurrency', () => {
+  it('bounds concurrent work and preserves input order', async () => {
+    let active = 0;
+    let peak = 0;
+    const releases = [];
+
+    const pending = mapWithConcurrency([3, 1, 2], 2, async (value, index) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => releases.push(resolve));
+      active -= 1;
+      return `${index}:${value}`;
+    });
+
+    await Promise.resolve();
+    expect(active).toBe(2);
+    releases.shift()();
+    await Promise.resolve();
+    releases.shift()();
+    await Promise.resolve();
+    releases.shift()();
+
+    await expect(pending).resolves.toEqual(['0:3', '1:1', '2:2']);
+    expect(peak).toBe(2);
+  });
+
+  it('returns an empty result without invoking the worker', async () => {
+    let invoked = false;
+    await expect(
+      mapWithConcurrency([], 2, async () => {
+        invoked = true;
+      }),
+    ).resolves.toEqual([]);
+    expect(invoked).toBe(false);
+  });
+});

--- a/lambda/shared/test/git-provider-issue-close.test.js
+++ b/lambda/shared/test/git-provider-issue-close.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { closeIssue as closeGithubIssue } from '../git-providers/github.js';
+import { closeIssue as closeGitlabIssue } from '../git-providers/gitlab.js';
+
+const response = (body) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+});
+
+describe('git-backed tracker close transport', () => {
+  it('closes a GitHub issue', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response({
+        number: 42,
+        html_url: 'https://github.com/acme/app/issues/42',
+        title: 'Issue',
+        state: 'closed',
+        labels: [],
+        user: { login: 'alice' },
+      }),
+    );
+
+    const issue = await closeGithubIssue({ token: 'token', fetchImpl }, 'acme/app', 42);
+
+    expect(issue.state).toBe('closed');
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.github.com/repos/acme/app/issues/42',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ state: 'closed' }),
+      }),
+    );
+  });
+
+  it('closes a GitLab issue', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response({
+        iid: 42,
+        web_url: 'https://gitlab.com/acme/app/-/issues/42',
+        title: 'Issue',
+        state: 'closed',
+        labels: [],
+        author: { username: 'alice' },
+      }),
+    );
+
+    const issue = await closeGitlabIssue({ token: 'token', fetchImpl }, 'acme/app', 42);
+
+    expect(issue.state).toBe('closed');
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://gitlab.com/api/v4/projects/acme%2Fapp/issues/42',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ state_event: 'close' }),
+      }),
+    );
+  });
+});

--- a/lambda/shared/test/git-provider-issue-close.test.js
+++ b/lambda/shared/test/git-provider-issue-close.test.js
@@ -33,6 +33,24 @@ describe('git-backed tracker close transport', () => {
     );
   });
 
+  it('does not PATCH when the issue number belongs to a pull request', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response({
+        number: 42,
+        html_url: 'https://github.com/acme/app/pull/42',
+        title: 'Pull request',
+        state: 'open',
+        pull_request: { url: 'https://api.github.com/repos/acme/app/pulls/42' },
+      }),
+    );
+
+    await expect(
+      closeGithubIssue({ token: 'token', fetchImpl }, 'acme/app', 42),
+    ).rejects.toMatchObject({ status: 404 });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl.mock.calls[0][1]?.method).toBeUndefined();
+  });
+
   it('closes a GitLab issue', async () => {
     const fetchImpl = vi.fn(async () =>
       response({

--- a/lambda/shared/test/intent-url.test.js
+++ b/lambda/shared/test/intent-url.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { buildIntentUrl } from '../intent-url.js';
+
+describe('buildIntentUrl', () => {
+  it('trims trailing slashes and encodes route identifiers', () => {
+    expect(
+      buildIntentUrl({
+        applicationUrl: 'https://aidlc.example///',
+        projectId: 'project/one',
+        intentId: 'intent two',
+      }),
+    ).toBe('https://aidlc.example/space/project%2Fone/intent/intent%20two');
+  });
+});

--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -19,6 +19,7 @@ import {
   unitPrKey,
   feedbackBatchKey,
   quorumEditKey,
+  trackerSyncKey,
   buildExecutionMeta,
   buildStageRow,
   buildEventRow,
@@ -32,6 +33,7 @@ import {
   buildUnitPrRow,
   buildFeedbackBatchRow,
   buildQuorumEditRow,
+  buildTrackerSyncRow,
   executionTypeStateIndex,
   HUMAN_TASK_STATUSES,
   STEERING_KINDS,
@@ -40,6 +42,7 @@ import {
   CONSTRUCTION_AUTONOMY_MODES,
   QUORUM_EDIT_STATES,
   QUORUM_EDIT_TERMINAL_STATES,
+  TRACKER_SYNC_STATES,
 } from '../v2-process-keys.js';
 import { createProcessStore } from '../v2-process-store.js';
 
@@ -48,6 +51,7 @@ describe('v2-process-keys', () => {
     expect(executionMetaKey('e1')).toEqual({ pk: 'EXEC#e1', sk: 'META' });
     expect(stageKey('e1', 'si-1')).toEqual({ pk: 'EXEC#e1', sk: 'STAGE#si-1' });
     expect(humanTaskKey('e1', 'h1')).toEqual({ pk: 'EXEC#e1', sk: 'HUMAN#h1' });
+    expect(trackerSyncKey('e1')).toEqual({ pk: 'EXEC#e1', sk: 'TRACKERSYNC' });
   });
 
   it('projects GSI1 for project-status browse and GSI2 for type/state', () => {
@@ -112,6 +116,25 @@ describe('v2-process-keys', () => {
       questions: '[{"text":"?"}]',
     });
     expect(row.GSI2SK).toBe('TYPE#HUMAN#STATE#pending#h1');
+  });
+
+  it('builds a pending tracker sync projected into maintenance', () => {
+    const row = buildTrackerSyncRow({
+      executionId: 'e1',
+      projectId: 'p1',
+      intentId: 'i1',
+      source: { bindingId: 'tb1', resourceId: '42' },
+      pullRequests: [{ provider: 'github', repoId: 'o/r', prNumber: 7 }],
+      now: 'T',
+    });
+    expect(row).toMatchObject({
+      sk: 'TRACKERSYNC',
+      state: 'PR_CREATED',
+      attempts: 0,
+      GSI3PK: 'TRACKER_SYNCS',
+      GSI3SK: 'CHECK#T#EXEC#e1',
+    });
+    expect(TRACKER_SYNC_STATES).toContain('COMPLETED');
   });
 });
 
@@ -1238,6 +1261,75 @@ describe('unit store methods', () => {
       IndexName: 'GSI3',
       ExpressionAttributeValues: { ':pk': 'PR_WAITS' },
     });
+  });
+
+  it('publishes and queries tracker synchronization through GSI3', async () => {
+    ddb.on(PutCommand).resolves({});
+    ddb.on(QueryCommand).resolves({ Items: [] });
+
+    await store.putTrackerSync({
+      executionId: 'e1',
+      projectId: 'p1',
+      intentId: 'i1',
+      source: { bindingId: 'tb1', resourceId: '42' },
+      pullRequests: [{ provider: 'github', repoId: 'o/r', prNumber: 7 }],
+    });
+    await store.listTrackerSyncs({ limit: 10 });
+
+    const put = ddb.commandCalls(PutCommand)[0].args[0].input;
+    expect(put.Item).toMatchObject({
+      sk: 'TRACKERSYNC',
+      state: 'PR_CREATED',
+      GSI3PK: 'TRACKER_SYNCS',
+    });
+    const query = ddb.commandCalls(QueryCommand)[0].args[0].input;
+    expect(query).toMatchObject({
+      IndexName: 'GSI3',
+      Limit: 10,
+      ExpressionAttributeValues: { ':pk': 'TRACKER_SYNCS' },
+    });
+  });
+
+  it('paginates tracker synchronization queries up to the requested limit', async () => {
+    const cursor = { pk: 'EXEC#e1', sk: 'TRACKERSYNC', GSI3PK: 'TRACKER_SYNCS', GSI3SK: 'CHECK#T' };
+    ddb
+      .on(QueryCommand)
+      .resolvesOnce({ Items: [{ executionId: 'e1' }], LastEvaluatedKey: cursor })
+      .resolvesOnce({ Items: [{ executionId: 'e2' }] });
+
+    await expect(store.listTrackerSyncs({ limit: 3 })).resolves.toEqual([
+      { executionId: 'e1' },
+      { executionId: 'e2' },
+    ]);
+
+    const [first, second] = ddb.commandCalls(QueryCommand).map((call) => call.args[0].input);
+    expect(first).toMatchObject({ Limit: 3 });
+    expect(first.ExclusiveStartKey).toBeUndefined();
+    expect(second).toMatchObject({ Limit: 2, ExclusiveStartKey: cursor });
+  });
+
+  it('claims tracker synchronization and removes maintenance projection when terminal', async () => {
+    ddb.on(UpdateCommand).resolves({ Attributes: {} });
+
+    await store.claimTrackerSync({
+      executionId: 'e1',
+      claimId: 'claim-1',
+      claimExpiresAt: 'T2',
+      now: 'T1',
+    });
+    await store.updateTrackerSync({
+      executionId: 'e1',
+      claimId: 'claim-1',
+      state: 'COMPLETED',
+      fields: { attempts: 0 },
+    });
+
+    const claim = ddb.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(claim.ConditionExpression).toContain('trackerSyncClaimExpiresAt < :now');
+    const complete = ddb.commandCalls(UpdateCommand)[1].args[0].input;
+    expect(complete.ConditionExpression).toBe('trackerSyncClaimId = :claimId');
+    expect(complete.UpdateExpression).toContain('REMOVE trackerSyncClaimId');
+    expect(complete.UpdateExpression).toContain('GSI3PK, GSI3SK');
   });
 
   it('syncUnitRows creates missing lanes, refreshes PENDING/READY, preserves active, reports orphans', async () => {

--- a/lambda/shared/v2-process-keys.js
+++ b/lambda/shared/v2-process-keys.js
@@ -32,9 +32,10 @@
 //     (list a project's executions by status, newest first)
 //   GSI2PK = EXEC#<executionId>       GSI2SK = TYPE#<type>#STATE#<state>#<id>
 //     (query one execution's records by record type + state)
-//   GSI3PK = ACTIVE_EXECUTIONS | PR_WAITS
-//     GSI3SK = EXEC#<executionId>[#UNIT#S<section>#<slug>]
-//     (sparse maintenance index: only live executions and parked unit PR waits)
+//   GSI3PK = ACTIVE_EXECUTIONS   GSI3SK = EXEC#<executionId>
+//   GSI3PK = PR_WAITS            GSI3SK = EXEC#<executionId>#UNIT#<unitLaneId>
+//   GSI3PK = TRACKER_SYNCS       GSI3SK = CHECK#<timestamp>#EXEC#<executionId>
+//     (sparse maintenance index for live execution and integration work)
 
 const META = 'META';
 
@@ -43,6 +44,7 @@ const executionPk = (executionId) => `EXEC#${executionId}`;
 const projectPk = (projectId) => `PROJECT#${projectId}`;
 const ACTIVE_EXECUTIONS_INDEX_PK = 'ACTIVE_EXECUTIONS';
 const PR_WAITS_INDEX_PK = 'PR_WAITS';
+const TRACKER_SYNCS_INDEX_PK = 'TRACKER_SYNCS';
 
 // ── Item keys ──
 const executionMetaKey = (executionId) => ({ pk: executionPk(executionId), sk: META });
@@ -141,6 +143,10 @@ const composeKey = (executionId, composeId) => ({
   pk: executionPk(executionId),
   sk: `COMPOSE#${composeId}`,
 });
+const trackerSyncKey = (executionId) => ({
+  pk: executionPk(executionId),
+  sk: 'TRACKERSYNC',
+});
 
 // ── Index projections ──
 // GSI1: a project's executions by status, newest first (status board / resume).
@@ -161,6 +167,10 @@ const activeExecutionIndex = ({ executionId }) => ({
 const unitPrWaitIndex = ({ executionId, sectionIndex, slug }) => ({
   GSI3PK: PR_WAITS_INDEX_PK,
   GSI3SK: `EXEC#${executionId}#UNIT#${unitLaneId(sectionIndex, slug)}`,
+});
+const trackerSyncIndex = ({ executionId, scheduledAt }) => ({
+  GSI3PK: TRACKER_SYNCS_INDEX_PK,
+  GSI3SK: `CHECK#${scheduledAt}#EXEC#${executionId}`,
 });
 
 // ── Vocabularies ──
@@ -261,6 +271,14 @@ const QUORUM_EDIT_TERMINAL_STATES = ['SUCCEEDED', 'FAILED', 'REJECTED', 'CANCELL
 //               grid) — the row carries the structured reason, never a guess
 const COMPOSE_STATES = ['PENDING', 'COMPLETED', 'FAILED'];
 const COMPOSE_MODES = ['front', 'report', 'inflight'];
+const TRACKER_SYNC_STATES = [
+  'PR_CREATED',
+  'WAITING_FOR_MERGE',
+  'PR_MERGED',
+  'BLOCKED',
+  'COMPLETED',
+];
+const TRACKER_SYNC_TERMINAL_STATES = ['BLOCKED', 'COMPLETED'];
 
 // ── Pure record builders ──
 // Every builder takes injected `now`/ids so callers/tests stay deterministic
@@ -1053,6 +1071,43 @@ const buildComposeRow = ({
   completedAt: null,
 });
 
+const buildTrackerSyncRow = ({
+  executionId,
+  projectId,
+  intentId,
+  source,
+  pullRequests,
+  intentTitle = null,
+  workflowId = null,
+  workflowVersion = null,
+  scope = null,
+  branch = null,
+  now,
+}) => ({
+  ...trackerSyncKey(executionId),
+  ...trackerSyncIndex({ executionId, scheduledAt: now }),
+  type: 'TrackerSync',
+  executionId,
+  projectId,
+  intentId,
+  source,
+  pullRequests,
+  intentTitle,
+  workflowId,
+  workflowVersion,
+  scope,
+  branch,
+  state: 'PR_CREATED',
+  attempts: 0,
+  createdCommentedAt: null,
+  mergedCommentedAt: null,
+  closedAt: null,
+  lastCheckedAt: null,
+  lastError: null,
+  createdAt: now,
+  updatedAt: now,
+});
+
 export {
   META,
   executionPk,
@@ -1075,12 +1130,15 @@ export {
   feedbackCommentKey,
   quorumEditKey,
   composeKey,
+  trackerSyncKey,
   projectStatusIndex,
   executionTypeStateIndex,
   activeExecutionIndex,
   unitPrWaitIndex,
+  trackerSyncIndex,
   ACTIVE_EXECUTIONS_INDEX_PK,
   PR_WAITS_INDEX_PK,
+  TRACKER_SYNCS_INDEX_PK,
   EXECUTION_STATUS,
   ACTIVE_EXECUTION_STATUSES,
   STAGE_STATE,
@@ -1096,6 +1154,8 @@ export {
   QUORUM_EDIT_TERMINAL_STATES,
   COMPOSE_STATES,
   COMPOSE_MODES,
+  TRACKER_SYNC_STATES,
+  TRACKER_SYNC_TERMINAL_STATES,
   buildExecutionMeta,
   buildStageRow,
   buildEventRow,
@@ -1112,6 +1172,7 @@ export {
   buildFeedbackCommentRow,
   buildQuorumEditRow,
   buildComposeRow,
+  buildTrackerSyncRow,
 };
 export default {
   META,
@@ -1135,12 +1196,15 @@ export default {
   feedbackCommentKey,
   quorumEditKey,
   composeKey,
+  trackerSyncKey,
   projectStatusIndex,
   executionTypeStateIndex,
   activeExecutionIndex,
   unitPrWaitIndex,
+  trackerSyncIndex,
   ACTIVE_EXECUTIONS_INDEX_PK,
   PR_WAITS_INDEX_PK,
+  TRACKER_SYNCS_INDEX_PK,
   EXECUTION_STATUS,
   ACTIVE_EXECUTION_STATUSES,
   STAGE_STATE,
@@ -1156,6 +1220,8 @@ export default {
   QUORUM_EDIT_TERMINAL_STATES,
   COMPOSE_STATES,
   COMPOSE_MODES,
+  TRACKER_SYNC_STATES,
+  TRACKER_SYNC_TERMINAL_STATES,
   buildExecutionMeta,
   buildStageRow,
   buildEventRow,
@@ -1172,4 +1238,5 @@ export default {
   buildFeedbackCommentRow,
   buildQuorumEditRow,
   buildComposeRow,
+  buildTrackerSyncRow,
 };

--- a/lambda/shared/v2-process-store.js
+++ b/lambda/shared/v2-process-store.js
@@ -30,12 +30,15 @@ import {
   unitLaneId,
   quorumEditKey,
   composeKey,
+  trackerSyncKey,
   executionPk,
   projectPk,
   projectStatusIndex,
   executionTypeStateIndex,
   activeExecutionIndex,
   unitPrWaitIndex,
+  trackerSyncIndex,
+  TRACKER_SYNCS_INDEX_PK,
   ACTIVE_EXECUTIONS_INDEX_PK,
   PR_WAITS_INDEX_PK,
   buildExecutionMeta,
@@ -54,11 +57,14 @@ import {
   buildFeedbackCommentRow,
   buildQuorumEditRow,
   buildComposeRow,
+  buildTrackerSyncRow,
   UNIT_STATES,
   UNIT_PR_STATES,
   FEEDBACK_STATES,
   QUORUM_EDIT_STATES,
   COMPOSE_STATES,
+  TRACKER_SYNC_STATES,
+  TRACKER_SYNC_TERMINAL_STATES,
   CONSTRUCTION_AUTONOMY_MODES,
   ACTIVE_EXECUTION_STATUSES,
 } from './v2-process-keys.js';
@@ -2132,6 +2138,120 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     return items.toSorted((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)));
   };
 
+  const putTrackerSync = async (input) => {
+    const item = buildTrackerSyncRow({ ...input, now: input.now ?? now() });
+    try {
+      await ddb.send(
+        new PutCommand({
+          TableName: table(),
+          Item: item,
+          ConditionExpression: 'attribute_not_exists(pk) AND attribute_not_exists(sk)',
+        }),
+      );
+      return item;
+    } catch (error) {
+      if (error?.name !== 'ConditionalCheckFailedException') throw error;
+      return getTrackerSync(input.executionId);
+    }
+  };
+
+  const getTrackerSync = async (executionId) => {
+    const { Item } = await ddb.send(
+      new GetCommand({ TableName: table(), Key: trackerSyncKey(executionId) }),
+    );
+    return Item ?? null;
+  };
+
+  const listTrackerSyncs = async ({ limit = 25 } = {}) => {
+    const items = [];
+    let ExclusiveStartKey;
+    do {
+      const page = await ddb.send(
+        new QueryCommand({
+          TableName: table(),
+          IndexName: 'GSI3',
+          KeyConditionExpression: 'GSI3PK = :pk',
+          ExpressionAttributeValues: { ':pk': TRACKER_SYNCS_INDEX_PK },
+          Limit: limit - items.length,
+          ExclusiveStartKey,
+        }),
+      );
+      items.push(...(page.Items ?? []));
+      ExclusiveStartKey = page.LastEvaluatedKey;
+    } while (ExclusiveStartKey && items.length < limit);
+    return items;
+  };
+
+  const claimTrackerSync = async ({
+    executionId,
+    claimId,
+    claimExpiresAt,
+    now: claimNow = now(),
+  }) => {
+    try {
+      const { Attributes } = await ddb.send(
+        new UpdateCommand({
+          TableName: table(),
+          Key: trackerSyncKey(executionId),
+          UpdateExpression:
+            'SET trackerSyncClaimId = :claimId, trackerSyncClaimExpiresAt = :expires, updatedAt = :now',
+          ConditionExpression:
+            'attribute_exists(pk) AND attribute_exists(GSI3PK) AND (attribute_not_exists(trackerSyncClaimId) OR trackerSyncClaimExpiresAt < :now)',
+          ExpressionAttributeValues: {
+            ':claimId': claimId,
+            ':expires': claimExpiresAt,
+            ':now': claimNow,
+          },
+          ReturnValues: 'ALL_NEW',
+        }),
+      );
+      return Attributes ?? null;
+    } catch (error) {
+      if (error?.name === 'ConditionalCheckFailedException') return null;
+      throw error;
+    }
+  };
+
+  const updateTrackerSync = async ({ executionId, claimId, state, fields = {} }) => {
+    if (!TRACKER_SYNC_STATES.includes(state)) {
+      throw new Error(`invalid tracker sync state: ${state}`);
+    }
+    const ts = now();
+    const sets = ['#state = :state', 'updatedAt = :updatedAt'];
+    const removes = ['trackerSyncClaimId', 'trackerSyncClaimExpiresAt'];
+    const names = { '#state': 'state' };
+    const values = {
+      ':state': state,
+      ':updatedAt': ts,
+      ':claimId': claimId,
+    };
+    for (const [key, value] of Object.entries(fields)) {
+      names[`#field_${key}`] = key;
+      values[`:field_${key}`] = value;
+      sets.push(`#field_${key} = :field_${key}`);
+    }
+    if (TRACKER_SYNC_TERMINAL_STATES.includes(state)) {
+      removes.push('GSI3PK', 'GSI3SK');
+    } else {
+      const projection = trackerSyncIndex({ executionId, scheduledAt: ts });
+      sets.push('GSI3PK = :g3pk', 'GSI3SK = :g3sk');
+      values[':g3pk'] = projection.GSI3PK;
+      values[':g3sk'] = projection.GSI3SK;
+    }
+    const { Attributes } = await ddb.send(
+      new UpdateCommand({
+        TableName: table(),
+        Key: trackerSyncKey(executionId),
+        UpdateExpression: `SET ${sets.join(', ')} REMOVE ${removes.join(', ')}`,
+        ConditionExpression: 'trackerSyncClaimId = :claimId',
+        ExpressionAttributeNames: names,
+        ExpressionAttributeValues: values,
+        ReturnValues: 'ALL_NEW',
+      }),
+    );
+    return Attributes ?? null;
+  };
+
   // Read every record for an execution, grouped by type (for the resume lambda /
   // admin / restore-on-reload). Fully paginated — see queryAll.
   //
@@ -2177,6 +2297,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
       feedbackBatches: records.filter((r) => r.sk.startsWith('FEEDBACK#')),
       quorumEdits: records.filter((r) => r.sk.startsWith('QEDIT#')),
       composes: records.filter((r) => r.sk.startsWith('COMPOSE#')),
+      trackerSync: records.find((r) => r.sk === 'TRACKERSYNC') ?? null,
     };
   };
 
@@ -2282,6 +2403,11 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     getCompose,
     updateCompose,
     listComposes,
+    putTrackerSync,
+    getTrackerSync,
+    listTrackerSyncs,
+    claimTrackerSync,
+    updateTrackerSync,
     getExecutionRecords,
   };
 };

--- a/lambda/source-control/index.js
+++ b/lambda/source-control/index.js
@@ -49,6 +49,7 @@ const SOURCE_CONTROL_OPERATIONS = Object.freeze({
   'get-issue': 'read',
   'list-issue-comments': 'read',
   'add-issue-comment': 'write',
+  'close-issue': 'write',
   'merge-branch': 'write',
 });
 
@@ -331,6 +332,8 @@ const callProvider = async (provider, operation, ctx, repo, args = {}) => {
       return provider.listIssueComments(ctx, repo, args.number);
     case 'add-issue-comment':
       return provider.addIssueComment(ctx, repo, args.number, args.body);
+    case 'close-issue':
+      return provider.closeIssue(ctx, repo, args.number);
     case 'merge-branch':
       return provider.mergeBranch(ctx, repo, args);
     default:

--- a/lambda/source-control/test/source-control.test.js
+++ b/lambda/source-control/test/source-control.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  SOURCE_CONTROL_OPERATIONS,
   bindingStatusForProject,
   executeSourceControlOperation,
   isSupportedProvider,
@@ -7,6 +8,10 @@ import {
 } from '../index.js';
 
 describe('source-control project contract', () => {
+  it('classifies tracker closure as a project-bound write operation', () => {
+    expect(SOURCE_CONTROL_OPERATIONS['close-issue']).toBe('write');
+  });
+
   it('requires one authentication type per provider', () => {
     expect(
       normalizeProviderSelections({

--- a/lambda/trackers/delivery-sync.js
+++ b/lambda/trackers/delivery-sync.js
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto';
+import { mapWithConcurrency } from '../shared/concurrency.js';
+import { buildIntentUrl } from '../shared/intent-url.js';
 
 const CREATED_PHRASE = 'AI-DLC completed the workflow for this issue.';
 const CREATED_TASK_PHRASE = 'AI-DLC completed the workflow for this task.';
@@ -8,12 +10,12 @@ const MAX_TRACKER_WRITE_ATTEMPTS = 10;
 const CLAIM_LEASE_MS = 90_000;
 const SCHEDULED_CONCURRENCY = 5;
 
-const trimBaseUrl = (value) => String(value || '').replace(/\/+$/, '');
-
 const intentUrlFor = (applicationUrl, sync) =>
-  `${trimBaseUrl(applicationUrl)}/space/${encodeURIComponent(
-    sync.projectId,
-  )}/intent/${encodeURIComponent(sync.intentId)}`;
+  buildIntentUrl({
+    applicationUrl,
+    projectId: sync.projectId,
+    intentId: sync.intentId,
+  });
 
 const intentLabel = (sync) => sync.intentTitle || sync.intentId;
 
@@ -30,7 +32,7 @@ const branchUrlFor = (pr, fallbackBranch) => {
   if (!branch || !pr.prUrl || !pr.repoId) return null;
   try {
     const url = new URL(pr.prUrl);
-    const encodedBranch = encodeURIComponent(branch);
+    const encodedBranch = branch.split('/').map(encodeURIComponent).join('/');
     if (pr.provider === 'github') {
       url.pathname = `/${pr.repoId}/tree/${encodedBranch}`;
     } else if (pr.provider === 'gitlab') {
@@ -115,24 +117,10 @@ const hasMergedDeliveryComment = (comments, body) => {
 const sanitizedError = (error) => ({
   code: error?.code || error?.name || 'TRACKER_SYNC_FAILED',
   message: String(error?.message || 'Tracker synchronization failed').slice(0, 500),
+  ...(error?.extra?.reconnect === true ? { reconnect: true } : {}),
 });
 
 const isPermanentTrackerWriteError = (error) => [401, 403].includes(Number(error?.status));
-
-const mapWithConcurrency = async (items, limit, worker) => {
-  const results = Array.from({ length: items.length });
-  let cursor = 0;
-  const workers = Array.from({ length: Math.min(Math.max(1, limit), items.length) }, async () => {
-    for (;;) {
-      const index = cursor;
-      cursor += 1;
-      if (index >= items.length) return;
-      results[index] = await worker(items[index], index);
-    }
-  });
-  await Promise.all(workers);
-  return results;
-};
 
 const createDeliverySynchronizer = ({
   store,
@@ -183,6 +171,7 @@ const createDeliverySynchronizer = ({
   const trackerWriteFailed = async (sync, claimId, error) => {
     const attempts = Number(sync.attempts || 0) + 1;
     const permanent = isPermanentTrackerWriteError(error);
+    const reconnect = error?.extra?.reconnect === true;
     const blocked = permanent || attempts >= maxTrackerWriteAttempts;
     await update(sync, claimId, blocked ? 'BLOCKED' : sync.state, {
       attempts,
@@ -191,11 +180,13 @@ const createDeliverySynchronizer = ({
     await emit(
       sync,
       blocked ? 'v2.tracker.blocked' : 'v2.tracker.failed',
-      permanent
-        ? 'Tracker synchronization stopped after a non-retryable authorization failure'
-        : blocked
-          ? `Tracker synchronization stopped after ${attempts} failed write attempts`
-          : `Tracker write attempt ${attempts} failed`,
+      reconnect
+        ? 'Reconnect Jira to resume tracker synchronization'
+        : permanent
+          ? 'Tracker synchronization stopped after a non-retryable authorization failure'
+          : blocked
+            ? `Tracker synchronization stopped after ${attempts} failed write attempts`
+            : `Tracker write attempt ${attempts} failed`,
     );
     return { blocked, attempts, permanent };
   };

--- a/lambda/trackers/delivery-sync.js
+++ b/lambda/trackers/delivery-sync.js
@@ -1,0 +1,414 @@
+import { randomUUID } from 'node:crypto';
+
+const CREATED_PHRASE = 'AI-DLC completed the workflow for this issue.';
+const CREATED_TASK_PHRASE = 'AI-DLC completed the workflow for this task.';
+const MERGED_PHRASE = 'AI-DLC merged all delivery pull requests';
+const MERGED_MR_PHRASE = 'AI-DLC merged all delivery merge requests';
+const MAX_TRACKER_WRITE_ATTEMPTS = 10;
+const CLAIM_LEASE_MS = 90_000;
+const SCHEDULED_CONCURRENCY = 5;
+
+const trimBaseUrl = (value) => String(value || '').replace(/\/+$/, '');
+
+const intentUrlFor = (applicationUrl, sync) =>
+  `${trimBaseUrl(applicationUrl)}/space/${encodeURIComponent(
+    sync.projectId,
+  )}/intent/${encodeURIComponent(sync.intentId)}`;
+
+const intentLabel = (sync) => sync.intentTitle || sync.intentId;
+
+const createdPhraseFor = (sync) =>
+  sync.source?.provider === 'jira-cloud' ? CREATED_TASK_PHRASE : CREATED_PHRASE;
+
+const trackerIssueLabel = (sync) => {
+  const resourceId = String(sync.source?.resourceId || '').replace(/^#/, '');
+  return resourceId ? `Issue #${resourceId}` : 'Issue';
+};
+
+const branchUrlFor = (pr, fallbackBranch) => {
+  const branch = pr.branch || fallbackBranch;
+  if (!branch || !pr.prUrl || !pr.repoId) return null;
+  try {
+    const url = new URL(pr.prUrl);
+    const encodedBranch = encodeURIComponent(branch);
+    if (pr.provider === 'github') {
+      url.pathname = `/${pr.repoId}/tree/${encodedBranch}`;
+    } else if (pr.provider === 'gitlab') {
+      url.pathname = `/${pr.repoId}/-/tree/${encodedBranch}`;
+    } else if (pr.provider === 'bitbucket') {
+      url.pathname = `/${pr.repoId}/branch/${encodedBranch}`;
+    } else {
+      return null;
+    }
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return null;
+  }
+};
+
+const branchLink = (pr, fallbackBranch) => {
+  const branch = pr.branch || fallbackBranch;
+  if (!branch) return null;
+  const url = branchUrlFor(pr, fallbackBranch);
+  return url ? `[\`${branch}\`](${url})` : `\`${branch}\``;
+};
+
+const branchLines = (sync) => {
+  const rows = sync.pullRequests
+    .map((pr) => ({ pr, link: branchLink(pr, sync.branch) }))
+    .filter((row) => row.link);
+  if (rows.length === 0) return [];
+  if (rows.length === 1) return [`- Branch: ${rows[0].link}`];
+  return ['- Branches:', ...rows.map(({ pr, link }) => `  - \`${pr.repoId}\`: ${link}`)];
+};
+
+const pullRequestLines = (pullRequests) =>
+  pullRequests.map((pr) => `  - \`${pr.repoId}\`: ${pr.prUrl}`);
+
+const mergedPullRequestLines = (pullRequests) =>
+  pullRequests.map((pr) => {
+    const prefix = pr.provider === 'gitlab' ? '!' : '#';
+    return `- \`${pr.repoId}\`: [${prefix}${pr.prNumber}](${pr.prUrl})`;
+  });
+
+const mergedPhraseFor = (sync) =>
+  sync.pullRequests[0]?.provider === 'gitlab' ? MERGED_MR_PHRASE : MERGED_PHRASE;
+
+const createdComment = (sync, applicationUrl) => {
+  const lines = [
+    createdPhraseFor(sync),
+    '',
+    `- Intent: [${intentLabel(sync)}](${intentUrlFor(applicationUrl, sync)})`,
+  ];
+  if (sync.workflowId) {
+    const version = sync.workflowVersion == null ? '' : `@${sync.workflowVersion}`;
+    const scope = sync.scope ? ` (\`${sync.scope}\`)` : '';
+    lines.push(`- Workflow: \`${sync.workflowId}${version}\`${scope}`);
+  }
+  lines.push(...branchLines(sync));
+  lines.push('- Pull requests:', ...pullRequestLines(sync.pullRequests));
+  return lines.join('\n');
+};
+
+const mergedComment = (sync) =>
+  [mergedPhraseFor(sync), '', ...mergedPullRequestLines(sync.pullRequests)].join('\n');
+
+const hasDeliveryComment = (comments, phrase, intentUrl) =>
+  comments.some((comment) => {
+    const body = String(comment?.body || '');
+    return body.includes(phrase) && body.includes(intentUrl);
+  });
+
+const normalizeCommentBody = (body) =>
+  String(body || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\n{2,}/g, '\n\n')
+    .trim();
+
+const hasMergedDeliveryComment = (comments, body) => {
+  const expected = normalizeCommentBody(body);
+  return comments.some((comment) => normalizeCommentBody(comment?.body) === expected);
+};
+
+const sanitizedError = (error) => ({
+  code: error?.code || error?.name || 'TRACKER_SYNC_FAILED',
+  message: String(error?.message || 'Tracker synchronization failed').slice(0, 500),
+});
+
+const isPermanentTrackerWriteError = (error) => [401, 403].includes(Number(error?.status));
+
+const mapWithConcurrency = async (items, limit, worker) => {
+  const results = Array.from({ length: items.length });
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(Math.max(1, limit), items.length) }, async () => {
+    for (;;) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+};
+
+const createDeliverySynchronizer = ({
+  store,
+  resolveBinding,
+  getTrackerProvider,
+  trackerContext,
+  getPullRequestStatus,
+  applicationUrl = process.env.APPLICATION_URL,
+  broadcast,
+  clock = () => new Date(),
+  ids = randomUUID,
+  maxTrackerWriteAttempts = MAX_TRACKER_WRITE_ATTEMPTS,
+}) => {
+  const emit = async (sync, type, summary) => {
+    try {
+      await store.appendEvent?.({
+        executionId: sync.executionId,
+        type,
+        actor: 'tracker-sync',
+        summary,
+      });
+    } catch {
+      // Timeline events are best-effort and never control synchronization.
+      return;
+    }
+    try {
+      await broadcast?.(sync.intentId, {
+        action: 'agent.note',
+        executionId: sync.executionId,
+        intentId: sync.intentId,
+        projectId: sync.projectId,
+        noteType: type,
+        summary,
+      });
+    } catch {
+      // Realtime delivery is best-effort; the persisted event appears on reload.
+    }
+  };
+
+  const update = (sync, claimId, state, fields = {}) =>
+    store.updateTrackerSync({
+      executionId: sync.executionId,
+      claimId,
+      state,
+      fields: { lastCheckedAt: clock().toISOString(), ...fields },
+    });
+
+  const trackerWriteFailed = async (sync, claimId, error) => {
+    const attempts = Number(sync.attempts || 0) + 1;
+    const permanent = isPermanentTrackerWriteError(error);
+    const blocked = permanent || attempts >= maxTrackerWriteAttempts;
+    await update(sync, claimId, blocked ? 'BLOCKED' : sync.state, {
+      attempts,
+      lastError: sanitizedError(error),
+    });
+    await emit(
+      sync,
+      blocked ? 'v2.tracker.blocked' : 'v2.tracker.failed',
+      permanent
+        ? 'Tracker synchronization stopped after a non-retryable authorization failure'
+        : blocked
+          ? `Tracker synchronization stopped after ${attempts} failed write attempts`
+          : `Tracker write attempt ${attempts} failed`,
+    );
+    return { blocked, attempts, permanent };
+  };
+
+  const ensureComment = async ({ sync, binding, provider, ctx, phrase, body, matchExisting }) => {
+    const intentUrl = intentUrlFor(applicationUrl, sync);
+    const comments = await provider.getIssueDiscussion(
+      ctx,
+      binding.externalProjectKey,
+      sync.source.resourceId,
+    );
+    const existing = matchExisting
+      ? matchExisting(comments, body, intentUrl)
+      : hasDeliveryComment(comments, phrase, intentUrl);
+    if (existing) return { existing: true };
+    await provider.addIssueComment(ctx, binding.externalProjectKey, sync.source.resourceId, body);
+    return { existing: false };
+  };
+
+  const processClaimed = async (sync, claimId) => {
+    const binding = await resolveBinding(sync.projectId, sync.source.bindingId);
+    if (!binding) {
+      await update(sync, claimId, 'BLOCKED', {
+        lastError: { code: 'TRACKER_BINDING_NOT_FOUND', message: 'Tracker binding not found' },
+      });
+      await emit(sync, 'v2.tracker.blocked', 'Tracker binding no longer exists');
+      return { state: 'BLOCKED' };
+    }
+
+    const provider = getTrackerProvider(binding.provider, binding.instance);
+    const ctx = trackerContext(sync.projectId, binding);
+
+    if (sync.state === 'PR_CREATED') {
+      try {
+        await ensureComment({
+          sync,
+          binding,
+          provider,
+          ctx,
+          phrase: createdPhraseFor(sync),
+          body: createdComment(sync, applicationUrl),
+        });
+      } catch (error) {
+        return trackerWriteFailed(sync, claimId, error);
+      }
+      await update(sync, claimId, 'WAITING_FOR_MERGE', {
+        attempts: 0,
+        lastError: null,
+        createdCommentedAt: clock().toISOString(),
+      });
+      await emit(sync, 'v2.tracker.commented', 'Added tracker delivery comment');
+      return { state: 'WAITING_FOR_MERGE' };
+    }
+
+    if (sync.state === 'WAITING_FOR_MERGE') {
+      const incompleteIdentity =
+        !Array.isArray(sync.pullRequests) ||
+        sync.pullRequests.length === 0 ||
+        sync.pullRequests.some(
+          (pr) => !pr?.provider || !pr?.repoId || pr.prNumber === null || pr.prNumber === undefined,
+        );
+      if (incompleteIdentity) {
+        await update(sync, claimId, 'BLOCKED', {
+          lastError: {
+            code: 'PR_IDENTITY_INCOMPLETE',
+            message: 'One or more final pull request identities are incomplete',
+          },
+        });
+        await emit(
+          sync,
+          'v2.tracker.blocked',
+          'Tracker synchronization stopped because final pull request identity is incomplete',
+        );
+        return { state: 'BLOCKED' };
+      }
+
+      let statuses;
+      try {
+        statuses = await Promise.all(
+          sync.pullRequests.map((pr) =>
+            getPullRequestStatus({
+              projectId: sync.projectId,
+              provider: pr.provider,
+              repository: pr.repoId,
+              number: pr.prNumber,
+            }),
+          ),
+        );
+      } catch (error) {
+        await update(sync, claimId, 'WAITING_FOR_MERGE', {
+          lastError: sanitizedError(error),
+        });
+        return { state: 'WAITING_FOR_MERGE', unavailable: true };
+      }
+      if (statuses.some((status) => !status?.state)) {
+        await update(sync, claimId, 'WAITING_FOR_MERGE', {
+          lastError: {
+            code: 'PR_STATUS_UNAVAILABLE',
+            message: 'One or more pull request statuses are unavailable',
+          },
+        });
+        return { state: 'WAITING_FOR_MERGE', unavailable: true };
+      }
+      if (statuses.some((status) => status.state === 'closed')) {
+        await update(sync, claimId, 'BLOCKED', {
+          lastError: {
+            code: 'PR_CLOSED_WITHOUT_MERGE',
+            message: 'A final pull request was closed without merging',
+          },
+        });
+        await emit(
+          sync,
+          'v2.tracker.blocked',
+          'Tracker synchronization stopped because a final pull request was closed',
+        );
+        return { state: 'BLOCKED' };
+      }
+      if (statuses.every((status) => status.state === 'merged')) {
+        await update(sync, claimId, 'PR_MERGED', {
+          attempts: 0,
+          lastError: null,
+        });
+        return { state: 'PR_MERGED' };
+      }
+      await update(sync, claimId, 'WAITING_FOR_MERGE', { lastError: null });
+      return { state: 'WAITING_FOR_MERGE' };
+    }
+
+    if (sync.state === 'PR_MERGED') {
+      try {
+        await ensureComment({
+          sync,
+          binding,
+          provider,
+          ctx,
+          phrase: mergedPhraseFor(sync),
+          body: mergedComment(sync),
+          matchExisting: hasMergedDeliveryComment,
+        });
+        if (typeof provider.closeIssue === 'function') {
+          await provider.closeIssue(ctx, binding.externalProjectKey, sync.source.resourceId);
+        }
+      } catch (error) {
+        return trackerWriteFailed(sync, claimId, error);
+      }
+      await update(sync, claimId, 'COMPLETED', {
+        attempts: 0,
+        lastError: null,
+        mergedCommentedAt: clock().toISOString(),
+        closedAt: typeof provider.closeIssue === 'function' ? clock().toISOString() : null,
+      });
+      await emit(sync, 'v2.tracker.merged_commented', 'Added merged delivery comment');
+      if (typeof provider.closeIssue === 'function') {
+        await emit(sync, 'v2.tracker.closed', `Closed ${trackerIssueLabel(sync)}`);
+      }
+      return { state: 'COMPLETED' };
+    }
+
+    await update(sync, claimId, 'BLOCKED', {
+      lastError: { code: 'INVALID_TRACKER_SYNC_STATE', message: `Unexpected state: ${sync.state}` },
+    });
+    return { state: 'BLOCKED' };
+  };
+
+  const process = async (candidate) => {
+    const claimId = ids();
+    const claimExpiresAt = new Date(clock().getTime() + CLAIM_LEASE_MS).toISOString();
+    const claimed = await store.claimTrackerSync({
+      executionId: candidate.executionId,
+      claimId,
+      claimExpiresAt,
+      now: clock().toISOString(),
+    });
+    if (!claimed) return { claimed: false };
+    try {
+      return await processClaimed(claimed, claimId);
+    } catch (error) {
+      // Keep ownership until the short lease expires so another worker cannot overlap this retry.
+      await update(claimed, claimId, claimed.state, {
+        lastError: sanitizedError(error),
+      }).catch(() => {});
+      return { state: claimed.state, error: sanitizedError(error) };
+    }
+  };
+
+  const runScheduled = async ({ limit = 25, concurrency = SCHEDULED_CONCURRENCY } = {}) => {
+    const candidates = await store.listTrackerSyncs({ limit });
+    const results = await mapWithConcurrency(candidates, concurrency, async (candidate) => {
+      try {
+        return await process(candidate);
+      } catch (error) {
+        return { error: sanitizedError(error) };
+      }
+    });
+    return { processed: results.length, results };
+  };
+
+  return { process, runScheduled };
+};
+
+export {
+  CREATED_PHRASE,
+  CREATED_TASK_PHRASE,
+  MERGED_PHRASE,
+  MERGED_MR_PHRASE,
+  branchUrlFor,
+  createdPhraseFor,
+  mergedPhraseFor,
+  trackerIssueLabel,
+  MAX_TRACKER_WRITE_ATTEMPTS,
+  createdComment,
+  mergedComment,
+  hasDeliveryComment,
+  hasMergedDeliveryComment,
+  createDeliverySynchronizer,
+};

--- a/lambda/trackers/index.js
+++ b/lambda/trackers/index.js
@@ -29,7 +29,10 @@ import {
   invalidateBindingsByCredentialRef,
   oauthCredentialRef,
 } from '../shared/source-control-bindings.js';
+import { createProcessStore } from '../shared/v2-process-store.js';
+import { broadcastToIntentChannel } from '../shared/ws-fanout.js';
 import { getProvider, KNOWN_PROVIDERS, ProviderError } from './providers/index.js';
+import { createDeliverySynchronizer } from './delivery-sync.js';
 import {
   buildAuthorizeUrl,
   exchangeCode,
@@ -44,19 +47,12 @@ const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const ssm = new SSMClient({});
 const secrets = new SecretsManagerClient({});
 const lambda = new LambdaClient({});
+const processStore = createProcessStore({ ddb });
 
 const trackerGitProvider = (provider) =>
   provider === 'github-issues' ? 'github' : provider === 'gitlab-issues' ? 'gitlab' : null;
 
-const invokeProjectSourceControl = async ({
-  projectId,
-  trackerProvider,
-  repository,
-  operation,
-  args = {},
-}) => {
-  const provider = trackerGitProvider(trackerProvider);
-  if (!provider) throw new ProviderError(400, 'Tracker is not backed by source control');
+const invokeSourceControl = async ({ projectId, provider, repository, operation, args = {} }) => {
   const functionName = process.env.SOURCE_CONTROL_FUNCTION;
   if (!functionName) throw new ProviderError(503, 'Project source control is not configured');
   const result = await lambda.send(
@@ -91,6 +87,18 @@ const invokeProjectSourceControl = async ({
     });
   }
   return payload.result;
+};
+
+const invokeProjectSourceControl = ({
+  projectId,
+  trackerProvider,
+  repository,
+  operation,
+  args = {},
+}) => {
+  const provider = trackerGitProvider(trackerProvider);
+  if (!provider) throw new ProviderError(400, 'Tracker is not backed by source control');
+  return invokeSourceControl({ projectId, provider, repository, operation, args });
 };
 
 // HMAC-signed envelope for the OAuth `state` parameter and the multi-site
@@ -319,6 +327,70 @@ const listBindingsForProject = async (g, projectId) => {
   return bindings;
 };
 
+const graphTraversal = (conn) => {
+  let g = traversal().withRemote(conn);
+  if (process.env.GREMLIN_PARTITION) {
+    g = g.withStrategies(
+      new PartitionStrategy({
+        partitionKey: '_partition',
+        writePartition: process.env.GREMLIN_PARTITION,
+        readPartitions: [process.env.GREMLIN_PARTITION],
+      }),
+    );
+  }
+  return g;
+};
+
+const runTrackerDeliveryMaintenance = async (event = {}) => {
+  const conn = await getConnection();
+  try {
+    const g = graphTraversal(conn);
+    const synchronizer = createDeliverySynchronizer({
+      store: processStore,
+      resolveBinding: (projectId, bindingId) => fetchBinding(g, projectId, bindingId),
+      getTrackerProvider: getProvider,
+      trackerContext: (projectId, binding) => {
+        const gitProvider = trackerGitProvider(binding.provider);
+        return {
+          ddb,
+          ssm,
+          secrets,
+          userId: binding.createdBy,
+          ...(gitProvider
+            ? {
+                sourceControl: ({ repository, operation, args }) =>
+                  invokeProjectSourceControl({
+                    projectId,
+                    trackerProvider: binding.provider,
+                    repository,
+                    operation,
+                    args,
+                  }),
+              }
+            : {}),
+        };
+      },
+      getPullRequestStatus: ({ projectId, provider, repository, number }) => {
+        if (!provider || !repository || number === null || number === undefined) {
+          throw new ProviderError(400, 'Final pull request identity is incomplete');
+        }
+        return invokeSourceControl({
+          projectId,
+          provider,
+          repository,
+          operation: 'pr-status',
+          args: { number },
+        });
+      },
+      applicationUrl: process.env.APPLICATION_URL,
+      broadcast: broadcastToIntentChannel,
+    });
+    return synchronizer.runScheduled({ limit: Number(event.limit) || 25 });
+  } finally {
+    await conn.close().catch(() => {});
+  }
+};
+
 const handleProviderError = (response, err) => {
   if (err instanceof ProviderError) {
     if (err.status === 429) return response(429, err.extra);
@@ -447,6 +519,9 @@ const disconnectTracker = async (response, userId, provider, instance) => {
 };
 
 export const handler = async (event) => {
+  if (event?.action === 'reconcile-tracker-deliveries') {
+    return runTrackerDeliveryMaintenance(event);
+  }
   const response = buildResponse(event);
   if (event.httpMethod === 'OPTIONS') return response(200, {});
 
@@ -522,7 +597,6 @@ export const handler = async (event) => {
             userId: statePayload.userId,
             resource: resources[0],
             tokens,
-            scope: 'read:jira-work read:jira-user offline_access',
           });
           return response(200, { success: true });
         }
@@ -600,7 +674,6 @@ export const handler = async (event) => {
           refreshToken: ticketPayload.refreshToken,
           expiresIn: ticketPayload.expiresIn,
         },
-        scope: 'read:jira-work read:jira-user offline_access',
       });
       return response(200, { success: true });
     } catch (err) {
@@ -735,16 +808,7 @@ export const handler = async (event) => {
   let conn;
   try {
     conn = await getConnection();
-    let g = traversal().withRemote(conn);
-    if (process.env.GREMLIN_PARTITION) {
-      g = g.withStrategies(
-        new PartitionStrategy({
-          partitionKey: '_partition',
-          writePartition: process.env.GREMLIN_PARTITION,
-          readPartitions: [process.env.GREMLIN_PARTITION],
-        }),
-      );
-    }
+    const g = graphTraversal(conn);
 
     const bindingId = pathParameters.bindingId;
 
@@ -927,7 +991,7 @@ export const handler = async (event) => {
 
       // POST /projects/{id}/trackers/{bid}/issues/{rid}/comments
       if (httpMethod === 'POST' && resourceId && path.endsWith('/comments')) {
-        if (!gitProvider)
+        if (typeof provider.addIssueComment !== 'function')
           return response(405, { error: 'Comments are read-only for this tracker' });
         const data = body ? JSON.parse(body) : {};
         if (!String(data.body || '').trim()) {

--- a/lambda/trackers/providers/github-issues.js
+++ b/lambda/trackers/providers/github-issues.js
@@ -19,6 +19,9 @@ const getIssueDiscussion = (ctx, repository, resourceId) =>
 const addIssueComment = (ctx, repository, resourceId, body) =>
   invoke(ctx, repository, 'add-issue-comment', { number: resourceId, body });
 
+const closeIssue = (ctx, repository, resourceId) =>
+  invoke(ctx, repository, 'close-issue', { number: resourceId });
+
 const listExternalProjects = async () => {
   throw new ProviderError(
     501,
@@ -35,4 +38,5 @@ export const provider = {
   getIssue,
   getIssueDiscussion,
   addIssueComment,
+  closeIssue,
 };

--- a/lambda/trackers/providers/gitlab-issues.js
+++ b/lambda/trackers/providers/gitlab-issues.js
@@ -19,6 +19,9 @@ const getIssueDiscussion = (ctx, repository, resourceId) =>
 const addIssueComment = (ctx, repository, resourceId, body) =>
   invoke(ctx, repository, 'add-issue-comment', { number: resourceId, body });
 
+const closeIssue = (ctx, repository, resourceId) =>
+  invoke(ctx, repository, 'close-issue', { number: resourceId });
+
 const listExternalProjects = async () => {
   throw new ProviderError(
     501,
@@ -33,4 +36,5 @@ export const provider = {
   getIssue,
   getIssueDiscussion,
   addIssueComment,
+  closeIssue,
 };

--- a/lambda/trackers/providers/jira-cloud.js
+++ b/lambda/trackers/providers/jira-cloud.js
@@ -14,6 +14,7 @@ export { ProviderError };
 const JIRA_TOKEN_PARAM_PATTERN = /^\/[\w-]+\/[\w-]+\/[\w-]+\/[\w-]+$/;
 const PROVIDER_INSTANCE = 'jira-cloud#cloud';
 const REFRESH_SAFETY_MARGIN_MS = 60_000;
+const JIRA_OAUTH_SCOPE = 'read:jira-work read:jira-user write:jira-work offline_access';
 
 const requireEnv = (name) => {
   const v = process.env[name];
@@ -31,7 +32,7 @@ export const buildAuthorizeUrl = ({ clientId, redirectUri, state }) => {
   const params = new URLSearchParams({
     audience: 'api.atlassian.com',
     client_id: clientId,
-    scope: 'read:jira-work read:jira-user offline_access',
+    scope: JIRA_OAUTH_SCOPE,
     redirect_uri: redirectUri,
     state,
     response_type: 'code',
@@ -150,7 +151,7 @@ export const persistConnection = async ({ ddb, ssm, userId, resource, tokens, sc
         baseUrl: `https://api.atlassian.com/ex/jira/${resource.cloudId}`,
         siteHost: resource.host || '',
         siteName: resource.name || '',
-        scope: scope || 'read:jira-work read:jira-user offline_access',
+        scope: scope || JIRA_OAUTH_SCOPE,
         createdAt: new Date().toISOString(),
         expiresAt,
       },
@@ -359,6 +360,89 @@ const mapCommentToTrackerComment = (c) => ({
   updatedAt: c.updated || '',
 });
 
+// Jira comment writes require Atlassian Document Format (ADF), so convert the
+// small Markdown subset used by delivery comments: links, inline code, and
+// one-level nested bullet lists.
+// https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+const markdownLineToAdf = (line) => {
+  const content = [];
+  const tokenPattern = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)|`([^`]+)`|(https?:\/\/\S+)/g;
+  let cursor = 0;
+  for (const match of line.matchAll(tokenPattern)) {
+    if (match.index > cursor) content.push({ type: 'text', text: line.slice(cursor, match.index) });
+    if (match[1]) {
+      const text =
+        match[1].startsWith('`') && match[1].endsWith('`') ? match[1].slice(1, -1) : match[1];
+      content.push({
+        type: 'text',
+        text,
+        marks: [{ type: 'link', attrs: { href: match[2] } }],
+      });
+    } else if (match[3]) {
+      content.push({
+        type: 'text',
+        text: match[3],
+        marks: [{ type: 'code' }],
+      });
+    } else {
+      content.push({
+        type: 'text',
+        text: match[4],
+        marks: [{ type: 'link', attrs: { href: match[4] } }],
+      });
+    }
+    cursor = match.index + match[0].length;
+  }
+  if (cursor < line.length) content.push({ type: 'text', text: line.slice(cursor) });
+  return content.length ? { type: 'paragraph', content } : { type: 'paragraph' };
+};
+
+const markdownListItemToAdf = (line) => ({
+  type: 'listItem',
+  content: [markdownLineToAdf(line)],
+});
+
+const markdownToAdf = (body) => {
+  const content = [];
+  let bulletList = null;
+  let lastListItem = null;
+
+  const flushBulletList = () => {
+    if (bulletList) content.push(bulletList);
+    bulletList = null;
+    lastListItem = null;
+  };
+
+  for (const line of String(body).split('\n')) {
+    if (line.startsWith('  - ')) {
+      bulletList ??= { type: 'bulletList', content: [] };
+      if (!lastListItem) {
+        lastListItem = markdownListItemToAdf(line.slice(4));
+        bulletList.content.push(lastListItem);
+        continue;
+      }
+      let nested = lastListItem.content.find((node) => node.type === 'bulletList');
+      if (!nested) {
+        nested = { type: 'bulletList', content: [] };
+        lastListItem.content.push(nested);
+      }
+      nested.content.push(markdownListItemToAdf(line.slice(4)));
+      continue;
+    }
+    if (line.startsWith('- ')) {
+      bulletList ??= { type: 'bulletList', content: [] };
+      lastListItem = markdownListItemToAdf(line.slice(2));
+      bulletList.content.push(lastListItem);
+      continue;
+    }
+    flushBulletList();
+    content.push(markdownLineToAdf(line));
+  }
+  flushBulletList();
+
+  return { version: 1, type: 'doc', content };
+};
+
 // ---------------------------------------------------------------------------
 // JQL helpers
 // ---------------------------------------------------------------------------
@@ -473,10 +557,26 @@ const getIssueDiscussion = async ({ ddb, ssm, secrets, userId }, projectKey, res
   return comments.map(mapCommentToTrackerComment);
 };
 
+const addIssueComment = async ({ ddb, ssm, secrets, userId }, projectKey, resourceId, body) => {
+  if (!resourceId) throw new ProviderError(400, 'Missing resourceId');
+  const ctx = await buildContext({ ddb, ssm, secrets, userId });
+  const r = await jiraFetch(ctx, `/rest/api/3/issue/${encodeURIComponent(resourceId)}/comment`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body: markdownToAdf(body) }),
+  });
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) {
+    throw new ProviderError(r.status, data.errorMessages?.[0] || 'Failed to add Jira comment');
+  }
+  return mapCommentToTrackerComment(data);
+};
+
 export const provider = {
   id: 'jira-cloud',
   listExternalProjects,
   listIssues,
   getIssue,
   getIssueDiscussion,
+  addIssueComment,
 };

--- a/lambda/trackers/providers/jira-cloud.js
+++ b/lambda/trackers/providers/jira-cloud.js
@@ -14,7 +14,13 @@ export { ProviderError };
 const JIRA_TOKEN_PARAM_PATTERN = /^\/[\w-]+\/[\w-]+\/[\w-]+\/[\w-]+$/;
 const PROVIDER_INSTANCE = 'jira-cloud#cloud';
 const REFRESH_SAFETY_MARGIN_MS = 60_000;
-const JIRA_OAUTH_SCOPE = 'read:jira-work read:jira-user write:jira-work offline_access';
+const JIRA_WRITE_SCOPE = 'write:jira-work';
+const JIRA_OAUTH_SCOPES = ['read:jira-work', 'read:jira-user', JIRA_WRITE_SCOPE, 'offline_access'];
+
+const normalizeScopes = (scopes) =>
+  (Array.isArray(scopes) ? scopes : String(scopes || '').split(/[,\s]+/))
+    .map((scope) => String(scope).trim())
+    .filter(Boolean);
 
 const requireEnv = (name) => {
   const v = process.env[name];
@@ -32,7 +38,7 @@ export const buildAuthorizeUrl = ({ clientId, redirectUri, state }) => {
   const params = new URLSearchParams({
     audience: 'api.atlassian.com',
     client_id: clientId,
-    scope: JIRA_OAUTH_SCOPE,
+    scope: JIRA_OAUTH_SCOPES.join(' '),
     redirect_uri: redirectUri,
     state,
     response_type: 'code',
@@ -117,7 +123,7 @@ export const listAccessibleResources = async (accessToken) => {
 
 // Persist the connection row + SSM token. Used by both the single-resource
 // and the multi-resource finalize paths in the trackers handler.
-export const persistConnection = async ({ ddb, ssm, userId, resource, tokens, scope }) => {
+export const persistConnection = async ({ ddb, ssm, userId, resource, tokens }) => {
   const parameterName = `/${requireEnv('JIRA_TOKEN_SSM_PREFIX')}/${userId}`;
   if (!JIRA_TOKEN_PARAM_PATTERN.test(parameterName)) {
     throw new Error('Invalid SSM parameter name format');
@@ -151,7 +157,7 @@ export const persistConnection = async ({ ddb, ssm, userId, resource, tokens, sc
         baseUrl: `https://api.atlassian.com/ex/jira/${resource.cloudId}`,
         siteHost: resource.host || '',
         siteName: resource.name || '',
-        scope: scope || JIRA_OAUTH_SCOPE,
+        scope: normalizeScopes(resource.scopes).join(' '),
         createdAt: new Date().toISOString(),
         expiresAt,
       },
@@ -265,6 +271,17 @@ const buildContext = async ({ ddb, ssm, secrets, userId }) => {
     ssm,
     secrets,
   };
+};
+
+const requireWriteScope = (ctx) => {
+  if (normalizeScopes(ctx.row.scope).includes(JIRA_WRITE_SCOPE)) return;
+  const error = new ProviderError(
+    403,
+    'Jira connection is missing write:jira-work; reconnect Jira to continue',
+    { reconnect: true },
+  );
+  error.code = 'MISSING_SCOPES';
+  throw error;
 };
 
 const jiraFetch = async (ctx, path, init = {}) => {
@@ -560,6 +577,7 @@ const getIssueDiscussion = async ({ ddb, ssm, secrets, userId }, projectKey, res
 const addIssueComment = async ({ ddb, ssm, secrets, userId }, projectKey, resourceId, body) => {
   if (!resourceId) throw new ProviderError(400, 'Missing resourceId');
   const ctx = await buildContext({ ddb, ssm, secrets, userId });
+  requireWriteScope(ctx);
   const r = await jiraFetch(ctx, `/rest/api/3/issue/${encodeURIComponent(resourceId)}/comment`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/lambda/trackers/test/delivery-sync.test.js
+++ b/lambda/trackers/test/delivery-sync.test.js
@@ -4,6 +4,7 @@ import {
   CREATED_TASK_PHRASE,
   MERGED_PHRASE,
   MERGED_MR_PHRASE,
+  branchUrlFor,
   createDeliverySynchronizer,
 } from '../delivery-sync.js';
 
@@ -84,6 +85,36 @@ describe('tracker delivery synchronizer', () => {
     });
   });
 
+  it.each([
+    [
+      'github',
+      'https://github.com/acme/app/pull/7',
+      'https://github.com/acme/app/tree/aidlc/login',
+    ],
+    [
+      'gitlab',
+      'https://gitlab.com/acme/app/-/merge_requests/7',
+      'https://gitlab.com/acme/app/-/tree/aidlc/login',
+    ],
+    [
+      'bitbucket',
+      'https://bitbucket.org/acme/app/pull-requests/7',
+      'https://bitbucket.org/acme/app/branch/aidlc/login',
+    ],
+  ])('preserves branch path separators in %s links', (providerName, prUrl, expected) => {
+    expect(
+      branchUrlFor(
+        {
+          provider: providerName,
+          repoId: 'acme/app',
+          prUrl,
+          branch: 'aidlc/login',
+        },
+        null,
+      ),
+    ).toBe(expected);
+  });
+
   it('posts the created comment and advances to merge polling', async () => {
     await synchronizer.process(candidate);
 
@@ -91,7 +122,7 @@ describe('tracker delivery synchronizer', () => {
     const body = provider.addIssueComment.mock.calls[0][3];
     expect(body).toContain(CREATED_PHRASE);
     expect(body).toContain('https://aidlc.example/space/p1/intent/i1');
-    expect(body).toContain('[`feat/login`](https://github.com/acme/app/tree/feat%2Flogin)');
+    expect(body).toContain('[`feat/login`](https://github.com/acme/app/tree/feat/login)');
     expect(body).toContain('https://github.com/acme/app/pull/7');
     expect(store.updateTrackerSync).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -338,6 +369,45 @@ describe('tracker delivery synchronizer', () => {
       expect.objectContaining({
         state: 'BLOCKED',
         fields: expect.objectContaining({ attempts: 1 }),
+      }),
+    );
+  });
+
+  it('surfaces a reconnect instruction for stale Jira grants', async () => {
+    candidate = syncRow({
+      source: {
+        bindingId: 'tb-jira',
+        provider: 'jira-cloud',
+        instance: 'cloud',
+        resourceId: 'PROJ-42',
+      },
+    });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    provider.addIssueComment.mockRejectedValue(
+      Object.assign(new Error('Jira connection is missing write:jira-work'), {
+        status: 403,
+        code: 'MISSING_SCOPES',
+        extra: { reconnect: true },
+      }),
+    );
+
+    await synchronizer.process(candidate);
+
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'BLOCKED',
+        fields: expect.objectContaining({
+          lastError: expect.objectContaining({
+            code: 'MISSING_SCOPES',
+            reconnect: true,
+          }),
+        }),
+      }),
+    );
+    expect(store.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'v2.tracker.blocked',
+        summary: 'Reconnect Jira to resume tracker synchronization',
       }),
     );
   });

--- a/lambda/trackers/test/delivery-sync.test.js
+++ b/lambda/trackers/test/delivery-sync.test.js
@@ -1,0 +1,367 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CREATED_PHRASE,
+  CREATED_TASK_PHRASE,
+  MERGED_PHRASE,
+  MERGED_MR_PHRASE,
+  createDeliverySynchronizer,
+} from '../delivery-sync.js';
+
+const NOW = new Date('2026-08-10T12:00:00.000Z');
+
+const syncRow = (overrides = {}) => ({
+  executionId: 'e1',
+  projectId: 'p1',
+  intentId: 'i1',
+  intentTitle: 'Implement login',
+  workflowId: 'aidlc-v2',
+  workflowVersion: 4,
+  scope: 'feature',
+  branch: 'feat/login',
+  source: {
+    bindingId: 'tb1',
+    provider: 'github-issues',
+    instance: 'public',
+    resourceId: '42',
+    resourceUrl: 'https://github.com/acme/app/issues/42',
+  },
+  pullRequests: [
+    {
+      provider: 'github',
+      repoId: 'acme/app',
+      prNumber: 7,
+      prUrl: 'https://github.com/acme/app/pull/7',
+      branch: 'feat/login',
+      baseBranch: 'main',
+    },
+  ],
+  state: 'PR_CREATED',
+  attempts: 0,
+  ...overrides,
+});
+
+describe('tracker delivery synchronizer', () => {
+  let store;
+  let provider;
+  let getPullRequestStatus;
+  let resolveBinding;
+  let broadcast;
+  let candidate;
+  let synchronizer;
+
+  beforeEach(() => {
+    candidate = syncRow();
+    store = {
+      claimTrackerSync: vi.fn(async () => candidate),
+      updateTrackerSync: vi.fn(async () => ({})),
+      listTrackerSyncs: vi.fn(async () => [candidate]),
+      appendEvent: vi.fn(async () => ({})),
+    };
+    provider = {
+      getIssueDiscussion: vi.fn(async () => []),
+      addIssueComment: vi.fn(async () => ({})),
+      closeIssue: vi.fn(async () => ({})),
+    };
+    getPullRequestStatus = vi.fn(async () => ({ state: 'open' }));
+    resolveBinding = vi.fn(async () => ({
+      id: 'tb1',
+      provider: 'github-issues',
+      instance: 'public',
+      externalProjectKey: 'acme/app',
+      createdBy: 'u1',
+    }));
+    broadcast = vi.fn(async () => {});
+    synchronizer = createDeliverySynchronizer({
+      store,
+      resolveBinding,
+      getTrackerProvider: () => provider,
+      trackerContext: () => ({}),
+      getPullRequestStatus,
+      applicationUrl: 'https://aidlc.example',
+      broadcast,
+      clock: () => NOW,
+      ids: () => 'claim-1',
+    });
+  });
+
+  it('posts the created comment and advances to merge polling', async () => {
+    await synchronizer.process(candidate);
+
+    expect(provider.addIssueComment).toHaveBeenCalledOnce();
+    const body = provider.addIssueComment.mock.calls[0][3];
+    expect(body).toContain(CREATED_PHRASE);
+    expect(body).toContain('https://aidlc.example/space/p1/intent/i1');
+    expect(body).toContain('[`feat/login`](https://github.com/acme/app/tree/feat%2Flogin)');
+    expect(body).toContain('https://github.com/acme/app/pull/7');
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'WAITING_FOR_MERGE',
+        fields: expect.objectContaining({ attempts: 0, createdCommentedAt: NOW.toISOString() }),
+      }),
+    );
+    expect(broadcast).toHaveBeenCalledWith('i1', {
+      action: 'agent.note',
+      executionId: 'e1',
+      intentId: 'i1',
+      projectId: 'p1',
+      noteType: 'v2.tracker.commented',
+      summary: 'Added tracker delivery comment',
+    });
+  });
+
+  it('does not duplicate an existing created comment', async () => {
+    provider.getIssueDiscussion.mockResolvedValue([
+      {
+        body: `${CREATED_PHRASE}\nhttps://aidlc.example/space/p1/intent/i1`,
+      },
+    ]);
+
+    await synchronizer.process(candidate);
+
+    expect(provider.addIssueComment).not.toHaveBeenCalled();
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'WAITING_FOR_MERGE' }),
+    );
+  });
+
+  it('calls Jira sources tasks and keeps the task-specific idempotency signature', async () => {
+    candidate = syncRow({
+      source: {
+        bindingId: 'tb-jira',
+        provider: 'jira-cloud',
+        instance: 'cloud-1',
+        resourceId: 'PROJ-42',
+        resourceUrl: 'https://acme.atlassian.net/browse/PROJ-42',
+      },
+    });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+
+    await synchronizer.process(candidate);
+
+    const body = provider.addIssueComment.mock.calls[0][3];
+    expect(body).toContain(CREATED_TASK_PHRASE);
+    expect(body).not.toContain(CREATED_PHRASE);
+  });
+
+  it('requires every mixed-provider final PR to be merged', async () => {
+    candidate = syncRow({
+      state: 'WAITING_FOR_MERGE',
+      pullRequests: [
+        { provider: 'github', repoId: 'acme/app', prNumber: 7, prUrl: 'gh' },
+        { provider: 'bitbucket', repoId: 'acme/web', prNumber: 9, prUrl: 'bb' },
+      ],
+    });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    getPullRequestStatus.mockResolvedValueOnce({ state: 'merged' }).mockResolvedValueOnce({
+      state: 'open',
+    });
+
+    await synchronizer.process(candidate);
+
+    expect(getPullRequestStatus.mock.calls.map(([request]) => request.provider)).toEqual([
+      'github',
+      'bitbucket',
+    ]);
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'WAITING_FOR_MERGE' }),
+    );
+  });
+
+  it('advances after every final PR is merged', async () => {
+    candidate = syncRow({ state: 'WAITING_FOR_MERGE' });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    getPullRequestStatus.mockResolvedValue({ state: 'merged' });
+
+    await synchronizer.process(candidate);
+
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'PR_MERGED' }),
+    );
+  });
+
+  it('blocks a structurally incomplete final merge request instead of polling forever', async () => {
+    candidate = syncRow({
+      state: 'WAITING_FOR_MERGE',
+      pullRequests: [
+        {
+          provider: 'gitlab',
+          repoId: 'acme/app',
+          prNumber: null,
+          prUrl: 'https://gitlab.com/acme/app/-/merge_requests/7',
+        },
+      ],
+    });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+
+    await synchronizer.process(candidate);
+
+    expect(getPullRequestStatus).not.toHaveBeenCalled();
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'BLOCKED',
+        fields: expect.objectContaining({
+          lastError: expect.objectContaining({ code: 'PR_IDENTITY_INCOMPLETE' }),
+        }),
+      }),
+    );
+    expect(store.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'v2.tracker.blocked',
+        summary:
+          'Tracker synchronization stopped because final pull request identity is incomplete',
+      }),
+    );
+  });
+
+  it('blocks and stops polling when a final PR is closed without merge', async () => {
+    candidate = syncRow({ state: 'WAITING_FOR_MERGE' });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    getPullRequestStatus.mockResolvedValue({ state: 'closed' });
+
+    await synchronizer.process(candidate);
+
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'BLOCKED',
+        fields: expect.objectContaining({
+          lastError: expect.objectContaining({ code: 'PR_CLOSED_WITHOUT_MERGE' }),
+        }),
+      }),
+    );
+  });
+
+  it('posts the merged comment and completes providers without close capability', async () => {
+    candidate = syncRow({ state: 'PR_MERGED' });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    delete provider.closeIssue;
+
+    await synchronizer.process(candidate);
+
+    expect(provider.addIssueComment.mock.calls[0][3]).toBe(
+      `${MERGED_PHRASE}\n\n- \`acme/app\`: [#7](https://github.com/acme/app/pull/7)`,
+    );
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'COMPLETED' }),
+    );
+  });
+
+  it('posts the merged comment and closes trackers with close capability', async () => {
+    candidate = syncRow({ state: 'PR_MERGED' });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+
+    await synchronizer.process(candidate);
+
+    expect(provider.addIssueComment.mock.calls[0][3]).toBe(
+      `${MERGED_PHRASE}\n\n- \`acme/app\`: [#7](https://github.com/acme/app/pull/7)`,
+    );
+    expect(provider.closeIssue).toHaveBeenCalledWith({}, 'acme/app', '42');
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'COMPLETED' }),
+    );
+    expect(store.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'v2.tracker.closed',
+        summary: 'Closed Issue #42',
+      }),
+    );
+    expect(broadcast).toHaveBeenCalledWith(
+      'i1',
+      expect.objectContaining({
+        action: 'agent.note',
+        noteType: 'v2.tracker.closed',
+        summary: 'Closed Issue #42',
+      }),
+    );
+  });
+
+  it('uses native merge request notation in simplified GitLab comments', async () => {
+    candidate = syncRow({
+      state: 'PR_MERGED',
+      pullRequests: [
+        {
+          provider: 'gitlab',
+          repoId: 'acme/app',
+          prNumber: 7,
+          prUrl: 'https://gitlab.com/acme/app/-/merge_requests/7',
+        },
+      ],
+    });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    delete provider.closeIssue;
+
+    await synchronizer.process(candidate);
+
+    expect(provider.addIssueComment.mock.calls[0][3]).toBe(
+      `${MERGED_MR_PHRASE}\n\n- \`acme/app\`: [!7](https://gitlab.com/acme/app/-/merge_requests/7)`,
+    );
+  });
+
+  it('does not duplicate an existing simplified merged comment', async () => {
+    candidate = syncRow({ state: 'PR_MERGED' });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    provider.getIssueDiscussion.mockResolvedValue([
+      {
+        body: `${MERGED_PHRASE}\n\n\n\n- \`acme/app\`: [#7](https://github.com/acme/app/pull/7)`,
+      },
+    ]);
+
+    await synchronizer.process(candidate);
+
+    expect(provider.addIssueComment).not.toHaveBeenCalled();
+  });
+
+  it('blocks every tracker provider after ten consecutive write failures', async () => {
+    candidate = syncRow({ state: 'PR_CREATED', attempts: 9 });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    provider.addIssueComment.mockRejectedValue(new Error('permission denied'));
+
+    await synchronizer.process(candidate);
+
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'BLOCKED',
+        fields: expect.objectContaining({ attempts: 10 }),
+      }),
+    );
+  });
+
+  it('blocks immediately when tracker authorization cannot permit the write', async () => {
+    candidate = syncRow({ state: 'PR_CREATED' });
+    store.claimTrackerSync.mockResolvedValue(candidate);
+    provider.addIssueComment.mockRejectedValue(
+      Object.assign(new Error('comment permission denied'), { status: 403 }),
+    );
+
+    await synchronizer.process(candidate);
+
+    expect(store.updateTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'BLOCKED',
+        fields: expect.objectContaining({ attempts: 1 }),
+      }),
+    );
+  });
+
+  it('processes scheduled sync records with bounded concurrency', async () => {
+    const candidates = [syncRow({ executionId: 'e1' }), syncRow({ executionId: 'e2' })];
+    store.listTrackerSyncs.mockResolvedValue(candidates);
+    let releaseFirst;
+    const firstClaim = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    store.claimTrackerSync.mockImplementation(async ({ executionId }) => {
+      if (executionId === 'e1') await firstClaim;
+      return candidates.find((item) => item.executionId === executionId);
+    });
+
+    const scheduled = synchronizer.runScheduled({ concurrency: 2 });
+    await vi.waitFor(() =>
+      expect(store.claimTrackerSync).toHaveBeenCalledWith(
+        expect.objectContaining({ executionId: 'e2' }),
+      ),
+    );
+    releaseFirst();
+
+    await expect(scheduled).resolves.toMatchObject({ processed: 2 });
+  });
+});

--- a/lambda/trackers/test/jira-cloud.test.js
+++ b/lambda/trackers/test/jira-cloud.test.js
@@ -128,7 +128,9 @@ describe('jira-cloud — OAuth helpers', () => {
     expect(url).toContain('https://auth.atlassian.com/authorize');
     expect(url).toContain('client_id=cid');
     expect(url).toContain('audience=api.atlassian.com');
-    expect(url).toContain('scope=read%3Ajira-work+read%3Ajira-user+offline_access');
+    expect(url).toContain(
+      'scope=read%3Ajira-work+read%3Ajira-user+write%3Ajira-work+offline_access',
+    );
     expect(url).toContain('redirect_uri=https%3A%2F%2Fapp%2Fcb');
     expect(url).toContain('state=abc');
     expect(url).toContain('prompt=consent');
@@ -479,6 +481,87 @@ describe('jira-cloud — provider methods', () => {
       fetchMock.mockResolvedValueOnce(errResponse(404, { errorMessages: ['Not found'] }));
       const comments = await jiraProvider.getIssueDiscussion(ctx(), 'PROJ', 'PROJ-99');
       expect(comments).toEqual([]);
+    });
+  });
+
+  describe('addIssueComment', () => {
+    it('posts an ADF comment and maps the response', async () => {
+      fetchMock.mockResolvedValueOnce(
+        okResponse({
+          id: '1002',
+          author: { displayName: 'AI-DLC' },
+          body: adfDoc('AI-DLC completed the workflow for this task.'),
+          created: '2026-08-10T00:00:00.000+0000',
+          updated: '2026-08-10T00:00:00.000+0000',
+        }),
+      );
+
+      const comment = await jiraProvider.addIssueComment(
+        ctx(),
+        'PROJ',
+        'PROJ-42',
+        [
+          'AI-DLC completed the workflow for this task.',
+          '',
+          '- Intent: [Login](https://aidlc.example/space/p1/intent/i1)',
+          '- Branch: [`feat/login`](https://github.com/acme/app/tree/feat%2Flogin)',
+          '- Pull requests:',
+          '  - `acme/app`: https://github.com/acme/app/pull/7',
+        ].join('\n'),
+      );
+
+      expect(comment).toMatchObject({ id: '1002', author: { handle: 'AI-DLC' } });
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.method).toBe('POST');
+      const payload = JSON.parse(init.body);
+      expect(payload.body).toMatchObject({ type: 'doc', version: 1 });
+      expect(payload.body.content[1]).toEqual({ type: 'paragraph' });
+      const bulletList = payload.body.content.find((node) => node.type === 'bulletList');
+      expect(bulletList.content).toHaveLength(3);
+      expect(bulletList.content[0]).toMatchObject({
+        type: 'listItem',
+        content: [
+          {
+            type: 'paragraph',
+            content: expect.arrayContaining([
+              expect.objectContaining({
+                text: 'Login',
+                marks: [
+                  {
+                    type: 'link',
+                    attrs: { href: 'https://aidlc.example/space/p1/intent/i1' },
+                  },
+                ],
+              }),
+            ]),
+          },
+        ],
+      });
+      expect(bulletList.content[1].content[0].content).toContainEqual({
+        type: 'text',
+        text: 'feat/login',
+        marks: [
+          {
+            type: 'link',
+            attrs: { href: 'https://github.com/acme/app/tree/feat%2Flogin' },
+          },
+        ],
+      });
+      const nested = bulletList.content[2].content.find((node) => node.type === 'bulletList');
+      expect(nested.content[0].content[0].content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ text: 'acme/app', marks: [{ type: 'code' }] }),
+          expect.objectContaining({
+            text: 'https://github.com/acme/app/pull/7',
+            marks: [
+              {
+                type: 'link',
+                attrs: { href: 'https://github.com/acme/app/pull/7' },
+              },
+            ],
+          }),
+        ]),
+      );
     });
   });
 

--- a/lambda/trackers/test/jira-cloud.test.js
+++ b/lambda/trackers/test/jira-cloud.test.js
@@ -91,6 +91,7 @@ const seedConnectionRow = (overrides = {}) => ({
     baseUrl: `https://api.atlassian.com/ex/jira/${CLOUD_ID}`,
     siteHost: SITE_HOST,
     siteName: 'Acme',
+    scope: 'read:jira-work read:jira-user write:jira-work offline_access',
     expiresAt: Date.now() + 60 * 60 * 1000,
     ...overrides,
   },
@@ -215,7 +216,12 @@ describe('jira-cloud — persistConnection', () => {
       ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
       ssm: new SSMClient({}),
       userId: 'user-1',
-      resource: { cloudId: CLOUD_ID, name: 'Acme', host: SITE_HOST },
+      resource: {
+        cloudId: CLOUD_ID,
+        name: 'Acme',
+        host: SITE_HOST,
+        scopes: ['read:jira-work', 'write:jira-work', 'offline_access'],
+      },
       tokens: { accessToken: 'a', refreshToken: 'r', expiresIn: 3600 },
     });
     const ssmCall = ssmMock.commandCalls(PutParameterCommand)[0];
@@ -228,6 +234,7 @@ describe('jira-cloud — persistConnection', () => {
       cloudId: CLOUD_ID,
       siteHost: SITE_HOST,
       baseUrl: `https://api.atlassian.com/ex/jira/${CLOUD_ID}`,
+      scope: 'read:jira-work write:jira-work offline_access',
     });
   });
 });
@@ -504,7 +511,7 @@ describe('jira-cloud — provider methods', () => {
           'AI-DLC completed the workflow for this task.',
           '',
           '- Intent: [Login](https://aidlc.example/space/p1/intent/i1)',
-          '- Branch: [`feat/login`](https://github.com/acme/app/tree/feat%2Flogin)',
+          '- Branch: [`feat/login`](https://github.com/acme/app/tree/feat/login)',
           '- Pull requests:',
           '  - `acme/app`: https://github.com/acme/app/pull/7',
         ].join('\n'),
@@ -543,7 +550,7 @@ describe('jira-cloud — provider methods', () => {
         marks: [
           {
             type: 'link',
-            attrs: { href: 'https://github.com/acme/app/tree/feat%2Flogin' },
+            attrs: { href: 'https://github.com/acme/app/tree/feat/login' },
           },
         ],
       });
@@ -562,6 +569,61 @@ describe('jira-cloud — provider methods', () => {
           }),
         ]),
       );
+    });
+
+    it('keeps multi-repository branches and pull requests under separate list items', async () => {
+      fetchMock.mockResolvedValueOnce(
+        okResponse({
+          id: '1003',
+          author: { displayName: 'AI-DLC' },
+          body: adfDoc('AI-DLC completed the workflow for this task.'),
+          created: '2026-08-10T00:00:00.000+0000',
+          updated: '2026-08-10T00:00:00.000+0000',
+        }),
+      );
+
+      await jiraProvider.addIssueComment(
+        ctx(),
+        'PROJ',
+        'PROJ-42',
+        [
+          'AI-DLC completed the workflow for this task.',
+          '',
+          '- Branches:',
+          '  - `acme/api`: [`aidlc/login`](https://github.com/acme/api/tree/aidlc/login)',
+          '  - `acme/web`: [`aidlc/login`](https://github.com/acme/web/tree/aidlc/login)',
+          '- Pull requests:',
+          '  - `acme/api`: https://github.com/acme/api/pull/7',
+          '  - `acme/web`: https://github.com/acme/web/pull/8',
+        ].join('\n'),
+      );
+
+      const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+      const bulletList = payload.body.content.find((node) => node.type === 'bulletList');
+      const branches = bulletList.content[0];
+      const pullRequests = bulletList.content[1];
+      expect(branches.content[0].content[0].text).toBe('Branches:');
+      expect(branches.content[1].content).toHaveLength(2);
+      expect(pullRequests.content[0].content[0].text).toBe('Pull requests:');
+      expect(pullRequests.content[1].content).toHaveLength(2);
+      expect(pullRequests.content[1].content[0].content[0].content).toContainEqual(
+        expect.objectContaining({ text: 'https://github.com/acme/api/pull/7' }),
+      );
+    });
+
+    it('requires reconnect before writing with a legacy read-only grant', async () => {
+      ddbMock
+        .on(GetCommand, { TableName: TRACKER_TABLE })
+        .resolves(seedConnectionRow({ scope: 'read:jira-work read:jira-user offline_access' }));
+
+      await expect(
+        jiraProvider.addIssueComment(ctx(), 'PROJ', 'PROJ-42', 'Delivery complete'),
+      ).rejects.toMatchObject({
+        status: 403,
+        code: 'MISSING_SCOPES',
+        extra: { reconnect: true },
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
     });
   });
 

--- a/lambda/trackers/test/providers.test.js
+++ b/lambda/trackers/test/providers.test.js
@@ -31,16 +31,18 @@ describe('GitHub Issues project binding adapter', () => {
     expect(JSON.stringify(sourceControl.mock.calls)).not.toContain('must-not-be-used');
   });
 
-  it('delegates detail, discussion, and comment writes', async () => {
+  it('delegates detail, discussion, comment, and close operations', async () => {
     const sourceControl = vi.fn().mockResolvedValue({});
     const ctx = { sourceControl };
     await githubIssuesProvider.getIssue(ctx, 'acme/widgets', '42');
     await githubIssuesProvider.getIssueDiscussion(ctx, 'acme/widgets', '42');
     await githubIssuesProvider.addIssueComment(ctx, 'acme/widgets', '42', 'Ship it');
+    await githubIssuesProvider.closeIssue(ctx, 'acme/widgets', '42');
     expect(sourceControl.mock.calls.map(([request]) => request.operation)).toEqual([
       'get-issue',
       'list-issue-comments',
       'add-issue-comment',
+      'close-issue',
     ]);
   });
 

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -1359,7 +1359,6 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         store,
         meta,
         executionId,
-        gitProvider,
         applicationUrl,
         log: (m) => ctx.logger?.info?.(m, { intentId }),
       }),
@@ -1373,6 +1372,39 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
     // un-succeeds a run whose PR already exists on the remote.
     const openedPrs = prResults.map((r) => r.pr).filter(Boolean);
     if (openedPrs.length > 0) {
+      if (meta.source?.bindingId && meta.source?.resourceId) {
+        const published = await ctx.step('publish-tracker-sync', async () => {
+          try {
+            await store.putTrackerSync({
+              executionId,
+              projectId,
+              intentId,
+              source: meta.source,
+              pullRequests: openedPrs,
+              intentTitle: meta.title ?? null,
+              workflowId,
+              workflowVersion,
+              scope,
+              branch: meta.branch ?? null,
+            });
+            return true;
+          } catch (error) {
+            ctx.logger?.error?.('tracker sync publication failed', {
+              intentId,
+              error: error?.message,
+            });
+            return false;
+          }
+        });
+        if (!published) {
+          await emitEvent(
+            ctx,
+            'tracker-sync-publish-failed',
+            'v2.tracker.failed',
+            'Tracker synchronization could not be scheduled',
+          );
+        }
+      }
       const recordResult = await ctx.step('record-pr', async () => {
         try {
           return await invokeRuntime(
@@ -1646,7 +1678,6 @@ const openIntentPrs = async ({
   store,
   meta,
   executionId,
-  gitProvider,
   applicationUrl,
   log,
 }) => {
@@ -1709,16 +1740,57 @@ const openIntentPrs = async ({
     projectId: meta.projectId,
     intentId: meta.intentId ?? executionId,
   });
-  const body = [
-    `Automated ${gitProvider === 'gitlab' ? 'MR' : 'PR'} created by ${aidlcAttribution} (strategy: ${strategy})`,
-    ...unitLines,
-  ].join('\n');
+  const trackerRepository = (() => {
+    try {
+      const pathname = decodeURIComponent(new URL(meta.source?.resourceUrl).pathname);
+      if (meta.source?.provider === 'github-issues') {
+        const parts = pathname.split('/').filter(Boolean);
+        return parts.length >= 4 && parts[2] === 'issues' ? parts.slice(0, 2).join('/') : null;
+      }
+      if (meta.source?.provider === 'gitlab-issues') {
+        const marker = '/-/issues/';
+        const markerIndex = pathname.indexOf(marker);
+        return markerIndex > 0 ? pathname.slice(1, markerIndex) : null;
+      }
+    } catch {
+      // A missing or malformed source URL only omits the PR tracker reference.
+    }
+    return null;
+  })();
+  const trackerReferenceFor = (provider, repoId) => {
+    const resourceId = String(meta.source?.resourceId || '').trim();
+    if (!resourceId) return null;
+    const matchingTracker =
+      (meta.source?.provider === 'github-issues' && provider === 'github') ||
+      (meta.source?.provider === 'gitlab-issues' && provider === 'gitlab');
+    if (matchingTracker && trackerRepository) {
+      const issueRef =
+        trackerRepository.toLowerCase() === repoId.toLowerCase()
+          ? `#${resourceId}`
+          : `${trackerRepository}#${resourceId}`;
+      return `Closes ${issueRef}`;
+    }
+    if (meta.source?.provider === 'jira-cloud') {
+      return meta.source.resourceUrl
+        ? `Related task: [${resourceId}](${meta.source.resourceUrl})`
+        : `Related task: ${resourceId}`;
+    }
+    return meta.source?.resourceUrl
+      ? `Related issue: [#${resourceId}](${meta.source.resourceUrl})`
+      : null;
+  };
 
   const results = [];
   for (const repo of repos) {
     const repoId = typeof repo === 'string' ? repo : repo.url;
     const provider = repoProvider(meta, repoId);
     try {
+      const trackerReference = trackerReferenceFor(provider, repoId);
+      const body = [
+        `Automated ${provider === 'gitlab' ? 'MR' : 'PR'} created by ${aidlcAttribution} (strategy: ${strategy})`,
+        ...unitLines,
+        ...(trackerReference ? ['', trackerReference] : []),
+      ].join('\n');
       const activity = repoGitActivity(repoId);
       // Pre-check: does the intent branch exist remotely with commits ahead of
       // base? 'unknown' (comparison unavailable) falls through to the PR call
@@ -1780,6 +1852,7 @@ const openIntentPrs = async ({
           // VPC-attached runtime; the orchestrator has no Neptune access).
           pr: {
             repoId,
+            provider,
             prUrl: res.prUrl,
             prNumber: res.prNumber ?? null,
             branch,

--- a/lambda/v2-orchestrator/pr-attribution.js
+++ b/lambda/v2-orchestrator/pr-attribution.js
@@ -1,6 +1,6 @@
+import { buildIntentUrl } from '../shared/intent-url.js';
+
 export const buildIntentAttribution = ({ applicationUrl, projectId, intentId }) => {
-  const intentUrl = `${applicationUrl.replace(/\/+$/, '')}/space/${encodeURIComponent(
-    projectId,
-  )}/intent/${encodeURIComponent(intentId)}`;
+  const intentUrl = buildIntentUrl({ applicationUrl, projectId, intentId });
   return `[AI-DLC](${intentUrl})`;
 };

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -115,6 +115,7 @@ beforeEach(() => {
       // Default: gate is answered (not pending) by the time we re-read it.
       getHumanTask: vi.fn(async () => ({ status: 'answered' })),
       appendEvent: vi.fn(async () => ({})),
+      putTrackerSync: vi.fn(async (args) => args),
       failRunningStageAttempt: vi.fn(async () => null),
       listUnits: vi.fn(async () => []),
       getUnit: vi.fn(async () => null),
@@ -2416,11 +2417,94 @@ describe('WP6 — PR opened on SUCCEEDED (intent-pr)', () => {
     expect(recordCall.prs).toHaveLength(2);
     expect(recordCall.prs[0]).toMatchObject({
       repoId: 'o/r',
+      provider: 'github',
       prUrl: 'https://github.com/o/r/pull/7',
       prNumber: 7,
       branch: 'aidlc/i1',
       baseBranch: 'main',
     });
+  });
+
+  it('publishes final PR delivery for tracker-originated intents', async () => {
+    deps.store.getExecution = vi.fn(async () => ({
+      ...META,
+      title: 'Bookstore API',
+      source: {
+        bindingId: 'tb1',
+        provider: 'github-issues',
+        instance: 'public',
+        resourceId: '42',
+        resourceUrl: 'https://github.com/o/r/issues/42',
+      },
+    }));
+    deps.openPr = vi.fn(async ({ repoId }) => ({
+      prUrl: `https://github.com/${repoId}/pull/7`,
+      prNumber: 7,
+    }));
+
+    const res = await start();
+
+    expect(res.ok).toBe(true);
+    expect(deps.store.putTrackerSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionId: 'i1',
+        projectId: 'p1',
+        intentId: 'i1',
+        intentTitle: 'Bookstore API',
+        source: expect.objectContaining({ bindingId: 'tb1', resourceId: '42' }),
+        pullRequests: [
+          expect.objectContaining({
+            provider: 'github',
+            repoId: 'owner/repo',
+            prNumber: 7,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('adds a native closing reference to final PRs from a repository issue', async () => {
+    deps.store.getExecution = vi.fn(async () => ({
+      ...META,
+      source: {
+        bindingId: 'tb1',
+        provider: 'github-issues',
+        instance: 'public',
+        resourceId: '42',
+        resourceUrl: 'https://github.com/owner/repo/issues/42',
+      },
+    }));
+    deps.openPr = vi.fn(async () => ({
+      prUrl: 'https://github.com/owner/repo/pull/7',
+      prNumber: 7,
+    }));
+
+    await start();
+
+    expect(deps.openPr.mock.calls[0][0].body.trim().endsWith('Closes #42')).toBe(true);
+  });
+
+  it('links Jira tasks without claiming the PR will close them', async () => {
+    deps.store.getExecution = vi.fn(async () => ({
+      ...META,
+      source: {
+        bindingId: 'tb-jira',
+        provider: 'jira-cloud',
+        instance: 'cloud-1',
+        resourceId: 'PROJ-42',
+        resourceUrl: 'https://acme.atlassian.net/browse/PROJ-42',
+      },
+    }));
+    deps.openPr = vi.fn(async () => ({
+      prUrl: 'https://github.com/owner/repo/pull/7',
+      prNumber: 7,
+    }));
+
+    await start();
+
+    const body = deps.openPr.mock.calls[0][0].body;
+    expect(body).toContain('Related task: [PROJ-42](https://acme.atlassian.net/browse/PROJ-42)');
+    expect(body).not.toContain('Closes PROJ-42');
   });
 
   it('emits v2.pr.recorded after a successful record-pr (so the UI refetches live)', async () => {

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -267,6 +267,8 @@ resource "aws_iam_role_policy" "trackers" {
             var.tracker_connections_table_arn,
             var.source_control_bindings_table_arn,
             "${var.source_control_bindings_table_arn}/index/*",
+            var.v2_executions_table_arn,
+            "${var.v2_executions_table_arn}/index/*",
           ])
         },
         {
@@ -1566,7 +1568,7 @@ module "trackers_lambda" {
   function_name = "${var.project_name}-trackers-${var.environment}"
   handler       = "index.handler"
   runtime       = "nodejs24.x"
-  timeout       = 30
+  timeout       = 60
 
   source_path = [
     {
@@ -1600,11 +1602,36 @@ module "trackers_lambda" {
     GITLAB_REDIRECT_URI            = var.gitlab_redirect_uri
     SOURCE_CONTROL_FUNCTION        = module.source_control_lambda.lambda_function_name
     SOURCE_CONTROL_BINDINGS_TABLE  = var.source_control_bindings_table_name
+    V2_PROCESS_TABLE               = var.v2_executions_table_name
+    APPLICATION_URL                = var.application_url
+    CONNECTIONS_TABLE              = var.connections_table_name
+    WEBSOCKET_ENDPOINT             = var.websocket_api_endpoint_https
     BITBUCKET_OAUTH_SECRET_NAME    = var.bitbucket_oauth_secret_name
     BITBUCKET_REDIRECT_URI         = var.bitbucket_redirect_uri
     ENVIRONMENT                    = var.environment
     CORS_ALLOWED_ORIGINS           = var.cors_allowed_origins
   }
+}
+
+resource "aws_cloudwatch_event_rule" "tracker_delivery_reconciler" {
+  name                = "${var.project_name}-tracker-delivery-reconciler-${var.environment}"
+  description         = "Reconcile final pull request delivery with originating tracker items"
+  schedule_expression = "rate(1 minute)"
+}
+
+resource "aws_cloudwatch_event_target" "tracker_delivery_reconciler" {
+  rule      = aws_cloudwatch_event_rule.tracker_delivery_reconciler.name
+  target_id = "tracker-delivery-reconciler"
+  arn       = module.trackers_lambda.lambda_function_arn
+  input     = jsonencode({ action = "reconcile-tracker-deliveries" })
+}
+
+resource "aws_lambda_permission" "tracker_delivery_reconciler" {
+  statement_id  = "AllowExecutionFromTrackerDeliveryReconciler"
+  action        = "lambda:InvokeFunction"
+  function_name = module.trackers_lambda.lambda_function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.tracker_delivery_reconciler.arn
 }
 
 # Timeline Events Lambda
@@ -1963,6 +1990,7 @@ resource "aws_iam_role_policy" "realtime_fanout" {
     agents_orchestrator = aws_iam_role.agents_orchestrator.id
     v2_orchestrator     = aws_iam_role.v2_orchestrator.id # durable orchestrator live fan-out
     intents             = aws_iam_role.intents.id         # artifact edit / quorum-edit reload hints
+    trackers            = aws_iam_role.trackers.id        # tracker delivery timeline reload hints
   }
   name = "realtime-fanout"
   role = each.value


### PR DESCRIPTION
## Summary

- publish durable tracker-delivery synchronization after final PR/MR creation
- add provider-specific tracker comments, branch and delivery links, merge polling, and GitHub/GitLab issue closure
- add native closing references to generated PR/MR bodies and Jira task references
- surface tracker synchronization events live in the intent timeline
- provision the scheduled reconciler and required DynamoDB/WebSocket permissions

## Issue
Solves #353 

## Verification

- manually tested the end-to-end workflow on a deployed development environment, including tracker comment creation, PR linkage, merge detection, issue closure, and timeline updates
- repository commit hook: 614 tests passed
- focused review suite: 197 backend tests passed
- IntentActivityPanel: 4 tests passed
- frontend typecheck passed
- trackers and v2-orchestrator builds passed
- lint and formatting checks passed
- Terraform validation passed with existing deprecation warnings

<img width="912" height="350" alt="image" src="https://github.com/user-attachments/assets/026dc73b-27a0-45f0-83f4-674160cab9af" />

<img width="691" height="881" alt="image" src="https://github.com/user-attachments/assets/8c971b5e-a428-4ba3-873b-f3f1fae3ade6" />
