### PR TITLE
Fix paused-stage workspace recovery

### DIFF
--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -58,6 +58,7 @@ vi.mock('@/hooks/useProjectsCache', () => ({
 
 const get = vi.fn();
 const start = vi.fn();
+const rewind = vi.fn();
 const answerGate = vi.fn();
 const repair = vi.fn();
 const graph = vi.fn();
@@ -67,6 +68,7 @@ vi.mock('@/services/intents', () => ({
   intentsService: {
     get: (...a: unknown[]) => get(...a),
     start: (...a: unknown[]) => start(...a),
+    rewind: (...a: unknown[]) => rewind(...a),
     answerGate: (...a: unknown[]) => answerGate(...a),
     repair: (...a: unknown[]) => repair(...a),
     // Knowledge graph feeding the popovers/derived-items section — empty
@@ -147,6 +149,7 @@ describe('IntentView', () => {
     clearIntentCache();
     get.mockReset();
     start.mockReset();
+    rewind.mockReset();
     answerGate.mockReset();
     repair.mockReset();
     projectCacheMock.role = 'owner';
@@ -177,6 +180,78 @@ describe('IntentView', () => {
       </MemoryRouter>,
     );
     expect(await screen.findByTestId('compose-page')).toBeInTheDocument();
+  });
+
+  it('retries a failed run from its earliest failed stage', async () => {
+    get.mockResolvedValue({
+      ...baseDetail({
+        status: 'FAILED',
+        currentStage: 'units-generation',
+        failureReason: 'stage_failed: units-generation',
+      }),
+      stages: [
+        {
+          stageInstanceId: 'si-requirements',
+          stageId: 'requirements-analysis',
+          state: 'SUCCEEDED',
+          phase: 'inception',
+        },
+        {
+          stageInstanceId: 'si-units',
+          stageId: 'units-generation',
+          state: 'FAILED',
+          phase: 'inception',
+          runtimeError: 'workspace_restore_failed',
+        },
+      ],
+    });
+    rewind.mockResolvedValue({});
+
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Retry Units Generation' }));
+    expect(rewind).toHaveBeenCalledWith('p1', 'i1', { fromStageId: 'units-generation' });
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('restarts the workflow when a failed run has no failed stage row', async () => {
+    get.mockResolvedValue(
+      baseDetail({
+        status: 'FAILED',
+        failureReason: 'workspace_initialization_failed',
+      }),
+    );
+    start.mockResolvedValue({});
+
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Restart workflow' }));
+    expect(start).toHaveBeenCalledWith('p1', 'i1');
+    expect(rewind).not.toHaveBeenCalled();
+  });
+
+  it('restarts a stalled CREATED handoff even when a stale failed stage row remains', async () => {
+    get.mockResolvedValue({
+      ...baseDetail({
+        status: 'CREATED',
+        updatedAt: '2020-01-01T00:00:00.000Z',
+      }),
+      stages: [
+        {
+          stageInstanceId: 'si-old',
+          stageId: 'units-generation',
+          state: 'FAILED',
+          phase: 'inception',
+        },
+      ],
+    });
+    start.mockResolvedValue({});
+
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Restart workflow' }));
+    expect(start).toHaveBeenCalledWith('p1', 'i1');
+    expect(rewind).not.toHaveBeenCalled();
   });
 
   it('renders one QuestionEditor for the active gate (exclusive expansion)', async () => {

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -183,6 +183,15 @@ describe('IntentView', () => {
   });
 
   it('retries a failed run from its earliest failed stage', async () => {
+    compiled.mockResolvedValue({
+      graph: {
+        nodes: [
+          { stageId: 'requirements-analysis', phasePath: '01', order: 0 },
+          { stageId: 'units-generation', phasePath: '01', order: 1 },
+        ],
+        edges: [],
+      },
+    });
     get.mockResolvedValue({
       ...baseDetail({
         status: 'FAILED',
@@ -212,6 +221,38 @@ describe('IntentView', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Retry Units Generation' }));
     expect(rewind).toHaveBeenCalledWith('p1', 'i1', { fromStageId: 'units-generation' });
     expect(start).not.toHaveBeenCalled();
+  });
+
+  it('restarts when the only failed stage row is no longer in the compiled plan', async () => {
+    compiled.mockResolvedValue({
+      graph: {
+        nodes: [{ stageId: 'requirements-analysis', phasePath: '01', order: 0 }],
+        edges: [],
+      },
+    });
+    get.mockResolvedValue({
+      ...baseDetail({
+        status: 'FAILED',
+        currentStage: 'units-generation',
+        failureReason: 'stage_failed: units-generation',
+      }),
+      stages: [
+        {
+          stageInstanceId: 'si-units',
+          stageId: 'units-generation',
+          state: 'FAILED',
+          phase: 'inception',
+          runtimeError: 'workspace_restore_failed',
+        },
+      ],
+    });
+    start.mockResolvedValue({});
+
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Restart workflow' }));
+    expect(start).toHaveBeenCalledWith('p1', 'i1');
+    expect(rewind).not.toHaveBeenCalled();
   });
 
   it('restarts the workflow when a failed run has no failed stage row', async () => {

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -41,6 +41,7 @@ import {
   Loader2,
   MoreHorizontal,
   Play,
+  RotateCcw,
   Trash2,
   TriangleAlert,
   Wrench,
@@ -66,7 +67,9 @@ export default function IntentView() {
     answerGate,
     cancelIntent,
     deleteIntent,
+    rewindIntent,
     focusOutput,
+    stageRows,
     stageNameOf,
   } = useIntent();
   const navigate = useNavigate();
@@ -87,18 +90,26 @@ export default function IntentView() {
   const [repairing, setRepairing] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  // Restart (FAILED / stranded CREATED) via the /start endpoint, which
-  // re-enters the pipeline and clears a prior failureReason. Fresh DRAFTs
-  // start from the compose page, never from here (the redirect above).
-  const handleStart = async () => {
+  // A stage failure retries from the earliest failed stage, preserving all
+  // completed upstream work. Failures before any stage row exists (init-ws,
+  // plan setup, or a stranded CREATED hand-off) still require a full start.
+  const failedStage =
+    detail?.intent.status === 'FAILED'
+      ? (stageRows.find((stage) => stage.state === 'FAILED') ?? null)
+      : null;
+  const handleRecovery = async () => {
     if (!projectId || !intentId) return;
     setStarting(true);
     setActionError(null);
     try {
-      await intentsService.start(projectId, intentId);
-      await reload();
+      if (failedStage) {
+        await rewindIntent(failedStage.stageId);
+      } else {
+        await intentsService.start(projectId, intentId);
+        await reload();
+      }
     } catch (err) {
-      setActionError(err instanceof Error ? err.message : 'Failed to start intent');
+      setActionError(err instanceof Error ? err.message : 'Failed to recover intent');
     } finally {
       setStarting(false);
     }
@@ -325,8 +336,8 @@ export default function IntentView() {
         </div>
       )}
 
-      {/* FAILED (or a stalled CREATED hand-off): show the reason + offer a restart
-          (re-runs init-ws + the plan; the /start endpoint accepts both states). */}
+      {/* Stage failures resume from the first failed stage. Pre-stage failures and
+          stalled CREATED hand-offs have no rewind target and restart the plan. */}
       {(isFailed || isStalled) && (
         <div className="rounded border border-agent-error/30 bg-agent-error/10 px-3 py-3 text-sm">
           <div className="flex items-start justify-between gap-3">
@@ -347,7 +358,7 @@ export default function IntentView() {
               )}
             </div>
             <Button
-              onClick={handleStart}
+              onClick={handleRecovery}
               disabled={starting}
               size="sm"
               variant="outline"
@@ -355,10 +366,18 @@ export default function IntentView() {
             >
               {starting ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : failedStage ? (
+                <RotateCcw className="h-3.5 w-3.5" />
               ) : (
                 <Play className="h-3.5 w-3.5" />
               )}
-              {starting ? 'Restarting…' : 'Restart'}
+              {starting
+                ? failedStage
+                  ? 'Retrying…'
+                  : 'Restarting…'
+                : failedStage
+                  ? `Retry ${humanizeStageId(failedStage.stageId)}`
+                  : 'Restart workflow'}
             </Button>
           </div>
         </div>

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -95,7 +95,7 @@ export default function IntentView() {
   // plan setup, or a stranded CREATED hand-off) still require a full start.
   const failedStage =
     detail?.intent.status === 'FAILED'
-      ? (stageRows.find((stage) => stage.state === 'FAILED') ?? null)
+      ? (stageRows.find((stage) => stage.planned && stage.state === 'FAILED') ?? null)
       : null;
   const handleRecovery = async () => {
     if (!projectId || !intentId) return;

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -864,6 +864,17 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
           };
         }
 
+        // Credential resolution only permits active executions. Unpark META
+        // before AgentCore restores a released session's workspace, otherwise
+        // the re-clone is rejected while the execution still reads WAITING.
+        await ctxArg.step(`gate-unpark-${humanTaskId}`, () =>
+          store.updateExecution({
+            executionId,
+            status: 'RUNNING',
+            pendingHumanTaskId: null,
+          }),
+        );
+
         result = await runStage(ctxArg, invokeRuntime, { ...stageOpts, resumeFrom: humanTaskId });
       }
 

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -867,13 +867,28 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         // Credential resolution only permits active executions. Unpark META
         // before AgentCore restores a released session's workspace, otherwise
         // the re-clone is rejected while the execution still reads WAITING.
-        await ctxArg.step(`gate-unpark-${humanTaskId}`, () =>
-          store.updateExecution({
-            executionId,
-            status: 'RUNNING',
-            pendingHumanTaskId: null,
-          }),
-        );
+        const ownedUnpark = await ctxArg.step(`gate-unpark-${humanTaskId}`, async () => {
+          try {
+            await store.updateExecution({
+              executionId,
+              status: 'RUNNING',
+              pendingHumanTaskId: null,
+              fromStatus: 'WAITING',
+              ifOrchestratorRunId: runId,
+            });
+            return true;
+          } catch (e) {
+            if (e?.name === 'ConditionalCheckFailedException') return false;
+            throw e;
+          }
+        });
+        if (!ownedUnpark) {
+          ctx.logger?.info?.('run retired while unparking gate', { intentId, humanTaskId });
+          return {
+            state: 'TERMINAL',
+            value: { ok: false, reason: 'retired', intentId, humanTaskId },
+          };
+        }
 
         result = await runStage(ctxArg, invokeRuntime, { ...stageOpts, resumeFrom: humanTaskId });
       }

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -511,6 +511,40 @@ describe('orchestrator durable handler', () => {
     expect(statuses).not.toContain('FAILED');
   });
 
+  it('exits retired when cancel or rewind wins the unpark CAS', async () => {
+    const cas = Object.assign(new Error('cas'), { name: 'ConditionalCheckFailedException' });
+    deps.store.updateExecution = vi.fn(async (input) => {
+      if (input.fromStatus === 'WAITING') throw cas;
+      return { orchestratorRunId: input.orchestratorRunId ?? null };
+    });
+    deps.store.getExecution
+      .mockResolvedValueOnce(META)
+      .mockResolvedValue({ ...META, status: 'WAITING' });
+    deps.loadPlan.mockResolvedValue({ valid: true, plan: { stages: [{ stageId: 'a' }] } });
+    deps.store.getHumanTask = vi.fn(async () => ({ status: 'answered' }));
+    deps.invokeRuntime = makeRuntime(ctx, (payload, n) => {
+      if (n === 1) return { ok: true };
+      if (n === 2) return { ok: true, state: 'WAITING_FOR_HUMAN', humanTaskId: 'h1' };
+      return { ok: true, state: 'SUCCEEDED' };
+    });
+
+    const res = await __durableHandler(
+      { action: 'start', intentId: 'i1', executionId: 'i1' },
+      ctx,
+      deps,
+    );
+
+    expect(res).toMatchObject({ ok: false, reason: 'retired', humanTaskId: 'h1' });
+    expect(invokes.filter((p) => p.resumeFrom === 'h1')).toHaveLength(0);
+    expect(deps.store.updateExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'RUNNING',
+        fromStatus: 'WAITING',
+        ifOrchestratorRunId: expect.stringMatching(/^run-/),
+      }),
+    );
+  });
+
   it('skips release when parkReleaseSeconds is null', async () => {
     deps.store.getExecution
       .mockResolvedValueOnce({ ...META, parkReleaseSeconds: null })

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -184,6 +184,13 @@ describe('orchestrator durable handler', () => {
     deps.invokeRuntime = makeRuntime(ctx, (payload, n) => {
       if (n === 1) return { ok: true }; // init-ws
       if (n === 2) return { ok: true, state: 'WAITING_FOR_HUMAN', humanTaskId: 'h1' };
+      expect(deps.store.updateExecution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionId: 'i1',
+          status: 'RUNNING',
+          pendingHumanTaskId: null,
+        }),
+      );
       return { ok: true, state: 'SUCCEEDED' };
     });
 


### PR DESCRIPTION
## Summary

A paused stage could fail immediately after a human answered its question.

The run was still marked `WAITING` when AgentCore tried to restore its workspace. Because repository credentials are only available to active runs, the clone was rejected with `EXECUTION_NOT_ACTIVE` and the stage reported `workspace_restore_failed`.

The recovery button then used the full workflow start path, so every stage ran again instead of retrying only the failed stage.

## Changes

- Mark the execution `RUNNING` before resuming AgentCore, allowing workspace restoration to obtain repository credentials.
- Retry executions with a failed stage through the existing rewind path, preserving completed upstream work.
- Keep the full start path for failures that have no stage to retry, such as workspace initialization failures and stalled `CREATED` runs.

## Verification

- 151 v2 orchestrator tests passed.
- 39 focused IntentView tests passed.
- Frontend typecheck, formatting, lint, and production build passed.
- Orchestrator lint, formatting, and production build passed.

Fixes #401