### PR TITLE
feat: export native AI-DLC workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,13 @@ Useful environment variables when iterating:
 | `AIDLC_BACKEND_FILE`  | Path to an alternative `.s3.tfbackend`                                              |
 | `AIDLC_CONFIG_DIR`    | Directory holding `environments/`, for Terraform configuration outside the checkout |
 
+Use `--skip-seed` when applying infrastructure-only changes that do not modify
+the upstream AI-DLC pin, baseline blocks, or default workflow:
+
+```bash
+./scripts/deploy-terraform.sh dev --skip-seed
+```
+
 </details>
 
 ## Post-install configuration

--- a/docs/getting-started/first-intent.md
+++ b/docs/getting-started/first-intent.md
@@ -71,6 +71,7 @@ Not happy with a stage's output? Open its detail view and **restart from this st
 ## What's next
 
 - [Creating intents](../using-the-platform/creating-intents.md) — the full reference for intent creation
+- [Exporting a workspace](../using-the-platform/exporting-workspaces.md) — continue an intent in a local agent harness
 - [Observing intents](../using-the-platform/intent-observability.md) — everything on the workbench, observability, graph, and audit pages
 - [Git and tracker integration](../using-the-platform/git-integration.md) — connect trackers and understand branch/PR behavior
 - [Managing workflows](../using-the-platform/workflows.md) — tailor the methodology (platform administrators)

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -322,6 +322,13 @@ These environment variables are useful when iterating:
 
 With `lambda_vpc_scope = "public-egress"`, the deployment summary prints the NAT addresses to add to provider allow-lists. Development environments expose one address and production environments expose two; allow-list every address printed. See [Git and Tracker Integration → Static egress IPs](../using-the-platform/git-integration.md#static-egress-ips) for the affected services.
 
+For infrastructure-only changes that do not modify the upstream AI-DLC pin,
+baseline blocks, or default workflow, skip the post-apply reseed:
+
+```bash
+./scripts/deploy-terraform.sh dev --skip-seed
+```
+
 ### Bootstrap the first platform administrator
 
 The **Admin** page (user management, agent settings and default models, provider OAuth/App configuration, migrations) and workflow/building-block authoring require the **`platform-admin`** role. For local Cognito users, bootstrap the first administrator via the CLI (users must sign out and back in to pick up the group); afterwards, additional local admins can be granted or revoked in the UI under **Admin → Users**:

--- a/docs/using-the-platform/creating-intents.md
+++ b/docs/using-the-platform/creating-intents.md
@@ -66,6 +66,12 @@ endpoint. See [Managed tools and environments](managed-environments.md#select-an
 
 Terminal states are not dead ends: any executed stage can be [rewound](intent-observability.md#steering-and-rewind) to iterate.
 
+## Continue in a local agent harness
+
+After an intent starts, you can download a point-in-time native AI-DLC workspace for Claude, Codex, Kiro CLI, Kiro IDE, or OpenCode. The export control is beside **Discuss** in the intent header. Choose the harness with the small arrow, then use the adjacent download button.
+
+Running intents export their latest completed workflow checkpoint, so work from the active stage is not included. The handoff is one-way: local decisions, artifacts, and code changes do not synchronize back to the intent. See [Exporting a workspace](exporting-workspaces.md) for the archive contents and setup steps.
+
 ## The project intent list
 
 The project page lists all intents with live status (Running, Waiting for input, Completed, Failed), created/updated timestamps, and sorting. The global dashboard surfaces each project's latest intent and floats projects with active work to the top.

--- a/docs/using-the-platform/exporting-workspaces.md
+++ b/docs/using-the-platform/exporting-workspaces.md
@@ -1,0 +1,86 @@
+# Exporting a Workspace
+
+You can export an intent as a [native AI-DLC](https://github.com/awslabs/aidlc-workflows/tree/v2) workspace and continue the workflow in a local agent harness. The export preserves the intent's methodology state and work products in a portable ZIP.
+
+Use this when you want to inspect or continue the work outside Collaborative AIDLC. It is a point-in-time handoff, not a synchronized local copy of the intent.
+
+## Export an intent
+
+The export control appears beside **Discuss** in the intent header after the workflow has started.
+
+1. Select the small arrow on the left side of the export control.
+2. Choose a harness:
+   - Claude
+   - Codex
+   - Kiro CLI
+   - Kiro IDE
+   - OpenCode
+3. Select the download button beside the arrow.
+4. Review the handoff warning, then choose **Download workspace**.
+
+Choosing a harness only changes the export format. The ZIP is not prepared or downloaded until you select the download button and confirm.
+
+The selected harness determines the configuration files, launch command, and AI-DLC continuation command included in the setup instructions. If you do not select another harness, the export uses the CLI configured for the intent.
+
+## Which state is exported
+
+The exported state depends on what the intent is doing:
+
+- **Running:** the export uses the latest completed workflow checkpoint. Work from the stage currently in progress is not included.
+- **Waiting:** the export uses the current parked state, including completed stages, answers, and available artifacts.
+- **Succeeded, failed, or cancelled:** the export uses the current terminal state.
+
+A running intent cannot be exported until it has completed at least one checkpoint. Retry after the current stage reaches a workflow boundary if the UI reports that no completed checkpoint is available.
+
+## What the ZIP contains
+
+The archive contains the selected native AI-DLC distribution and a projection of the intent, including:
+
+- Harness-specific configuration and AI-DLC tools (.kiro, .claude, etc...)
+- Workflow state and the continuation point
+- The intent's pinned workflow projection, including custom scopes such as `feature-custom` and their stage execute/skip selection
+- Completed methodology artifacts
+- Recorded human questions and answers
+- The workflow audit trail and runtime graph
+- The approved unit-of-work dependency graph, when available
+- Repository URLs, intent branches, and workspace layout metadata
+- `export-manifest.json`, with the exported files, sizes, and SHA-256 hashes
+
+The export keeps the AI-DLC methodology revision pinned by the intent so the local workspace uses the same methodology definition as the collaborative run. It registers the intent's selected projection as a native AI-DLC scope, preserving a customized workflow instead of reverting to a standard feature scope.
+
+## What the ZIP does not contain
+
+Source repositories and source-control credentials are not bundled in the archive. The setup dialog provides commands to clone or update each repository on its declared intent branch using your own Git credentials.
+
+Active-stage work that has not reached a completed checkpoint is also excluded from a running-intent export.
+
+!!! warning "Local work is not synchronized back"
+
+    Decisions, approvals, artifacts, and code changes made in the exported workspace are not synchronized back to the original intent or added to its traceability history. Treat the export as a one-way handoff. Push local code through your normal source-control process if you want to preserve it.
+
+## Set up the downloaded workspace
+
+After the download starts, the setup dialog shows commands tailored to the archive's workspace layout and repositories. Follow them in order:
+
+1. Create a local directory and extract the ZIP.
+2. Clone or update the repositories on the branches listed by the export.
+3. Start the selected harness, or open the directory in Kiro IDE.
+4. Run the displayed AI-DLC continuation command inside the agent session.
+
+For multi-repository projects, keep the cloned repositories as immediate children of the exported workspace. When offered, the workspace-sync command reads `repos.json` and creates this layout automatically.
+
+The download URL is short-lived and expires after 15 minutes. Create another export if the download no longer starts.
+
+## Warnings and compatibility
+
+Read any warnings shown after the download. They can identify a legacy intent that did not pin its methodology revision or an older AI-DLC runtime that needs an explicit construction-unit continuation instruction.
+
+An export may be unavailable when:
+
+- The intent is still a draft or has not started.
+- A running intent has no completed checkpoint yet.
+- The workflow used incompatible edited methodology blocks.
+- The execution contains stages from different AI-DLC methodology revisions.
+- The intent changed while a parked-state export was being prepared. Retry to export a consistent snapshot.
+
+Exporting does not stop, cancel, or otherwise modify the collaborative intent.

--- a/frontend/src/components/intent/NativeExportSetupDialog.tsx
+++ b/frontend/src/components/intent/NativeExportSetupDialog.tsx
@@ -1,0 +1,316 @@
+import { useState } from 'react';
+import { Check, Copy, TriangleAlert } from 'lucide-react';
+import type { NativeWorkflowExport } from '@/services/intents';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+
+const shellQuote = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
+
+const workspaceDirectoryName = (value?: string | null) => {
+  const name = String(value ?? '')
+    .normalize('NFKD')
+    .replace(/[^\p{ASCII}]/gu, '')
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^[._-]+|[._-]+$/g, '')
+    .slice(0, 80)
+    .replace(/[._-]+$/g, '');
+  return name || 'aidlc-workspace';
+};
+
+const CommandBlock = ({ children, label }: { children: string; label: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(children);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative mt-2 min-w-0">
+      <pre className="w-full min-w-0 max-w-full whitespace-pre-wrap break-all rounded-md bg-muted py-2 pl-3 pr-10 font-mono text-xs leading-relaxed">
+        <code>{children}</code>
+      </pre>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute right-1.5 top-1.5 h-7 w-7"
+        aria-label={copied ? `${label} copied` : label}
+        title={copied ? 'Copied' : label}
+        onClick={() => void copy()}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-green-600" />
+        ) : (
+          <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
+      </Button>
+    </div>
+  );
+};
+
+interface NativeExportSetupDialogProps {
+  exportResult: NativeWorkflowExport | null;
+  projectName?: string | null;
+  onClose: () => void;
+}
+
+export function NativeExportSetupDialog({
+  exportResult,
+  projectName,
+  onClose,
+}: NativeExportSetupDialogProps) {
+  const setup = exportResult?.setup ?? null;
+  const showSetup = setup?.showWorkspaceSetup ?? false;
+  const exportDirectory = workspaceDirectoryName(projectName);
+  const downloadedZip = exportResult
+    ? `"$HOME/Downloads/${exportResult.filename}"`
+    : '"$HOME/Downloads/aidlc-workspace.zip"';
+  const extractCommands = [
+    `mkdir ${shellQuote(exportDirectory)}`,
+    `cd ${shellQuote(exportDirectory)}`,
+    `unzip ${downloadedZip} -d .`,
+  ].join('\n');
+  const legacyConstruction = setup?.construction?.perUnitIteration === false;
+  const completedUnitSummary = setup?.construction?.completedUnits.join(', ');
+  const constructionContinueCommand =
+    legacyConstruction && setup?.construction?.nextUnit && setup.continueCommand
+      ? [
+          `${setup.continueCommand} Continue the construction phase.`,
+          completedUnitSummary ? `Completed units: ${completedUnitSummary}.` : '',
+          `Continue with unit: ${setup.construction.nextUnit}.`,
+        ]
+          .filter(Boolean)
+          .join(' ')
+      : setup?.continueCommand;
+  const launchCommand = setup?.launchCommand ?? null;
+
+  return (
+    <AlertDialog
+      open={exportResult !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <AlertDialogContent className="max-h-[85vh] w-[calc(100vw-2rem)] max-w-4xl min-w-0 overflow-x-hidden overflow-y-scroll [&>*]:min-w-0">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {showSetup ? 'Set up your local workspace' : 'Workspace downloaded with warnings'}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {showSetup
+              ? 'The workspace download is in progress. Source code should be retrieved separately from Git using your own credentials.'
+              : 'Review these warnings before continuing with the downloaded workspace.'}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {!!exportResult?.warnings.length && (
+          <div
+            role="alert"
+            className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm"
+          >
+            <div className="flex items-center gap-2 font-medium">
+              <TriangleAlert className="h-4 w-4 shrink-0 text-amber-600" />
+              Export warnings
+            </div>
+            <ul className="list-disc space-y-1 pl-5 text-muted-foreground">
+              {exportResult.warnings.map((warning, index) => (
+                <li key={`${index}-${warning}`}>{warning}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {showSetup && setup?.mode === 'workspace-sync' && (
+          <ol className="list-decimal space-y-4 pl-5 text-sm">
+            <li>
+              Create an empty workspace directory and extract the downloaded ZIP:
+              <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
+            </li>
+            <li>
+              Clone the repositories declared by the export:
+              <CommandBlock label="Copy workspace sync command">
+                {setup.syncCommand ?? ''}
+              </CommandBlock>
+              <p className="mt-1 text-xs text-muted-foreground">
+                This reads <code>repos.json</code> and clones{' '}
+                {setup.repositories.length === 1
+                  ? 'the repository'
+                  : `all ${setup.repositories.length} repositories`}
+                {' on their declared intent branches.'}
+              </p>
+            </li>
+            <li>
+              Start the selected harness:
+              {launchCommand ? (
+                <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
+              ) : (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Open this directory in Kiro IDE.
+                </p>
+              )}
+              <p className="mt-1 text-xs text-muted-foreground">
+                Open this directory in your IDE. VS Code users may open{' '}
+                <code>aidlc.code-workspace</code>.
+              </p>
+            </li>
+            <li>
+              Then run inside the agent session:
+              <CommandBlock label="Copy AI-DLC command">
+                {constructionContinueCommand ?? ''}
+              </CommandBlock>
+            </li>
+          </ol>
+        )}
+
+        {showSetup && setup?.mode === 'manual-workspace' && (
+          <ol className="list-decimal space-y-4 pl-5 text-sm">
+            <li>
+              Create an empty workspace directory and extract the downloaded ZIP:
+              <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
+            </li>
+            <li>
+              Clone each repository into the workspace:
+              {setup.repositories.map((repository) => (
+                <div key={repository.id} className="mt-3 space-y-3">
+                  <div>
+                    <p className="text-xs font-medium">Fresh clone: {repository.id}</p>
+                    <CommandBlock label={`Copy fresh clone command for ${repository.id}`}>
+                      {`git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.directory)}`}
+                    </CommandBlock>
+                  </div>
+                  <div>
+                    <p className="text-xs font-medium">Existing clone: {repository.id}</p>
+                    <CommandBlock label={`Copy existing clone commands for ${repository.id}`}>
+                      {[
+                        `git -C ${shellQuote(repository.directory)} fetch origin`,
+                        `git -C ${shellQuote(repository.directory)} switch ${shellQuote(repository.branch)}`,
+                        `git -C ${shellQuote(repository.directory)} pull --ff-only`,
+                      ].join('\n')}
+                    </CommandBlock>
+                  </div>
+                </div>
+              ))}
+              <p className="mt-2 text-xs text-muted-foreground">
+                Keep these repositories as immediate children of the workspace, alongside{' '}
+                <code>aidlc/</code> and the harness directory.
+              </p>
+            </li>
+            <li>
+              Start the selected harness:
+              {launchCommand ? (
+                <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
+              ) : (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Open this directory in Kiro IDE.
+                </p>
+              )}
+            </li>
+            <li>
+              Then run inside the agent session:
+              <CommandBlock label="Copy AI-DLC command">
+                {constructionContinueCommand ?? ''}
+              </CommandBlock>
+            </li>
+          </ol>
+        )}
+
+        {showSetup && setup?.mode === 'manual-clone' && (
+          <ol className="list-decimal space-y-4 pl-5 text-sm">
+            <li>
+              Retrieve the source repository and its intent branch:
+              {setup.repositories.map((repository) => (
+                <div key={repository.id} className="mt-3 space-y-3">
+                  <div>
+                    <p className="text-xs font-medium">Fresh clone</p>
+                    <CommandBlock label={`Copy fresh clone commands for ${repository.id}`}>
+                      {[
+                        `git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.directory)}`,
+                        `cd ${shellQuote(repository.directory)}`,
+                      ].join('\n')}
+                    </CommandBlock>
+                  </div>
+                  <div>
+                    <p className="text-xs font-medium">Existing clone</p>
+                    <CommandBlock label={`Copy existing clone commands for ${repository.id}`}>
+                      {[
+                        `cd ${shellQuote(`/path/to/${repository.directory}`)}`,
+                        'git fetch origin',
+                        `git switch ${shellQuote(repository.branch)}`,
+                        'git pull --ff-only',
+                      ].join('\n')}
+                    </CommandBlock>
+                  </div>
+                </div>
+              ))}
+            </li>
+            <li>
+              From the repository root, extract the downloaded workspace:
+              <CommandBlock label="Copy extraction command">
+                {`unzip ${downloadedZip} -d .`}
+              </CommandBlock>
+            </li>
+            <li>
+              Start the selected harness:
+              {launchCommand ? (
+                <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
+              ) : (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Open this directory in Kiro IDE.
+                </p>
+              )}
+            </li>
+            <li>
+              Then run inside the agent session:
+              <CommandBlock label="Copy AI-DLC command">
+                {constructionContinueCommand ?? ''}
+              </CommandBlock>
+            </li>
+          </ol>
+        )}
+
+        {showSetup && setup?.mode === 'extract-only' && (
+          <ol className="list-decimal space-y-4 pl-5 text-sm">
+            <li>
+              Create a project directory and extract the downloaded workspace:
+              <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
+            </li>
+            <li>Open the extracted workspace directory in your IDE.</li>
+            <li>
+              Start the selected harness:
+              {launchCommand ? (
+                <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
+              ) : (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Open this directory in Kiro IDE.
+                </p>
+              )}
+            </li>
+            <li>
+              Then run inside the agent session:
+              <CommandBlock label="Copy AI-DLC command">
+                {constructionContinueCommand ?? ''}
+              </CommandBlock>
+            </li>
+          </ol>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogAction onClick={onClose}>Done</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/intent/WorkProductsSection.tsx
+++ b/frontend/src/components/intent/WorkProductsSection.tsx
@@ -56,18 +56,6 @@ export function WorkProductsSection({ detail, gates }: WorkProductsSectionProps)
     if (!['CREATED', 'RUNNING', 'WAITING'].includes(detail.intent.status)) {
       return null;
     }
-    return (
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-sm">Work products</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="py-4 text-center text-sm text-muted-foreground">
-            No work products yet — documents, items and code will appear here as the run progresses.
-          </p>
-        </CardContent>
-      </Card>
-    );
   }
 
   return (
@@ -75,36 +63,38 @@ export function WorkProductsSection({ detail, gates }: WorkProductsSectionProps)
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between gap-2">
           <CardTitle className="text-sm">Work products</CardTitle>
-          {documentCount > 1 && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7"
-                    aria-label={
-                      newestFirst
-                        ? 'Sort work products by oldest first'
-                        : 'Sort work products by newest first'
-                    }
-                    onClick={() => {
-                      const nextOrder = newestFirst ? 'oldest-first' : 'newest-first';
-                      setDocumentOrderState(nextOrder);
-                      setDocumentOrder(nextOrder);
-                    }}
-                  >
-                    <ArrowDownUp className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {newestFirst
-                    ? 'Show oldest work products first'
-                    : 'Show newest work products first'}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
+          <div className="flex items-center gap-1">
+            {documentCount > 1 && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7"
+                      aria-label={
+                        newestFirst
+                          ? 'Sort work products by oldest first'
+                          : 'Sort work products by newest first'
+                      }
+                      onClick={() => {
+                        const nextOrder = newestFirst ? 'oldest-first' : 'newest-first';
+                        setDocumentOrderState(nextOrder);
+                        setDocumentOrder(nextOrder);
+                      }}
+                    >
+                      <ArrowDownUp className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {newestFirst
+                      ? 'Show oldest work products first'
+                      : 'Show newest work products first'}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
         </div>
         {detail.intent.planWarnings &&
           detail.intent.planWarnings.length > 0 &&
@@ -126,24 +116,32 @@ export function WorkProductsSection({ detail, gates }: WorkProductsSectionProps)
           )}
       </CardHeader>
       <CardContent className="space-y-3">
-        <ProvenanceTree
-          detail={detail}
-          stageRows={stageRows}
-          phaseNameOf={phaseNameOf}
-          getNeighbors={getNeighbors}
-          itemsByArtifact={itemsByArtifact}
-          derivedItems={derivedItems}
-          codeItems={codeItems}
-          openArtifactPreview={openArtifactPreview}
-          openItemPreview={openItemPreview}
-          documentOrder={documentOrder}
-        />
+        {detail.artifacts.length > 0 || codeItems.length > 0 ? (
+          <ProvenanceTree
+            detail={detail}
+            stageRows={stageRows}
+            phaseNameOf={phaseNameOf}
+            getNeighbors={getNeighbors}
+            itemsByArtifact={itemsByArtifact}
+            derivedItems={derivedItems}
+            codeItems={codeItems}
+            openArtifactPreview={openArtifactPreview}
+            openItemPreview={openItemPreview}
+            documentOrder={documentOrder}
+          />
+        ) : (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            No work products yet — documents, items and code will appear here as the run progresses.
+          </p>
+        )}
 
-        <HistorySection
-          questionGates={questionGates}
-          steering={steering}
-          influencedArtifactsByQuestion={influencedArtifactsByQuestion}
-        />
+        {(questionGates.length > 0 || steering.length > 0) && (
+          <HistorySection
+            questionGates={questionGates}
+            steering={steering}
+            influencedArtifactsByQuestion={influencedArtifactsByQuestion}
+          />
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -4,7 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router';
 
 const yjsMock = vi.hoisted(() => ({ docs: new Map<string, unknown>() }));
-const projectCacheMock = vi.hoisted(() => ({ role: 'owner' as 'owner' | 'admin' | 'member' }));
+const projectCacheMock = vi.hoisted(() => ({
+  role: 'owner' as 'owner' | 'admin' | 'member',
+  name: 'Bookstore Tracker',
+}));
 
 // Heavy leaf components are stubbed to simple markers — these tests exercise
 // IntentView's OWN rendering logic (DRAFT card, pipeline, gates, artifacts)
@@ -53,7 +56,9 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({ user: { displayName: 'U', email: 'u@x' } }),
 }));
 vi.mock('@/hooks/useProjectsCache', () => ({
-  useProjectCache: () => ({ project: { userRole: projectCacheMock.role } }),
+  useProjectCache: () => ({
+    project: { name: projectCacheMock.name, userRole: projectCacheMock.role },
+  }),
 }));
 
 const get = vi.fn();
@@ -165,6 +170,7 @@ describe('IntentView', () => {
     });
     writeText.mockReset().mockResolvedValue(undefined);
     projectCacheMock.role = 'owner';
+    projectCacheMock.name = 'Bookstore Tracker';
     graph.mockReset().mockResolvedValue({ nodes: [], edges: [] });
     compiled.mockReset().mockResolvedValue({ graph: { nodes: [], edges: [] } });
     workflowGet.mockReset().mockResolvedValue({ phases: [] });
@@ -588,9 +594,8 @@ describe('IntentView', () => {
       warnings: [],
       setup: {
         workspaceLayout: 'spaces',
-        mode: 'workspace-sync',
+        mode: 'manual-workspace',
         harnessDir: '.codex',
-        syncCommand: 'bun .codex/tools/aidlc-workspace-sync.ts',
         launchCommand: 'codex',
         continueCommand: '$aidlc',
         showWorkspaceSetup: true,
@@ -620,11 +625,11 @@ describe('IntentView', () => {
 
     expect(downloadClick).toHaveBeenCalledOnce();
     expect(await screen.findByText('Set up your local workspace')).toBeInTheDocument();
-    expect(screen.getByText(/mkdir 'workspace'/)).toBeInTheDocument();
+    expect(screen.getByText(/mkdir 'Bookstore_Tracker'/)).toBeInTheDocument();
     expect(screen.getByText(/unzip "\$HOME\/Downloads\/workspace.zip" -d \./)).toBeInTheDocument();
-    expect(screen.getByText('bun .codex/tools/aidlc-workspace-sync.ts')).toBeInTheDocument();
-    expect(screen.getByText(/all 2 repositories/)).toBeInTheDocument();
-    expect(screen.getByText('aidlc.code-workspace')).toBeInTheDocument();
+    expect(screen.getByText(/git clone --branch 'aidlc\/i1'.*'api'/)).toBeInTheDocument();
+    expect(screen.getByText(/git clone --branch 'aidlc\/i1'.*'web'/)).toBeInTheDocument();
+    expect(screen.queryByText(/aidlc-workspace-sync/)).not.toBeInTheDocument();
     expect(screen.getByText('Start the selected harness:')).toBeInTheDocument();
     expect(screen.getByText('codex')).toBeInTheDocument();
     expect(screen.getByText('Then run inside the agent session:')).toBeInTheDocument();

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -631,7 +631,7 @@ describe('IntentView', () => {
     expect(screen.getByRole('alert')).toHaveTextContent(
       'This legacy intent did not pin a native upstream ref; the current deployment ref was used.',
     );
-    expect(screen.queryByText('Create a project directory')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Create a project directory/)).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(screen.queryByText('Workspace downloaded with warnings')).not.toBeInTheDocument();
@@ -713,6 +713,61 @@ describe('IntentView', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(screen.queryByText('Set up your local workspace')).not.toBeInTheDocument();
+    downloadClick.mockRestore();
+  });
+
+  it('renders and copies workspace-sync setup instructions', async () => {
+    get.mockResolvedValue(
+      baseDetail({
+        status: 'WAITING',
+        agentCli: 'codex',
+        currentPhase: 'CONSTRUCTION',
+      }),
+    );
+    exportWorkflow.mockResolvedValue({
+      exportId: 'export-sync',
+      filename: 'workspace.zip',
+      downloadUrl: 'https://download.example/workspace.zip',
+      expiresAt: '2026-08-12T12:15:00.000Z',
+      warnings: [],
+      setup: {
+        workspaceLayout: 'spaces',
+        mode: 'workspace-sync',
+        harnessDir: '.codex',
+        launchCommand: 'codex',
+        continueCommand: '$aidlc',
+        syncCommand: 'bun .codex/tools/aidlc-workspace-sync.ts',
+        showWorkspaceSetup: true,
+        repositories: [
+          {
+            id: 'example/plant-finder',
+            directory: 'plant-finder',
+            url: 'git@github.com:example/plant-finder.git',
+            branch: 'aidlc/intent-1',
+          },
+        ],
+      },
+    });
+    const downloadClick = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Download Codex workspace' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Download workspace' }));
+
+    expect(await screen.findByText('Set up your local workspace')).toBeInTheDocument();
+    expect(screen.getByText('bun .codex/tools/aidlc-workspace-sync.ts')).toBeInTheDocument();
+    expect(screen.getByText('repos.json').closest('p')).toHaveTextContent(
+      'This reads repos.json and clones the repository on their declared intent branches.',
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy workspace sync command' }));
+    expect(writeText).toHaveBeenCalledWith('bun .codex/tools/aidlc-workspace-sync.ts');
+    expect(
+      screen.getByRole('button', { name: 'Copy workspace sync command copied' }),
+    ).toBeInTheDocument();
+
     downloadClick.mockRestore();
   });
 

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -62,6 +62,7 @@ const rewind = vi.fn();
 const answerGate = vi.fn();
 const repair = vi.fn();
 const exportWorkflow = vi.fn();
+const writeText = vi.fn();
 const graph = vi.fn();
 const compiled = vi.fn();
 const workflowGet = vi.fn();
@@ -158,6 +159,11 @@ describe('IntentView', () => {
     answerGate.mockReset();
     repair.mockReset();
     exportWorkflow.mockReset();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    writeText.mockReset().mockResolvedValue(undefined);
     projectCacheMock.role = 'owner';
     graph.mockReset().mockResolvedValue({ nodes: [], edges: [] });
     compiled.mockReset().mockResolvedValue({ graph: { nodes: [], edges: [] } });
@@ -571,7 +577,7 @@ describe('IntentView', () => {
       baseDetail({
         status: 'WAITING',
         agentCli: 'codex',
-        currentPhase: 'CONSTRUCTION',
+        currentPhase: 'INCEPTION',
       }),
     );
     exportWorkflow.mockResolvedValue({
@@ -587,10 +593,17 @@ describe('IntentView', () => {
         syncCommand: 'bun .codex/tools/aidlc-workspace-sync.ts',
         launchCommand: 'codex',
         continueCommand: '$aidlc',
+        showWorkspaceSetup: true,
         repositories: [
           { name: 'api', url: 'git@github.com:example/api.git', branch: 'aidlc/i1' },
           { name: 'web', url: 'git@github.com:example/web.git', branch: 'aidlc/i1' },
         ],
+        construction: {
+          nextUnit: 'identify-plant',
+          completedUnits: ['upload-image'],
+          readyUnits: ['identify-plant'],
+          perUnitIteration: true,
+        },
       },
     });
     const downloadClick = vi
@@ -612,7 +625,14 @@ describe('IntentView', () => {
     expect(screen.getByText('bun .codex/tools/aidlc-workspace-sync.ts')).toBeInTheDocument();
     expect(screen.getByText(/all 2 repositories/)).toBeInTheDocument();
     expect(screen.getByText('aidlc.code-workspace')).toBeInTheDocument();
-    expect(screen.getByText(/codex[\s\S]*\$aidlc/)).toBeInTheDocument();
+    expect(screen.getByText('Start the selected harness:')).toBeInTheDocument();
+    expect(screen.getByText('codex')).toBeInTheDocument();
+    expect(screen.getByText('Then run inside the agent session:')).toBeInTheDocument();
+    expect(screen.getByText('$aidlc')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy AI-DLC command' }));
+    expect(writeText).toHaveBeenCalledWith('$aidlc');
+    expect(screen.getByRole('button', { name: 'Copy AI-DLC command copied' })).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(screen.queryByText('Set up your local workspace')).not.toBeInTheDocument();
@@ -639,6 +659,7 @@ describe('IntentView', () => {
         harnessDir: '.claude',
         launchCommand: 'claude',
         continueCommand: '/aidlc',
+        showWorkspaceSetup: true,
         repositories: [
           {
             name: 'plant-finder',
@@ -646,6 +667,12 @@ describe('IntentView', () => {
             branch: 'aidlc/intent-1',
           },
         ],
+        construction: {
+          nextUnit: 'identify-plant',
+          completedUnits: ['upload-image'],
+          readyUnits: ['identify-plant'],
+          perUnitIteration: false,
+        },
       },
     });
     const downloadClick = vi
@@ -668,7 +695,13 @@ describe('IntentView', () => {
     expect(
       screen.getByText(/unzip "\$HOME\/Downloads\/legacy-claude.zip" -d \./),
     ).toBeInTheDocument();
-    expect(screen.getByText(/claude[\s\S]*\/aidlc/)).toBeInTheDocument();
+    expect(screen.getByText('claude')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '/aidlc Continue the construction phase. Completed units: upload-image. Continue with unit: identify-plant.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/older AI-DLC runtime/)).toBeInTheDocument();
     expect(screen.queryByText(/local\/aidlc-continuation/)).not.toBeInTheDocument();
     downloadClick.mockRestore();
   });

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -617,8 +617,18 @@ describe('IntentView', () => {
         continueCommand: '$aidlc',
         showWorkspaceSetup: true,
         repositories: [
-          { name: 'api', url: 'git@github.com:example/api.git', branch: 'aidlc/i1' },
-          { name: 'web', url: 'git@github.com:example/web.git', branch: 'aidlc/i1' },
+          {
+            id: 'org-a/api',
+            directory: 'org-a_api',
+            url: 'git@github.com:org-a/api.git',
+            branch: 'aidlc/i1',
+          },
+          {
+            id: 'org-b/api',
+            directory: 'org-b_api',
+            url: 'git@github.com:org-b/api.git',
+            branch: 'aidlc/i1',
+          },
         ],
         construction: {
           nextUnit: 'identify-plant',
@@ -644,8 +654,10 @@ describe('IntentView', () => {
     expect(await screen.findByText('Set up your local workspace')).toBeInTheDocument();
     expect(screen.getByText(/mkdir 'Bookstore_Tracker'/)).toBeInTheDocument();
     expect(screen.getByText(/unzip "\$HOME\/Downloads\/workspace.zip" -d \./)).toBeInTheDocument();
-    expect(screen.getByText(/git clone --branch 'aidlc\/i1'.*'api'/)).toBeInTheDocument();
-    expect(screen.getByText(/git clone --branch 'aidlc\/i1'.*'web'/)).toBeInTheDocument();
+    expect(screen.getByText('Fresh clone: org-a/api')).toBeInTheDocument();
+    expect(screen.getByText('Fresh clone: org-b/api')).toBeInTheDocument();
+    expect(screen.getByText(/git clone --branch 'aidlc\/i1'.*'org-a_api'/)).toBeInTheDocument();
+    expect(screen.getByText(/git clone --branch 'aidlc\/i1'.*'org-b_api'/)).toBeInTheDocument();
     expect(screen.queryByText(/aidlc-workspace-sync/)).not.toBeInTheDocument();
     expect(screen.getByText('Start the selected harness:')).toBeInTheDocument();
     expect(screen.getByText('codex')).toBeInTheDocument();
@@ -684,7 +696,8 @@ describe('IntentView', () => {
         showWorkspaceSetup: true,
         repositories: [
           {
-            name: 'plant-finder',
+            id: 'example/plant-finder',
+            directory: 'plant-finder',
             url: 'git@github.com:example/plant-finder.git',
             branch: 'aidlc/intent-1',
           },

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -571,6 +571,9 @@ describe('IntentView', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Choose workspace harness' }));
     expect(await screen.findByText('Codex')).toBeInTheDocument();
     await userEvent.click(await screen.findByText('Claude'));
+    expect(screen.queryByText('Continue outside Collaborative AI-DLC?')).not.toBeInTheDocument();
+    expect(exportWorkflow).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: 'Download Claude workspace' }));
     expect(await screen.findByText('Continue outside Collaborative AI-DLC?')).toBeInTheDocument();
     expect(screen.getByText(/will not be synchronized back to this intent/i)).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Download workspace' }));

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -595,14 +595,16 @@ describe('IntentView', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
-  it('shows export warnings even when no workspace setup is required', async () => {
+  it('shows the legacy-ref warning even when no workspace setup is required', async () => {
     get.mockResolvedValue(baseDetail({ status: 'WAITING', agentCli: 'codex' }));
     exportWorkflow.mockResolvedValue({
       exportId: 'export-warning',
       filename: 'workspace.zip',
       downloadUrl: 'https://download.example/workspace.zip',
       expiresAt: '2026-08-12T12:15:00.000Z',
-      warnings: ['The pinned runtime has limited per-unit Construction support.'],
+      warnings: [
+        'This legacy intent did not pin a native upstream ref; the current deployment ref was used.',
+      ],
       setup: {
         workspaceLayout: 'spaces',
         mode: 'extract-only',
@@ -624,7 +626,7 @@ describe('IntentView', () => {
     expect(downloadClick).toHaveBeenCalledOnce();
     expect(await screen.findByText('Workspace downloaded with warnings')).toBeInTheDocument();
     expect(screen.getByRole('alert')).toHaveTextContent(
-      'The pinned runtime has limited per-unit Construction support.',
+      'This legacy intent did not pin a native upstream ref; the current deployment ref was used.',
     );
     expect(screen.queryByText('Create a project directory')).not.toBeInTheDocument();
 

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -61,6 +61,7 @@ const start = vi.fn();
 const rewind = vi.fn();
 const answerGate = vi.fn();
 const repair = vi.fn();
+const exportWorkflow = vi.fn();
 const graph = vi.fn();
 const compiled = vi.fn();
 const workflowGet = vi.fn();
@@ -71,6 +72,7 @@ vi.mock('@/services/intents', () => ({
     rewind: (...a: unknown[]) => rewind(...a),
     answerGate: (...a: unknown[]) => answerGate(...a),
     repair: (...a: unknown[]) => repair(...a),
+    exportWorkflow: (...a: unknown[]) => exportWorkflow(...a),
     // Knowledge graph feeding the popovers/derived-items section — empty
     // graph keeps those affordances out of these page-behavior tests.
     graph: (...a: unknown[]) => graph(...a),
@@ -155,6 +157,7 @@ describe('IntentView', () => {
     rewind.mockReset();
     answerGate.mockReset();
     repair.mockReset();
+    exportWorkflow.mockReset();
     projectCacheMock.role = 'owner';
     graph.mockReset().mockResolvedValue({ nodes: [], edges: [] });
     compiled.mockReset().mockResolvedValue({ graph: { nodes: [], edges: [] } });
@@ -535,6 +538,160 @@ describe('IntentView', () => {
 
     expect(
       await screen.findByRole('heading', { name: 'Reshape remaining stages' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a visible native export beside Discuss', async () => {
+    get.mockResolvedValue(baseDetail({ status: 'WAITING', agentCli: 'codex' }));
+    renderAt();
+    expect(
+      await screen.findByRole('button', { name: 'Download Codex workspace' }),
+    ).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('button', { name: 'Intent actions' }));
+    expect(screen.queryByText('Export')).not.toBeInTheDocument();
+  });
+
+  it('can export the workflow with a different native harness', async () => {
+    get.mockResolvedValue(baseDetail({ status: 'WAITING', agentCli: 'codex' }));
+    exportWorkflow.mockImplementation(() => new Promise(() => {}));
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Choose workspace harness' }));
+    expect(await screen.findByText('Codex')).toBeInTheDocument();
+    await userEvent.click(await screen.findByText('Claude'));
+    expect(await screen.findByText('Continue outside Collaborative AI-DLC?')).toBeInTheDocument();
+    expect(screen.getByText(/will not be synchronized back to this intent/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Download workspace' }));
+
+    expect(exportWorkflow).toHaveBeenCalledWith('p1', 'i1', 'claude');
+  });
+
+  it('keeps construction setup instructions open after starting the download', async () => {
+    get.mockResolvedValue(
+      baseDetail({
+        status: 'WAITING',
+        agentCli: 'codex',
+        currentPhase: 'CONSTRUCTION',
+      }),
+    );
+    exportWorkflow.mockResolvedValue({
+      exportId: 'export-1',
+      filename: 'workspace.zip',
+      downloadUrl: 'https://download.example/workspace.zip',
+      expiresAt: '2026-08-12T12:15:00.000Z',
+      warnings: [],
+      setup: {
+        workspaceLayout: 'spaces',
+        mode: 'workspace-sync',
+        harnessDir: '.codex',
+        syncCommand: 'bun .codex/tools/aidlc-workspace-sync.ts',
+        launchCommand: 'codex',
+        continueCommand: '$aidlc',
+        repositories: [
+          { name: 'api', url: 'git@github.com:example/api.git', branch: 'aidlc/i1' },
+          { name: 'web', url: 'git@github.com:example/web.git', branch: 'aidlc/i1' },
+        ],
+      },
+    });
+    const downloadClick = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Download Codex workspace' }));
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: 'Download workspace',
+      }),
+    );
+
+    expect(downloadClick).toHaveBeenCalledOnce();
+    expect(await screen.findByText('Set up your local workspace')).toBeInTheDocument();
+    expect(screen.getByText(/mkdir 'workspace'/)).toBeInTheDocument();
+    expect(screen.getByText(/unzip "\$HOME\/Downloads\/workspace.zip" -d \./)).toBeInTheDocument();
+    expect(screen.getByText('bun .codex/tools/aidlc-workspace-sync.ts')).toBeInTheDocument();
+    expect(screen.getByText(/all 2 repositories/)).toBeInTheDocument();
+    expect(screen.getByText('aidlc.code-workspace')).toBeInTheDocument();
+    expect(screen.getByText(/codex[\s\S]*\$aidlc/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByText('Set up your local workspace')).not.toBeInTheDocument();
+    downloadClick.mockRestore();
+  });
+
+  it('shows clone and checkout commands for a legacy construction export', async () => {
+    get.mockResolvedValue(
+      baseDetail({
+        status: 'WAITING',
+        agentCli: 'claude',
+        currentPhase: 'CONSTRUCTION',
+      }),
+    );
+    exportWorkflow.mockResolvedValue({
+      exportId: 'export-legacy',
+      filename: 'legacy-claude.zip',
+      downloadUrl: 'https://download.example/legacy-claude.zip',
+      expiresAt: '2026-08-12T12:15:00.000Z',
+      warnings: [],
+      setup: {
+        workspaceLayout: 'flat',
+        mode: 'manual-clone',
+        harnessDir: '.claude',
+        launchCommand: 'claude',
+        continueCommand: '/aidlc',
+        repositories: [
+          {
+            name: 'plant-finder',
+            url: 'git@github.com:example/plant-finder.git',
+            branch: 'aidlc/intent-1',
+          },
+        ],
+      },
+    });
+    const downloadClick = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Download Claude workspace' }));
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: 'Download workspace',
+      }),
+    );
+
+    expect(await screen.findByText('Set up your local workspace')).toBeInTheDocument();
+    expect(screen.getByText(/git clone --branch 'aidlc\/intent-1'/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/git fetch origin[\s\S]*git switch 'aidlc\/intent-1'/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/unzip "\$HOME\/Downloads\/legacy-claude.zip" -d \./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/claude[\s\S]*\/aidlc/)).toBeInTheDocument();
+    expect(screen.queryByText(/local\/aidlc-continuation/)).not.toBeInTheDocument();
+    downloadClick.mockRestore();
+  });
+
+  it('shows export disabled while a created intent may still start running', async () => {
+    get.mockResolvedValue(baseDetail({ status: 'CREATED', agentCli: 'codex' }));
+    renderAt();
+    expect(await screen.findByRole('button', { name: 'Download Codex workspace' })).toBeDisabled();
+    await userEvent.click(await screen.findByRole('button', { name: 'Intent actions' }));
+    expect(screen.queryByText('Export')).not.toBeInTheDocument();
+  });
+
+  it('shows export disabled with an explanation while the workflow is running', async () => {
+    get.mockResolvedValue(baseDetail({ status: 'RUNNING', agentCli: 'codex' }));
+    renderAt();
+
+    expect(await screen.findByRole('button', { name: 'Download Codex workspace' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Choose workspace harness' })).toBeDisabled();
+    await userEvent.hover(screen.getByTestId('workspace-export-download'));
+    expect(
+      await screen.findByRole('tooltip', {
+        name: 'Not available while workflow is running',
+      }),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -595,6 +595,44 @@ describe('IntentView', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
+  it('shows export warnings even when no workspace setup is required', async () => {
+    get.mockResolvedValue(baseDetail({ status: 'WAITING', agentCli: 'codex' }));
+    exportWorkflow.mockResolvedValue({
+      exportId: 'export-warning',
+      filename: 'workspace.zip',
+      downloadUrl: 'https://download.example/workspace.zip',
+      expiresAt: '2026-08-12T12:15:00.000Z',
+      warnings: ['The pinned runtime has limited per-unit Construction support.'],
+      setup: {
+        workspaceLayout: 'spaces',
+        mode: 'extract-only',
+        harnessDir: '.codex',
+        launchCommand: 'codex',
+        continueCommand: '$aidlc',
+        showWorkspaceSetup: false,
+        repositories: [],
+      },
+    });
+    const downloadClick = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Download Codex workspace' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Download workspace' }));
+
+    expect(downloadClick).toHaveBeenCalledOnce();
+    expect(await screen.findByText('Workspace downloaded with warnings')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'The pinned runtime has limited per-unit Construction support.',
+    );
+    expect(screen.queryByText('Create a project directory')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(screen.queryByText('Workspace downloaded with warnings')).not.toBeInTheDocument();
+    downloadClick.mockRestore();
+  });
+
   it('keeps construction setup instructions open after starting the download', async () => {
     get.mockResolvedValue(
       baseDetail({
@@ -686,7 +724,9 @@ describe('IntentView', () => {
       filename: 'legacy-claude.zip',
       downloadUrl: 'https://download.example/legacy-claude.zip',
       expiresAt: '2026-08-12T12:15:00.000Z',
-      warnings: [],
+      warnings: [
+        'This workspace uses an older AI-DLC runtime with limited automatic per-unit iteration.',
+      ],
       setup: {
         workspaceLayout: 'flat',
         mode: 'manual-clone',

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -578,6 +578,23 @@ describe('IntentView', () => {
     expect(exportWorkflow).toHaveBeenCalledWith('p1', 'i1', 'claude');
   });
 
+  it('shows only the error message and allows dismissing it', async () => {
+    get.mockResolvedValue(baseDetail({ status: 'WAITING', agentCli: 'codex' }));
+    exportWorkflow.mockRejectedValue(new Error('{"error":"Workspace export is unavailable"}'));
+    renderAt();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Download Codex workspace' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Download workspace' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Workspace export is unavailable');
+    expect(
+      screen.queryByText('{"error":"Workspace export is unavailable"}'),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss error' }));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
   it('keeps construction setup instructions open after starting the download', async () => {
     get.mockResolvedValue(
       baseDetail({
@@ -719,17 +736,29 @@ describe('IntentView', () => {
     expect(screen.queryByText('Export')).not.toBeInTheDocument();
   });
 
-  it('shows export disabled with an explanation while the workflow is running', async () => {
+  it('allows downloading the latest completed checkpoint while the workflow is running', async () => {
     get.mockResolvedValue(baseDetail({ status: 'RUNNING', agentCli: 'codex' }));
     renderAt();
 
-    expect(await screen.findByRole('button', { name: 'Download Codex workspace' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Choose workspace harness' })).toBeDisabled();
+    expect(
+      await screen.findByRole('button', {
+        name: 'Download Codex workspace from latest completed checkpoint',
+      }),
+    ).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Choose workspace harness' })).toBeEnabled();
     await userEvent.hover(screen.getByTestId('workspace-export-download'));
     expect(
       await screen.findByRole('tooltip', {
-        name: 'Not available while workflow is running',
+        name: 'Download Codex workspace from latest completed checkpoint',
       }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Download Codex workspace from latest completed checkpoint',
+      }),
+    );
+    expect(
+      await screen.findByText(/excludes the stage currently in progress/i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -569,8 +569,8 @@ describe('IntentView', () => {
     renderAt();
 
     await userEvent.click(await screen.findByRole('button', { name: 'Choose workspace harness' }));
-    expect(await screen.findByText('Codex')).toBeInTheDocument();
-    await userEvent.click(await screen.findByText('Claude'));
+    expect(await screen.findByRole('menuitem', { name: /^Codex/ })).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Claude' }));
     expect(screen.queryByText('Continue outside Collaborative AI-DLC?')).not.toBeInTheDocument();
     expect(exportWorkflow).not.toHaveBeenCalled();
     await userEvent.click(screen.getByRole('button', { name: 'Download Claude workspace' }));

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -841,20 +841,20 @@ export default function IntentView() {
               <li>
                 Clone each repository into the workspace:
                 {constructionSetup.repositories.map((repository) => (
-                  <div key={repository.name} className="mt-3 space-y-3">
+                  <div key={repository.id} className="mt-3 space-y-3">
                     <div>
-                      <p className="text-xs font-medium">Fresh clone: {repository.name}</p>
-                      <CommandBlock label={`Copy fresh clone command for ${repository.name}`}>
-                        {`git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.name)}`}
+                      <p className="text-xs font-medium">Fresh clone: {repository.id}</p>
+                      <CommandBlock label={`Copy fresh clone command for ${repository.id}`}>
+                        {`git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.directory)}`}
                       </CommandBlock>
                     </div>
                     <div>
-                      <p className="text-xs font-medium">Existing clone: {repository.name}</p>
-                      <CommandBlock label={`Copy existing clone commands for ${repository.name}`}>
+                      <p className="text-xs font-medium">Existing clone: {repository.id}</p>
+                      <CommandBlock label={`Copy existing clone commands for ${repository.id}`}>
                         {[
-                          `git -C ${shellQuote(repository.name)} fetch origin`,
-                          `git -C ${shellQuote(repository.name)} switch ${shellQuote(repository.branch)}`,
-                          `git -C ${shellQuote(repository.name)} pull --ff-only`,
+                          `git -C ${shellQuote(repository.directory)} fetch origin`,
+                          `git -C ${shellQuote(repository.directory)} switch ${shellQuote(repository.branch)}`,
+                          `git -C ${shellQuote(repository.directory)} pull --ff-only`,
                         ].join('\n')}
                       </CommandBlock>
                     </div>
@@ -889,21 +889,21 @@ export default function IntentView() {
               <li>
                 Retrieve the source repository and its intent branch:
                 {constructionSetup.repositories.map((repository) => (
-                  <div key={repository.name} className="mt-3 space-y-3">
+                  <div key={repository.id} className="mt-3 space-y-3">
                     <div>
                       <p className="text-xs font-medium">Fresh clone</p>
-                      <CommandBlock label={`Copy fresh clone commands for ${repository.name}`}>
+                      <CommandBlock label={`Copy fresh clone commands for ${repository.id}`}>
                         {[
-                          `git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.name)}`,
-                          `cd ${shellQuote(repository.name)}`,
+                          `git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.directory)}`,
+                          `cd ${shellQuote(repository.directory)}`,
                         ].join('\n')}
                       </CommandBlock>
                     </div>
                     <div>
                       <p className="text-xs font-medium">Existing clone</p>
-                      <CommandBlock label={`Copy existing clone commands for ${repository.name}`}>
+                      <CommandBlock label={`Copy existing clone commands for ${repository.id}`}>
                         {[
-                          `cd ${shellQuote(`/path/to/${repository.name}`)}`,
+                          `cd ${shellQuote(`/path/to/${repository.directory}`)}`,
                           'git fetch origin',
                           `git switch ${shellQuote(repository.branch)}`,
                           'git pull --ff-only',

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -128,6 +128,9 @@ export default function IntentView() {
   const [configurationOpen, setConfigurationOpen] = useState(false);
   const [reshapeOpen, setReshapeOpen] = useState(false);
   const [confirmExport, setConfirmExport] = useState(false);
+  const [selectedExportHarness, setSelectedExportHarness] = useState<
+    NativeExportHarness | undefined
+  >();
   const [requestedExportHarness, setRequestedExportHarness] = useState<
     NativeExportHarness | undefined
   >();
@@ -294,8 +297,9 @@ export default function IntentView() {
   const exportUnavailableReason = 'Not available before the workflow starts';
   const exportDisabled = exporting || !isExportable;
   const defaultExportHarness = intent.agentCli ?? undefined;
+  const activeExportHarness = selectedExportHarness ?? defaultExportHarness;
   const exportCli =
-    EXPORT_HARNESSES.find((option) => option.value === defaultExportHarness)?.label ??
+    EXPORT_HARNESSES.find((option) => option.value === activeExportHarness)?.label ??
     'native AI-DLC';
   const exportButtonLabel =
     intent.status === 'RUNNING'
@@ -373,10 +377,10 @@ export default function IntentView() {
                           <DropdownMenuItem
                             key={option.value}
                             disabled={exporting}
-                            onClick={() => requestExport(option.value)}
+                            onClick={() => setSelectedExportHarness(option.value)}
                           >
                             <span>{option.label}</span>
-                            {option.value === defaultExportHarness && (
+                            {option.value === activeExportHarness && (
                               <Check className="ml-auto h-4 w-4" aria-label="Current harness" />
                             )}
                           </DropdownMenuItem>
@@ -402,7 +406,7 @@ export default function IntentView() {
                       size="icon"
                       className="h-7 w-7 rounded-none"
                       disabled={exportDisabled}
-                      onClick={() => requestExport()}
+                      onClick={() => requestExport(activeExportHarness)}
                       aria-label={exportButtonLabel}
                     >
                       {exporting ? (

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
-import { intentsService } from '@/services/intents';
+import {
+  intentsService,
+  type NativeExportHarness,
+  type NativeWorkflowExport,
+} from '@/services/intents';
 import { useIntent } from '@/contexts/IntentContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useProjectCache } from '@/hooks/useProjectsCache';
@@ -38,7 +42,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import {
+  Check,
+  ChevronDown,
+  Download,
   GitBranch,
   KeyRound,
   Loader2,
@@ -58,6 +66,22 @@ import {
 
 const TERMINAL_STATUSES = new Set(['FAILED', 'CANCELLED', 'SUCCEEDED']);
 const CREDENTIAL_FAILURE_CODES = new Set(['credential_unavailable', 'credential_invalid']);
+const EXPORTABLE_STATUSES = new Set(['DRAFT', 'WAITING', 'FAILED', 'CANCELLED', 'SUCCEEDED']);
+const EXPORT_HARNESSES: Array<{ value: NativeExportHarness; label: string }> = [
+  { value: 'claude', label: 'Claude' },
+  { value: 'codex', label: 'Codex' },
+  { value: 'kiro', label: 'Kiro CLI' },
+  { value: 'kiro-ide', label: 'Kiro IDE' },
+  { value: 'opencode', label: 'OpenCode' },
+];
+
+const shellQuote = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
+
+const CommandBlock = ({ children }: { children: string }) => (
+  <pre className="mt-2 w-full min-w-0 max-w-full whitespace-pre-wrap break-all rounded-md bg-muted px-3 py-2 font-mono text-xs leading-relaxed">
+    <code>{children}</code>
+  </pre>
+);
 
 export default function IntentView() {
   const {
@@ -95,6 +119,12 @@ export default function IntentView() {
   const [repairing, setRepairing] = useState(false);
   const [configurationOpen, setConfigurationOpen] = useState(false);
   const [reshapeOpen, setReshapeOpen] = useState(false);
+  const [confirmExport, setConfirmExport] = useState(false);
+  const [requestedExportHarness, setRequestedExportHarness] = useState<
+    NativeExportHarness | undefined
+  >();
+  const [exporting, setExporting] = useState(false);
+  const [constructionExport, setConstructionExport] = useState<NativeWorkflowExport | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   // A stage failure retries from the earliest failed stage, preserving all
@@ -170,6 +200,40 @@ export default function IntentView() {
     }
   };
 
+  const handleExport = async (harness?: NativeExportHarness) => {
+    setConfirmExport(false);
+    setExporting(true);
+    setActionError(null);
+    try {
+      const result = await intentsService.exportWorkflow(projectId, intentId, harness);
+      const download = document.createElement('a');
+      download.href = result.downloadUrl;
+      download.download = result.filename;
+      download.rel = 'noopener';
+      document.body.append(download);
+      download.click();
+      download.remove();
+      const currentPhase = detail?.intent.currentPhase?.toLowerCase();
+      const hasActiveConstruction = detail?.stages.some(
+        (stage) =>
+          stage.phase?.toLowerCase() === 'construction' &&
+          ['RUNNING', 'WAITING_FOR_HUMAN'].includes(stage.state),
+      );
+      if (currentPhase === 'construction' || hasActiveConstruction) {
+        setConstructionExport(result);
+      }
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to export workflow');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const requestExport = (harness?: NativeExportHarness) => {
+    setRequestedExportHarness(harness);
+    setConfirmExport(true);
+  };
+
   if (!projectId || !intentId) return <div className="p-6">Intent not found</div>;
   if (loading && !detail) {
     return (
@@ -217,6 +281,18 @@ export default function IntentView() {
   const isCancellable = ['WAITING', 'CREATED', 'FAILED'].includes(intent.status);
   // Deletable (destructive): owner/admin, any status except mid-RUNNING.
   const isDeletable = canDelete && intent.status !== 'RUNNING';
+  const isExportable = EXPORTABLE_STATUSES.has(intent.status);
+  const exportUnavailableReason =
+    intent.status === 'RUNNING'
+      ? 'Not available while workflow is running'
+      : intent.status === 'CREATED'
+        ? 'Not available while workflow is starting'
+        : 'Not available for this workflow status';
+  const exportDisabled = exporting || !isExportable;
+  const defaultExportHarness = intent.agentCli ?? undefined;
+  const exportCli =
+    EXPORT_HARNESSES.find((option) => option.value === defaultExportHarness)?.label ??
+    'native AI-DLC';
   // Pre-stage progress: before any stage row exists, init-ws lifecycle events
   // are the only signal the run is doing something (they stream into the
   // sidebar Timeline); this strip keeps the main pane from looking dead.
@@ -244,6 +320,21 @@ export default function IntentView() {
         : null
     : null;
   const failureMessage = intent.failure?.message ?? intent.failureReason;
+  const constructionSetup = constructionExport?.setup ?? null;
+  const exportDirectory = constructionExport?.filename.replace(/\.zip$/i, '') ?? 'aidlc-workspace';
+  const downloadedZip = constructionExport
+    ? `"$HOME/Downloads/${constructionExport.filename}"`
+    : '"$HOME/Downloads/aidlc-workspace.zip"';
+  const extractCommands = [
+    `mkdir ${shellQuote(exportDirectory)}`,
+    `cd ${shellQuote(exportDirectory)}`,
+    `unzip ${downloadedZip} -d .`,
+  ].join('\n');
+  const launchCommands = constructionSetup?.launchCommand
+    ? `${constructionSetup.launchCommand}\n# Then run inside the agent session:\n${constructionSetup.continueCommand}`
+    : constructionSetup
+      ? `# Open this directory in Kiro IDE, then run:\n${constructionSetup.continueCommand}`
+      : '';
 
   return (
     <div className="space-y-6">
@@ -267,6 +358,78 @@ export default function IntentView() {
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <DiscussButton entityType="intent" entityTitle={intent.title || 'Intent'} />
+          <div className="inline-flex h-7 shrink-0 overflow-hidden rounded-md border border-border/60">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex" data-testid="workspace-export-harness">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          className="h-7 w-5 rounded-none border-r border-border/60 px-0"
+                          disabled={exportDisabled}
+                          aria-label="Choose workspace harness"
+                        >
+                          <ChevronDown className="h-3 w-3" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start">
+                        {EXPORT_HARNESSES.map((option) => (
+                          <DropdownMenuItem
+                            key={option.value}
+                            disabled={exporting}
+                            onClick={() => requestExport(option.value)}
+                          >
+                            <span>{option.label}</span>
+                            {option.value === defaultExportHarness && (
+                              <Check className="ml-auto h-4 w-4" aria-label="Current harness" />
+                            )}
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {exporting
+                    ? 'Preparing workspace…'
+                    : isExportable
+                      ? 'Choose workspace harness'
+                      : exportUnavailableReason}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex" data-testid="workspace-export-download">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 rounded-none"
+                      disabled={exportDisabled}
+                      onClick={() => requestExport()}
+                      aria-label={`Download ${exportCli} workspace`}
+                    >
+                      {exporting ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Download className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {exporting
+                    ? 'Preparing workspace…'
+                    : isExportable
+                      ? `Download ${exportCli} workspace`
+                      : exportUnavailableReason}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Intent actions">
@@ -487,6 +650,140 @@ export default function IntentView() {
           <WorkProductsSection detail={detail} gates={gates} />
         </>
       )}
+
+      <AlertDialog
+        open={confirmExport}
+        onOpenChange={(open) => {
+          if (exporting) return;
+          setConfirmExport(open);
+          if (!open) setRequestedExportHarness(undefined);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Continue outside Collaborative AI-DLC?</AlertDialogTitle>
+            <AlertDialogDescription className="break-words">
+              This download creates a point-in-time workspace. Work completed locally, including
+              decisions, approvals, artifacts, and code changes, will not be synchronized back to
+              this intent or included in its traceability history.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={exporting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={exporting}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleExport(requestedExportHarness);
+              }}
+            >
+              {exporting ? 'Preparing workspace…' : 'Download workspace'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={constructionExport !== null}
+        onOpenChange={(open) => {
+          if (!open) setConstructionExport(null);
+        }}
+      >
+        <AlertDialogContent className="max-h-[85vh] w-[calc(100vw-2rem)] max-w-4xl min-w-0 overflow-x-hidden overflow-y-auto [&>*]:min-w-0">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Set up your local workspace</AlertDialogTitle>
+            <AlertDialogDescription>
+              The workspace download is in progress. Source code should be retrieved separately from
+              Git using your own credentials.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {constructionSetup?.mode === 'workspace-sync' && (
+            <ol className="list-decimal space-y-4 pl-5 text-sm">
+              <li>
+                Create an empty workspace directory and extract the downloaded ZIP:
+                <CommandBlock>{extractCommands}</CommandBlock>
+              </li>
+              <li>
+                Clone the repositories declared by the export:
+                <CommandBlock>{constructionSetup.syncCommand ?? ''}</CommandBlock>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  This reads <code>repos.json</code> and clones{' '}
+                  {constructionSetup.repositories.length === 1
+                    ? 'the repository'
+                    : `all ${constructionSetup.repositories.length} repositories`}
+                  {' on their declared intent branches.'}
+                </p>
+              </li>
+              <li>
+                Start the selected harness and continue AI-DLC:
+                <CommandBlock>{launchCommands}</CommandBlock>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Open this directory in your IDE. VS Code users may open{' '}
+                  <code>aidlc.code-workspace</code>.
+                </p>
+              </li>
+            </ol>
+          )}
+
+          {constructionSetup?.mode === 'manual-clone' && (
+            <ol className="list-decimal space-y-4 pl-5 text-sm">
+              <li>
+                Retrieve the source repository and its intent branch:
+                {constructionSetup.repositories.map((repository) => (
+                  <div key={repository.name} className="mt-3 space-y-3">
+                    <div>
+                      <p className="text-xs font-medium">Fresh clone</p>
+                      <CommandBlock>
+                        {[
+                          `git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.name)}`,
+                          `cd ${shellQuote(repository.name)}`,
+                        ].join('\n')}
+                      </CommandBlock>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium">Existing clone</p>
+                      <CommandBlock>
+                        {[
+                          `cd ${shellQuote(`/path/to/${repository.name}`)}`,
+                          'git fetch origin',
+                          `git switch ${shellQuote(repository.branch)}`,
+                          'git pull --ff-only',
+                        ].join('\n')}
+                      </CommandBlock>
+                    </div>
+                  </div>
+                ))}
+              </li>
+              <li>
+                From the repository root, extract the downloaded workspace:
+                <CommandBlock>{`unzip ${downloadedZip} -d .`}</CommandBlock>
+              </li>
+              <li>
+                Start the selected harness and continue AI-DLC:
+                <CommandBlock>{launchCommands}</CommandBlock>
+              </li>
+            </ol>
+          )}
+
+          {constructionSetup?.mode === 'extract-only' && (
+            <ol className="list-decimal space-y-4 pl-5 text-sm">
+              <li>
+                Create a project directory and extract the downloaded workspace:
+                <CommandBlock>{extractCommands}</CommandBlock>
+              </li>
+              <li>
+                Start the selected harness and continue AI-DLC:
+                <CommandBlock>{launchCommands}</CommandBlock>
+              </li>
+            </ol>
+          )}
+
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setConstructionExport(null)}>Done</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Delete confirmation */}
       <AlertDialog

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -78,6 +78,20 @@ const EXPORT_HARNESSES: Array<{ value: NativeExportHarness; label: string }> = [
 
 const shellQuote = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
 
+const workspaceDirectoryName = (value?: string | null) => {
+  const name = String(value ?? '')
+    .normalize('NFKD')
+    .replace(/[^\p{ASCII}]/gu, '')
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^[._-]+|[._-]+$/g, '')
+    .slice(0, 80)
+    .replace(/[._-]+$/g, '');
+  return name || 'aidlc-workspace';
+};
+
 const CommandBlock = ({ children, label }: { children: string; label: string }) => {
   const [copied, setCopied] = useState(false);
 
@@ -343,7 +357,7 @@ export default function IntentView() {
     : null;
   const failureMessage = intent.failure?.message ?? intent.failureReason;
   const constructionSetup = constructionExport?.setup ?? null;
-  const exportDirectory = constructionExport?.filename.replace(/\.zip$/i, '') ?? 'aidlc-workspace';
+  const exportDirectory = workspaceDirectoryName(project?.name);
   const downloadedZip = constructionExport
     ? `"$HOME/Downloads/${constructionExport.filename}"`
     : '"$HOME/Downloads/aidlc-workspace.zip"';
@@ -721,7 +735,7 @@ export default function IntentView() {
           if (!open) setConstructionExport(null);
         }}
       >
-        <AlertDialogContent className="max-h-[85vh] w-[calc(100vw-2rem)] max-w-4xl min-w-0 overflow-x-hidden overflow-y-auto [&>*]:min-w-0">
+        <AlertDialogContent className="max-h-[85vh] w-[calc(100vw-2rem)] max-w-4xl min-w-0 overflow-x-hidden overflow-y-scroll [&>*]:min-w-0">
           <AlertDialogHeader>
             <AlertDialogTitle>Set up your local workspace</AlertDialogTitle>
             <AlertDialogDescription>
@@ -772,6 +786,58 @@ export default function IntentView() {
                   Open this directory in your IDE. VS Code users may open{' '}
                   <code>aidlc.code-workspace</code>.
                 </p>
+              </li>
+              <li>
+                Then run inside the agent session:
+                <CommandBlock label="Copy AI-DLC command">
+                  {constructionContinueCommand ?? ''}
+                </CommandBlock>
+              </li>
+            </ol>
+          )}
+
+          {constructionSetup?.mode === 'manual-workspace' && (
+            <ol className="list-decimal space-y-4 pl-5 text-sm">
+              <li>
+                Create an empty workspace directory and extract the downloaded ZIP:
+                <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
+              </li>
+              <li>
+                Clone each repository into the workspace:
+                {constructionSetup.repositories.map((repository) => (
+                  <div key={repository.name} className="mt-3 space-y-3">
+                    <div>
+                      <p className="text-xs font-medium">Fresh clone: {repository.name}</p>
+                      <CommandBlock label={`Copy fresh clone command for ${repository.name}`}>
+                        {`git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.name)}`}
+                      </CommandBlock>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium">Existing clone: {repository.name}</p>
+                      <CommandBlock label={`Copy existing clone commands for ${repository.name}`}>
+                        {[
+                          `git -C ${shellQuote(repository.name)} fetch origin`,
+                          `git -C ${shellQuote(repository.name)} switch ${shellQuote(repository.branch)}`,
+                          `git -C ${shellQuote(repository.name)} pull --ff-only`,
+                        ].join('\n')}
+                      </CommandBlock>
+                    </div>
+                  </div>
+                ))}
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Keep these repositories as immediate children of the workspace, alongside{' '}
+                  <code>aidlc/</code> and the harness directory.
+                </p>
+              </li>
+              <li>
+                Start the selected harness:
+                {launchCommand ? (
+                  <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Open this directory in Kiro IDE.
+                  </p>
+                )}
               </li>
               <li>
                 Then run inside the agent session:

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -21,6 +21,7 @@ import { AgentProgressCard } from '@/components/intent/AgentProgressCard';
 import { GateCard } from '@/components/intent/GateCard';
 import { StageReviewPanel } from '@/components/intent/StageReviewPanel';
 import { WorkProductsSection } from '@/components/intent/WorkProductsSection';
+import { NativeExportSetupDialog } from '@/components/intent/NativeExportSetupDialog';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -46,7 +47,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import {
   Check,
   ChevronDown,
-  Copy,
   Download,
   GitBranch,
   KeyRound,
@@ -77,8 +77,6 @@ const EXPORT_HARNESSES: Array<{ value: NativeExportHarness; label: string }> = [
   { value: 'opencode', label: 'OpenCode' },
 ];
 
-const shellQuote = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
-
 const errorMessage = (value: string) => {
   try {
     const parsed = JSON.parse(value);
@@ -91,53 +89,6 @@ const errorMessage = (value: string) => {
     // Plain-text errors are already display-ready.
   }
   return value;
-};
-
-const workspaceDirectoryName = (value?: string | null) => {
-  const name = String(value ?? '')
-    .normalize('NFKD')
-    .replace(/[^\p{ASCII}]/gu, '')
-    .trim()
-    .replace(/\s+/g, '_')
-    .replace(/[^A-Za-z0-9._-]+/g, '_')
-    .replace(/_+/g, '_')
-    .replace(/^[._-]+|[._-]+$/g, '')
-    .slice(0, 80)
-    .replace(/[._-]+$/g, '');
-  return name || 'aidlc-workspace';
-};
-
-const CommandBlock = ({ children, label }: { children: string; label: string }) => {
-  const [copied, setCopied] = useState(false);
-
-  const copy = async () => {
-    await navigator.clipboard.writeText(children);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <div className="relative mt-2 min-w-0">
-      <pre className="w-full min-w-0 max-w-full whitespace-pre-wrap break-all rounded-md bg-muted py-2 pl-3 pr-10 font-mono text-xs leading-relaxed">
-        <code>{children}</code>
-      </pre>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="absolute right-1.5 top-1.5 h-7 w-7"
-        aria-label={copied ? `${label} copied` : label}
-        title={copied ? 'Copied' : label}
-        onClick={() => void copy()}
-      >
-        {copied ? (
-          <Check className="h-3.5 w-3.5 text-green-600" />
-        ) : (
-          <Copy className="h-3.5 w-3.5 text-muted-foreground" />
-        )}
-      </Button>
-    </div>
-  );
 };
 
 export default function IntentView() {
@@ -275,7 +226,7 @@ export default function IntentView() {
       document.body.append(download);
       download.click();
       download.remove();
-      if (result.setup.showWorkspaceSetup) {
+      if (result.setup.showWorkspaceSetup || result.warnings.length > 0) {
         setConstructionExport(result);
       }
     } catch (err) {
@@ -377,31 +328,6 @@ export default function IntentView() {
         : null
     : null;
   const failureMessage = intent.failure?.message ?? intent.failureReason;
-  const constructionSetup = constructionExport?.setup ?? null;
-  const exportDirectory = workspaceDirectoryName(project?.name);
-  const downloadedZip = constructionExport
-    ? `"$HOME/Downloads/${constructionExport.filename}"`
-    : '"$HOME/Downloads/aidlc-workspace.zip"';
-  const extractCommands = [
-    `mkdir ${shellQuote(exportDirectory)}`,
-    `cd ${shellQuote(exportDirectory)}`,
-    `unzip ${downloadedZip} -d .`,
-  ].join('\n');
-  const legacyConstruction = constructionSetup?.construction?.perUnitIteration === false;
-  const completedUnitSummary = constructionSetup?.construction?.completedUnits.join(', ');
-  const constructionContinueCommand =
-    legacyConstruction &&
-    constructionSetup?.construction?.nextUnit &&
-    constructionSetup.continueCommand
-      ? [
-          `${constructionSetup.continueCommand} Continue the construction phase.`,
-          completedUnitSummary ? `Completed units: ${completedUnitSummary}.` : '',
-          `Continue with unit: ${constructionSetup.construction.nextUnit}.`,
-        ]
-          .filter(Boolean)
-          .join(' ')
-      : constructionSetup?.continueCommand;
-  const launchCommand = constructionSetup?.launchCommand ?? null;
 
   return (
     <div className="space-y-6">
@@ -765,210 +691,11 @@ export default function IntentView() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <AlertDialog
-        open={constructionExport !== null}
-        onOpenChange={(open) => {
-          if (!open) setConstructionExport(null);
-        }}
-      >
-        <AlertDialogContent className="max-h-[85vh] w-[calc(100vw-2rem)] max-w-4xl min-w-0 overflow-x-hidden overflow-y-scroll [&>*]:min-w-0">
-          <AlertDialogHeader>
-            <AlertDialogTitle>Set up your local workspace</AlertDialogTitle>
-            <AlertDialogDescription>
-              The workspace download is in progress. Source code should be retrieved separately from
-              Git using your own credentials.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-
-          {constructionSetup?.construction?.nextUnit &&
-            !constructionSetup.construction.perUnitIteration && (
-              <p className="text-sm text-muted-foreground">
-                This workspace uses an older AI-DLC runtime with limited automatic per-unit
-                iteration. The complete Bolt DAG and completed-unit receipts are included. The
-                continuation command below names the next dependency-ready unit:{' '}
-                <code>{constructionSetup.construction.nextUnit}</code>.
-              </p>
-            )}
-
-          {constructionSetup?.mode === 'workspace-sync' && (
-            <ol className="list-decimal space-y-4 pl-5 text-sm">
-              <li>
-                Create an empty workspace directory and extract the downloaded ZIP:
-                <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
-              </li>
-              <li>
-                Clone the repositories declared by the export:
-                <CommandBlock label="Copy workspace sync command">
-                  {constructionSetup.syncCommand ?? ''}
-                </CommandBlock>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  This reads <code>repos.json</code> and clones{' '}
-                  {constructionSetup.repositories.length === 1
-                    ? 'the repository'
-                    : `all ${constructionSetup.repositories.length} repositories`}
-                  {' on their declared intent branches.'}
-                </p>
-              </li>
-              <li>
-                Start the selected harness:
-                {launchCommand ? (
-                  <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
-                ) : (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Open this directory in Kiro IDE.
-                  </p>
-                )}
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Open this directory in your IDE. VS Code users may open{' '}
-                  <code>aidlc.code-workspace</code>.
-                </p>
-              </li>
-              <li>
-                Then run inside the agent session:
-                <CommandBlock label="Copy AI-DLC command">
-                  {constructionContinueCommand ?? ''}
-                </CommandBlock>
-              </li>
-            </ol>
-          )}
-
-          {constructionSetup?.mode === 'manual-workspace' && (
-            <ol className="list-decimal space-y-4 pl-5 text-sm">
-              <li>
-                Create an empty workspace directory and extract the downloaded ZIP:
-                <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
-              </li>
-              <li>
-                Clone each repository into the workspace:
-                {constructionSetup.repositories.map((repository) => (
-                  <div key={repository.id} className="mt-3 space-y-3">
-                    <div>
-                      <p className="text-xs font-medium">Fresh clone: {repository.id}</p>
-                      <CommandBlock label={`Copy fresh clone command for ${repository.id}`}>
-                        {`git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.directory)}`}
-                      </CommandBlock>
-                    </div>
-                    <div>
-                      <p className="text-xs font-medium">Existing clone: {repository.id}</p>
-                      <CommandBlock label={`Copy existing clone commands for ${repository.id}`}>
-                        {[
-                          `git -C ${shellQuote(repository.directory)} fetch origin`,
-                          `git -C ${shellQuote(repository.directory)} switch ${shellQuote(repository.branch)}`,
-                          `git -C ${shellQuote(repository.directory)} pull --ff-only`,
-                        ].join('\n')}
-                      </CommandBlock>
-                    </div>
-                  </div>
-                ))}
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Keep these repositories as immediate children of the workspace, alongside{' '}
-                  <code>aidlc/</code> and the harness directory.
-                </p>
-              </li>
-              <li>
-                Start the selected harness:
-                {launchCommand ? (
-                  <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
-                ) : (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Open this directory in Kiro IDE.
-                  </p>
-                )}
-              </li>
-              <li>
-                Then run inside the agent session:
-                <CommandBlock label="Copy AI-DLC command">
-                  {constructionContinueCommand ?? ''}
-                </CommandBlock>
-              </li>
-            </ol>
-          )}
-
-          {constructionSetup?.mode === 'manual-clone' && (
-            <ol className="list-decimal space-y-4 pl-5 text-sm">
-              <li>
-                Retrieve the source repository and its intent branch:
-                {constructionSetup.repositories.map((repository) => (
-                  <div key={repository.id} className="mt-3 space-y-3">
-                    <div>
-                      <p className="text-xs font-medium">Fresh clone</p>
-                      <CommandBlock label={`Copy fresh clone commands for ${repository.id}`}>
-                        {[
-                          `git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.directory)}`,
-                          `cd ${shellQuote(repository.directory)}`,
-                        ].join('\n')}
-                      </CommandBlock>
-                    </div>
-                    <div>
-                      <p className="text-xs font-medium">Existing clone</p>
-                      <CommandBlock label={`Copy existing clone commands for ${repository.id}`}>
-                        {[
-                          `cd ${shellQuote(`/path/to/${repository.directory}`)}`,
-                          'git fetch origin',
-                          `git switch ${shellQuote(repository.branch)}`,
-                          'git pull --ff-only',
-                        ].join('\n')}
-                      </CommandBlock>
-                    </div>
-                  </div>
-                ))}
-              </li>
-              <li>
-                From the repository root, extract the downloaded workspace:
-                <CommandBlock label="Copy extraction command">
-                  {`unzip ${downloadedZip} -d .`}
-                </CommandBlock>
-              </li>
-              <li>
-                Start the selected harness:
-                {launchCommand ? (
-                  <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
-                ) : (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Open this directory in Kiro IDE.
-                  </p>
-                )}
-              </li>
-              <li>
-                Then run inside the agent session:
-                <CommandBlock label="Copy AI-DLC command">
-                  {constructionContinueCommand ?? ''}
-                </CommandBlock>
-              </li>
-            </ol>
-          )}
-
-          {constructionSetup?.mode === 'extract-only' && (
-            <ol className="list-decimal space-y-4 pl-5 text-sm">
-              <li>
-                Create a project directory and extract the downloaded workspace:
-                <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
-              </li>
-              <li>Open the extracted workspace directory in your IDE.</li>
-              <li>
-                Start the selected harness:
-                {launchCommand ? (
-                  <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
-                ) : (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Open this directory in Kiro IDE.
-                  </p>
-                )}
-              </li>
-              <li>
-                Then run inside the agent session:
-                <CommandBlock label="Copy AI-DLC command">
-                  {constructionContinueCommand ?? ''}
-                </CommandBlock>
-              </li>
-            </ol>
-          )}
-
-          <AlertDialogFooter>
-            <AlertDialogAction onClick={() => setConstructionExport(null)}>Done</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <NativeExportSetupDialog
+        exportResult={constructionExport}
+        projectName={project?.name}
+        onClose={() => setConstructionExport(null)}
+      />
 
       {/* Delete confirmation */}
       <AlertDialog

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -58,6 +58,7 @@ import {
   Trash2,
   TriangleAlert,
   Wrench,
+  X,
   XCircle,
 } from 'lucide-react';
 
@@ -67,7 +68,7 @@ import {
 
 const TERMINAL_STATUSES = new Set(['FAILED', 'CANCELLED', 'SUCCEEDED']);
 const CREDENTIAL_FAILURE_CODES = new Set(['credential_unavailable', 'credential_invalid']);
-const EXPORTABLE_STATUSES = new Set(['DRAFT', 'WAITING', 'FAILED', 'CANCELLED', 'SUCCEEDED']);
+const NON_EXPORTABLE_STATUSES = new Set(['DRAFT', 'CREATED']);
 const EXPORT_HARNESSES: Array<{ value: NativeExportHarness; label: string }> = [
   { value: 'claude', label: 'Claude' },
   { value: 'codex', label: 'Codex' },
@@ -77,6 +78,20 @@ const EXPORT_HARNESSES: Array<{ value: NativeExportHarness; label: string }> = [
 ];
 
 const shellQuote = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
+
+const errorMessage = (value: string) => {
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed === 'string') return parsed;
+    if (parsed && typeof parsed === 'object') {
+      if ('message' in parsed && typeof parsed.message === 'string') return parsed.message;
+      if ('error' in parsed && typeof parsed.error === 'string') return parsed.error;
+    }
+  } catch {
+    // Plain-text errors are already display-ready.
+  }
+  return value;
+};
 
 const workspaceDirectoryName = (value?: string | null) => {
   const name = String(value ?? '')
@@ -168,6 +183,7 @@ export default function IntentView() {
   const [exporting, setExporting] = useState(false);
   const [constructionExport, setConstructionExport] = useState<NativeWorkflowExport | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [dismissedError, setDismissedError] = useState<string | null>(null);
 
   // A stage failure retries from the earliest failed stage, preserving all
   // completed upstream work. Failures before any stage row exists (init-ws,
@@ -188,6 +204,7 @@ export default function IntentView() {
         await reload();
       }
     } catch (err) {
+      setDismissedError(null);
       setActionError(err instanceof Error ? err.message : 'Failed to recover intent');
     } finally {
       setStarting(false);
@@ -206,6 +223,7 @@ export default function IntentView() {
     try {
       await cancelIntent();
     } catch (err) {
+      setDismissedError(null);
       setActionError(err instanceof Error ? err.message : 'Failed to cancel intent');
     } finally {
       setCancelling(false);
@@ -222,6 +240,7 @@ export default function IntentView() {
       await deleteIntent();
       navigate(`/space/${projectId}`);
     } catch (err) {
+      setDismissedError(null);
       setActionError(err instanceof Error ? err.message : 'Failed to delete intent');
       setConfirmDelete(false);
       setDeleting(false);
@@ -236,6 +255,7 @@ export default function IntentView() {
       setConfirmRepair(false);
       await reload();
     } catch (err) {
+      setDismissedError(null);
       setActionError(err instanceof Error ? err.message : 'Failed to repair intent');
     } finally {
       setRepairing(false);
@@ -259,6 +279,7 @@ export default function IntentView() {
         setConstructionExport(result);
       }
     } catch (err) {
+      setDismissedError(null);
       setActionError(err instanceof Error ? err.message : 'Failed to export workflow');
     } finally {
       setExporting(false);
@@ -303,6 +324,7 @@ export default function IntentView() {
   const needsLaneRepair =
     recoveryWaits.length > 0 && ['RUNNING', 'WAITING', 'FAILED'].includes(intent.status);
   const error = actionError ?? loadError;
+  const visibleError = error && error !== dismissedError ? errorMessage(error) : null;
   const isDraft = intent.status === 'DRAFT';
   // A DRAFT belongs on the collaborative compose page — one canonical draft
   // experience (shared prompt + projection selection) instead of two UIs.
@@ -317,18 +339,17 @@ export default function IntentView() {
   const isCancellable = ['WAITING', 'CREATED', 'FAILED'].includes(intent.status);
   // Deletable (destructive): owner/admin, any status except mid-RUNNING.
   const isDeletable = canDelete && intent.status !== 'RUNNING';
-  const isExportable = EXPORTABLE_STATUSES.has(intent.status);
-  const exportUnavailableReason =
-    intent.status === 'RUNNING'
-      ? 'Not available while workflow is running'
-      : intent.status === 'CREATED'
-        ? 'Not available while workflow is starting'
-        : 'Not available for this workflow status';
+  const isExportable = !NON_EXPORTABLE_STATUSES.has(intent.status);
+  const exportUnavailableReason = 'Not available before the workflow starts';
   const exportDisabled = exporting || !isExportable;
   const defaultExportHarness = intent.agentCli ?? undefined;
   const exportCli =
     EXPORT_HARNESSES.find((option) => option.value === defaultExportHarness)?.label ??
     'native AI-DLC';
+  const exportButtonLabel =
+    intent.status === 'RUNNING'
+      ? `Download ${exportCli} workspace from latest completed checkpoint`
+      : `Download ${exportCli} workspace`;
   // Pre-stage progress: before any stage row exists, init-ws lifecycle events
   // are the only signal the run is doing something (they stream into the
   // sidebar Timeline); this strip keeps the main pane from looking dead.
@@ -456,7 +477,7 @@ export default function IntentView() {
                       className="h-7 w-7 rounded-none"
                       disabled={exportDisabled}
                       onClick={() => requestExport()}
-                      aria-label={`Download ${exportCli} workspace`}
+                      aria-label={exportButtonLabel}
                     >
                       {exporting ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
@@ -470,7 +491,7 @@ export default function IntentView() {
                   {exporting
                     ? 'Preparing workspace…'
                     : isExportable
-                      ? `Download ${exportCli} workspace`
+                      ? exportButtonLabel
                       : exportUnavailableReason}
                 </TooltipContent>
               </Tooltip>
@@ -519,9 +540,22 @@ export default function IntentView() {
         onOpenScopeDefinition={canReshape ? () => setReshapeOpen(true) : undefined}
       />
 
-      {error && (
-        <div className="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {error}
+      {visibleError && (
+        <div
+          className="flex items-center gap-2 rounded border border-destructive/20 bg-destructive/10 py-2 pl-3 pr-1 text-sm text-destructive"
+          role="alert"
+        >
+          <span className="min-w-0 flex-1 break-words">{visibleError}</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
+            aria-label="Dismiss error"
+            onClick={() => setDismissedError(error)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
         </div>
       )}
 
@@ -709,9 +743,11 @@ export default function IntentView() {
           <AlertDialogHeader>
             <AlertDialogTitle>Continue outside Collaborative AI-DLC?</AlertDialogTitle>
             <AlertDialogDescription className="break-words">
-              This download creates a point-in-time workspace. Work completed locally, including
-              decisions, approvals, artifacts, and code changes, will not be synchronized back to
-              this intent or included in its traceability history.
+              {intent.status === 'RUNNING'
+                ? 'This download uses the latest completed workflow checkpoint and excludes the stage currently in progress. '
+                : 'This download creates a point-in-time workspace. '}
+              Work completed locally, including decisions, approvals, artifacts, and code changes,
+              will not be synchronized back to this intent or included in its traceability history.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -46,6 +46,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import {
   Check,
   ChevronDown,
+  Copy,
   Download,
   GitBranch,
   KeyRound,
@@ -77,11 +78,38 @@ const EXPORT_HARNESSES: Array<{ value: NativeExportHarness; label: string }> = [
 
 const shellQuote = (value: string) => `'${value.replaceAll("'", "'\"'\"'")}'`;
 
-const CommandBlock = ({ children }: { children: string }) => (
-  <pre className="mt-2 w-full min-w-0 max-w-full whitespace-pre-wrap break-all rounded-md bg-muted px-3 py-2 font-mono text-xs leading-relaxed">
-    <code>{children}</code>
-  </pre>
-);
+const CommandBlock = ({ children, label }: { children: string; label: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(children);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="relative mt-2 min-w-0">
+      <pre className="w-full min-w-0 max-w-full whitespace-pre-wrap break-all rounded-md bg-muted py-2 pl-3 pr-10 font-mono text-xs leading-relaxed">
+        <code>{children}</code>
+      </pre>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute right-1.5 top-1.5 h-7 w-7"
+        aria-label={copied ? `${label} copied` : label}
+        title={copied ? 'Copied' : label}
+        onClick={() => void copy()}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-green-600" />
+        ) : (
+          <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
+      </Button>
+    </div>
+  );
+};
 
 export default function IntentView() {
   const {
@@ -213,13 +241,7 @@ export default function IntentView() {
       document.body.append(download);
       download.click();
       download.remove();
-      const currentPhase = detail?.intent.currentPhase?.toLowerCase();
-      const hasActiveConstruction = detail?.stages.some(
-        (stage) =>
-          stage.phase?.toLowerCase() === 'construction' &&
-          ['RUNNING', 'WAITING_FOR_HUMAN'].includes(stage.state),
-      );
-      if (currentPhase === 'construction' || hasActiveConstruction) {
+      if (result.setup.showWorkspaceSetup) {
         setConstructionExport(result);
       }
     } catch (err) {
@@ -330,11 +352,21 @@ export default function IntentView() {
     `cd ${shellQuote(exportDirectory)}`,
     `unzip ${downloadedZip} -d .`,
   ].join('\n');
-  const launchCommands = constructionSetup?.launchCommand
-    ? `${constructionSetup.launchCommand}\n# Then run inside the agent session:\n${constructionSetup.continueCommand}`
-    : constructionSetup
-      ? `# Open this directory in Kiro IDE, then run:\n${constructionSetup.continueCommand}`
-      : '';
+  const legacyConstruction = constructionSetup?.construction?.perUnitIteration === false;
+  const completedUnitSummary = constructionSetup?.construction?.completedUnits.join(', ');
+  const constructionContinueCommand =
+    legacyConstruction &&
+    constructionSetup?.construction?.nextUnit &&
+    constructionSetup.continueCommand
+      ? [
+          `${constructionSetup.continueCommand} Continue the construction phase.`,
+          completedUnitSummary ? `Completed units: ${completedUnitSummary}.` : '',
+          `Continue with unit: ${constructionSetup.construction.nextUnit}.`,
+        ]
+          .filter(Boolean)
+          .join(' ')
+      : constructionSetup?.continueCommand;
+  const launchCommand = constructionSetup?.launchCommand ?? null;
 
   return (
     <div className="space-y-6">
@@ -698,15 +730,27 @@ export default function IntentView() {
             </AlertDialogDescription>
           </AlertDialogHeader>
 
+          {constructionSetup?.construction?.nextUnit &&
+            !constructionSetup.construction.perUnitIteration && (
+              <p className="text-sm text-muted-foreground">
+                This workspace uses an older AI-DLC runtime with limited automatic per-unit
+                iteration. The complete Bolt DAG and completed-unit receipts are included. The
+                continuation command below names the next dependency-ready unit:{' '}
+                <code>{constructionSetup.construction.nextUnit}</code>.
+              </p>
+            )}
+
           {constructionSetup?.mode === 'workspace-sync' && (
             <ol className="list-decimal space-y-4 pl-5 text-sm">
               <li>
                 Create an empty workspace directory and extract the downloaded ZIP:
-                <CommandBlock>{extractCommands}</CommandBlock>
+                <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
               </li>
               <li>
                 Clone the repositories declared by the export:
-                <CommandBlock>{constructionSetup.syncCommand ?? ''}</CommandBlock>
+                <CommandBlock label="Copy workspace sync command">
+                  {constructionSetup.syncCommand ?? ''}
+                </CommandBlock>
                 <p className="mt-1 text-xs text-muted-foreground">
                   This reads <code>repos.json</code> and clones{' '}
                   {constructionSetup.repositories.length === 1
@@ -716,12 +760,24 @@ export default function IntentView() {
                 </p>
               </li>
               <li>
-                Start the selected harness and continue AI-DLC:
-                <CommandBlock>{launchCommands}</CommandBlock>
+                Start the selected harness:
+                {launchCommand ? (
+                  <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Open this directory in Kiro IDE.
+                  </p>
+                )}
                 <p className="mt-1 text-xs text-muted-foreground">
                   Open this directory in your IDE. VS Code users may open{' '}
                   <code>aidlc.code-workspace</code>.
                 </p>
+              </li>
+              <li>
+                Then run inside the agent session:
+                <CommandBlock label="Copy AI-DLC command">
+                  {constructionContinueCommand ?? ''}
+                </CommandBlock>
               </li>
             </ol>
           )}
@@ -734,7 +790,7 @@ export default function IntentView() {
                   <div key={repository.name} className="mt-3 space-y-3">
                     <div>
                       <p className="text-xs font-medium">Fresh clone</p>
-                      <CommandBlock>
+                      <CommandBlock label={`Copy fresh clone commands for ${repository.name}`}>
                         {[
                           `git clone --branch ${shellQuote(repository.branch)} ${shellQuote(repository.url)} ${shellQuote(repository.name)}`,
                           `cd ${shellQuote(repository.name)}`,
@@ -743,7 +799,7 @@ export default function IntentView() {
                     </div>
                     <div>
                       <p className="text-xs font-medium">Existing clone</p>
-                      <CommandBlock>
+                      <CommandBlock label={`Copy existing clone commands for ${repository.name}`}>
                         {[
                           `cd ${shellQuote(`/path/to/${repository.name}`)}`,
                           'git fetch origin',
@@ -757,11 +813,25 @@ export default function IntentView() {
               </li>
               <li>
                 From the repository root, extract the downloaded workspace:
-                <CommandBlock>{`unzip ${downloadedZip} -d .`}</CommandBlock>
+                <CommandBlock label="Copy extraction command">
+                  {`unzip ${downloadedZip} -d .`}
+                </CommandBlock>
               </li>
               <li>
-                Start the selected harness and continue AI-DLC:
-                <CommandBlock>{launchCommands}</CommandBlock>
+                Start the selected harness:
+                {launchCommand ? (
+                  <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Open this directory in Kiro IDE.
+                  </p>
+                )}
+              </li>
+              <li>
+                Then run inside the agent session:
+                <CommandBlock label="Copy AI-DLC command">
+                  {constructionContinueCommand ?? ''}
+                </CommandBlock>
               </li>
             </ol>
           )}
@@ -770,11 +840,24 @@ export default function IntentView() {
             <ol className="list-decimal space-y-4 pl-5 text-sm">
               <li>
                 Create a project directory and extract the downloaded workspace:
-                <CommandBlock>{extractCommands}</CommandBlock>
+                <CommandBlock label="Copy extraction commands">{extractCommands}</CommandBlock>
+              </li>
+              <li>Open the extracted workspace directory in your IDE.</li>
+              <li>
+                Start the selected harness:
+                {launchCommand ? (
+                  <CommandBlock label="Copy harness command">{launchCommand}</CommandBlock>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Open this directory in Kiro IDE.
+                  </p>
+                )}
               </li>
               <li>
-                Start the selected harness and continue AI-DLC:
-                <CommandBlock>{launchCommands}</CommandBlock>
+                Then run inside the agent session:
+                <CommandBlock label="Copy AI-DLC command">
+                  {constructionContinueCommand ?? ''}
+                </CommandBlock>
               </li>
             </ol>
           )}

--- a/frontend/src/services/intents.ts
+++ b/frontend/src/services/intents.ts
@@ -72,6 +72,7 @@ export interface Intent {
   gitProvider?: string | null;
   workflowId: string;
   workflowVersion: number | null;
+  aidlcRepoRef?: string | null;
   scope: string | null;
   currentPhase: string | null;
   currentStage: string | null;
@@ -131,6 +132,29 @@ export interface IntentAttachmentUpload {
   fields: Record<string, string>;
   expiresIn: number;
 }
+
+export interface NativeWorkflowExport {
+  exportId: string;
+  filename: string;
+  downloadUrl: string;
+  expiresAt: string;
+  warnings: string[];
+  setup: {
+    workspaceLayout: 'flat' | 'spaces';
+    mode: 'extract-only' | 'workspace-sync' | 'manual-clone';
+    harnessDir: string | null;
+    syncCommand?: string;
+    launchCommand: string | null;
+    continueCommand: string;
+    repositories: Array<{
+      name: string;
+      url: string;
+      branch: string;
+    }>;
+  };
+}
+
+export type NativeExportHarness = AgentCli | 'kiro-ide';
 
 // Shape mirrors the plan resolver's error objects (lambda/shared/v2-execution-plan.js).
 export interface PlanWarning {
@@ -1025,6 +1049,11 @@ export const intentsService = {
   ) => api.post<Intent>(`/projects/${projectId}/intents/${intentId}/start`, input ?? {}),
   cancel: (projectId: string, intentId: string) =>
     api.post<Intent>(`/projects/${projectId}/intents/${intentId}/cancel`, {}),
+  exportWorkflow: (projectId: string, intentId: string, harness?: NativeExportHarness) =>
+    api.post<NativeWorkflowExport>(
+      `/projects/${projectId}/intents/${intentId}/export`,
+      harness ? { harness } : {},
+    ),
   // Permanent delete: removes the intent's graph data, process state and
   // realtime docs. Owner/admin only; refused (409) while RUNNING.
   delete: (projectId: string, intentId: string) =>

--- a/frontend/src/services/intents.ts
+++ b/frontend/src/services/intents.ts
@@ -139,6 +139,11 @@ export interface NativeWorkflowExport {
   downloadUrl: string;
   expiresAt: string;
   warnings: string[];
+  checkpoint?: {
+    checkpointId: string;
+    createdAt: string;
+    sourceStageInstanceId: string | null;
+  };
   setup: {
     workspaceLayout: 'flat' | 'spaces';
     mode: 'extract-only' | 'workspace-sync' | 'manual-workspace' | 'manual-clone';

--- a/frontend/src/services/intents.ts
+++ b/frontend/src/services/intents.ts
@@ -141,7 +141,7 @@ export interface NativeWorkflowExport {
   warnings: string[];
   setup: {
     workspaceLayout: 'flat' | 'spaces';
-    mode: 'extract-only' | 'workspace-sync' | 'manual-clone';
+    mode: 'extract-only' | 'workspace-sync' | 'manual-workspace' | 'manual-clone';
     harnessDir: string | null;
     syncCommand?: string;
     launchCommand: string | null;

--- a/frontend/src/services/intents.ts
+++ b/frontend/src/services/intents.ts
@@ -146,11 +146,18 @@ export interface NativeWorkflowExport {
     syncCommand?: string;
     launchCommand: string | null;
     continueCommand: string;
+    showWorkspaceSetup: boolean;
     repositories: Array<{
       name: string;
       url: string;
       branch: string;
     }>;
+    construction?: {
+      nextUnit: string | null;
+      completedUnits: string[];
+      readyUnits: string[];
+      perUnitIteration: boolean;
+    };
   };
 }
 

--- a/frontend/src/services/intents.ts
+++ b/frontend/src/services/intents.ts
@@ -153,7 +153,8 @@ export interface NativeWorkflowExport {
     continueCommand: string;
     showWorkspaceSetup: boolean;
     repositories: Array<{
-      name: string;
+      id: string;
+      directory: string;
       url: string;
       branch: string;
     }>;

--- a/lambda/agentcore/block-loader.js
+++ b/lambda/agentcore/block-loader.js
@@ -7,10 +7,10 @@
 // the same id. We read default first, fall back to SYSTEM — matching the API's
 // read semantics so the runtime honours user forks.
 
-import { QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { ddb, s3 } from './clients.js';
-import { catalogGsi1Pk } from '../shared/blocks.js';
+import { blockPk, catalogGsi1Pk, LATEST, versionSk } from '../shared/blocks.js';
 import { workflowPk, workflowVersionPrefix } from '../shared/workflows.js';
 import { DEFAULT_TENANT, SYSTEM_TENANT } from '../shared/tenant.js';
 
@@ -69,6 +69,28 @@ export const listMergedBlocks = async (type) => {
   return [...byId.values()];
 };
 
+const loadPlacedStages = async (placements) => {
+  const legacyPlacements = placements.filter((placement) => !placement.stageTenant);
+  const legacyStages = legacyPlacements.length ? await listMergedBlocks('STAGE') : [];
+  const legacyById = new Map(legacyStages.map((stage) => [stage.id ?? stage.blockId, stage]));
+  const stages = await Promise.all(
+    placements.map(async (placement) => {
+      if (!placement.stageTenant) return legacyById.get(placement.stageId) ?? null;
+      const tenant = placement.stageTenant;
+      const sk =
+        placement.pinnedVersion == null ? LATEST : versionSk(Number(placement.pinnedVersion));
+      const result = await ddb.send(
+        new GetCommand({
+          TableName: blocksTable(),
+          Key: { pk: blockPk(tenant, 'STAGE', placement.stageId), sk },
+        }),
+      );
+      return result.Item ?? null;
+    }),
+  );
+  return stages.filter(Boolean);
+};
+
 // Load the pinned workflow composition (META + phases + placements + refs) at an
 // immutable version, honouring default→SYSTEM shadowing.
 const loadWorkflow = async ({ workflowId, workflowVersion }) => {
@@ -102,6 +124,8 @@ const assembleWorkflow = (items, { workflowId, workflowVersion }) => {
     if (sk.startsWith('PLACEMENT#')) {
       placements.push({
         stageId: it.stageId,
+        stageTenant: it.stageTenant ?? null,
+        pinnedVersion: it.pinnedVersion ?? null,
         order: it.order ?? 0,
         phasePath: it.phasePath ?? null,
         scopeMembership: it.scopeMembership ?? {},
@@ -136,7 +160,7 @@ export const loadLibrary = async ({ workflowId, workflowVersion }) => {
   const workflow = assembleWorkflow(wf.items, { workflowId, workflowVersion });
 
   const [stages, agents, sensors, rules, artifacts, knowledge] = await Promise.all([
-    listMergedBlocks('STAGE'),
+    loadPlacedStages(workflow.placements),
     listMergedBlocks('AGENT'),
     listMergedBlocks('SENSOR'),
     listMergedBlocks('RULE'),
@@ -184,4 +208,4 @@ export const loadRuntimeFile = async (ref, repoPath) =>
 export const loadConductor = async (ref) =>
   ref ? getObjectText(`aidlc-runtime/${ref}/core/aidlc-common/conductor.md`) : '';
 
-export const __test = { assembleWorkflow, keyById, streamToString };
+export const __test = { assembleWorkflow, keyById, streamToString, loadPlacedStages };

--- a/lambda/agentcore/block-loader.js
+++ b/lambda/agentcore/block-loader.js
@@ -95,6 +95,39 @@ const loadPinnedBlocks = async (type, pins) => {
 const loadLibraryType = (type, methodologyPins) =>
   methodologyPins?.[type] ? loadPinnedBlocks(type, methodologyPins[type]) : listMergedBlocks(type);
 
+const assertSystemSourceRef = ({ aidlcRepoRef, workflowTenant, workflow, blocksByType }) => {
+  if (!aidlcRepoRef) return;
+
+  const mismatches = [];
+  const recordMismatch = (label, sourceRef) => {
+    if (sourceRef !== aidlcRepoRef) {
+      mismatches.push(`${label} has sourceRef ${sourceRef ?? '<missing>'}`);
+    }
+  };
+
+  if (workflowTenant === SYSTEM_TENANT) {
+    recordMismatch(
+      `workflow ${workflow.workflowId}@${workflow.workflowVersion}`,
+      workflow.sourceRef,
+    );
+  }
+  for (const [type, blocks] of Object.entries(blocksByType)) {
+    for (const block of blocks) {
+      if (block.tenantId !== SYSTEM_TENANT) continue;
+      recordMismatch(
+        `${type} ${block.id ?? block.blockId}@${block.version ?? '<unknown>'}`,
+        block.sourceRef,
+      );
+    }
+  }
+
+  if (mismatches.length) {
+    throw new Error(
+      `Pinned methodology snapshot does not match AI-DLC repository ref ${aidlcRepoRef}: ${mismatches.join('; ')}`,
+    );
+  }
+};
+
 const loadPlacedStages = async (placements, stagePins = null) => {
   const legacyPlacements = placements.filter(
     (placement) => !placement.stageTenant && !stagePins?.[placement.stageId],
@@ -199,7 +232,12 @@ const keyById = (items) => Object.fromEntries(items.map((b) => [b.id ?? b.blockI
 
 // Load everything the runtime needs for one execution: the pinned workflow plus
 // the library blocks (stages/agents/sensors/rules/artifacts) it references.
-export const loadLibrary = async ({ workflowId, workflowVersion, methodologyPins = null }) => {
+export const loadLibrary = async ({
+  workflowId,
+  workflowVersion,
+  methodologyPins = null,
+  aidlcRepoRef = null,
+}) => {
   const wf = await loadWorkflow({ workflowId, workflowVersion });
   if (!wf) return { workflow: null, library: null };
   const workflow = assembleWorkflow(wf.items, { workflowId, workflowVersion });
@@ -212,6 +250,20 @@ export const loadLibrary = async ({ workflowId, workflowVersion, methodologyPins
     loadLibraryType('ARTIFACT', methodologyPins),
     loadLibraryType('KNOWLEDGE', methodologyPins),
   ]);
+
+  assertSystemSourceRef({
+    aidlcRepoRef,
+    workflowTenant: wf.tenant,
+    workflow,
+    blocksByType: {
+      STAGE: stages,
+      AGENT: agents,
+      SENSOR: sensors,
+      RULE: rules,
+      ARTIFACT: artifacts,
+      KNOWLEDGE: knowledge,
+    },
+  });
 
   const library = {
     stagesById: keyById(stages),
@@ -259,4 +311,5 @@ export const __test = {
   streamToString,
   loadPlacedStages,
   loadPinnedBlocks,
+  assertSystemSourceRef,
 };

--- a/lambda/agentcore/block-loader.js
+++ b/lambda/agentcore/block-loader.js
@@ -69,12 +69,53 @@ export const listMergedBlocks = async (type) => {
   return [...byId.values()];
 };
 
-const loadPlacedStages = async (placements) => {
-  const legacyPlacements = placements.filter((placement) => !placement.stageTenant);
+const loadPinnedBlocks = async (type, pins) => {
+  const entries = Object.entries(pins ?? {});
+  const blocks = await Promise.all(
+    entries.map(async ([blockId, pin]) => {
+      const result = await ddb.send(
+        new GetCommand({
+          TableName: blocksTable(),
+          Key: {
+            pk: blockPk(pin.tenantId, type, blockId),
+            sk: versionSk(Number(pin.version)),
+          },
+        }),
+      );
+      return result.Item ?? null;
+    }),
+  );
+  const missing = entries.filter((_, index) => blocks[index] == null).map(([blockId]) => blockId);
+  if (missing.length) {
+    throw new Error(`Pinned ${type} block versions are unavailable: ${missing.join(', ')}`);
+  }
+  return blocks;
+};
+
+const loadLibraryType = (type, methodologyPins) =>
+  methodologyPins?.[type] ? loadPinnedBlocks(type, methodologyPins[type]) : listMergedBlocks(type);
+
+const loadPlacedStages = async (placements, stagePins = null) => {
+  const legacyPlacements = placements.filter(
+    (placement) => !placement.stageTenant && !stagePins?.[placement.stageId],
+  );
   const legacyStages = legacyPlacements.length ? await listMergedBlocks('STAGE') : [];
   const legacyById = new Map(legacyStages.map((stage) => [stage.id ?? stage.blockId, stage]));
   const stages = await Promise.all(
     placements.map(async (placement) => {
+      const pin = stagePins?.[placement.stageId];
+      if (!placement.stageTenant && pin) {
+        const result = await ddb.send(
+          new GetCommand({
+            TableName: blocksTable(),
+            Key: {
+              pk: blockPk(pin.tenantId, 'STAGE', placement.stageId),
+              sk: versionSk(Number(pin.version)),
+            },
+          }),
+        );
+        return result.Item ?? null;
+      }
       if (!placement.stageTenant) return legacyById.get(placement.stageId) ?? null;
       const tenant = placement.stageTenant;
       const sk =
@@ -119,9 +160,12 @@ const assembleWorkflow = (items, { workflowId, workflowVersion }) => {
   const ruleRefs = [];
   const scopeRefs = [];
   const phases = [];
+  let sourceRef = null;
   for (const it of items) {
     const sk = liveSk(it.sk);
-    if (sk.startsWith('PLACEMENT#')) {
+    if (sk === 'META') {
+      sourceRef = it.sourceRef ?? null;
+    } else if (sk.startsWith('PLACEMENT#')) {
       placements.push({
         stageId: it.stageId,
         stageTenant: it.stageTenant ?? null,
@@ -141,6 +185,7 @@ const assembleWorkflow = (items, { workflowId, workflowVersion }) => {
   return {
     workflowId,
     workflowVersion: Number(workflowVersion),
+    sourceRef,
     placements,
     ruleRefs,
     scopeRefs,
@@ -154,18 +199,18 @@ const keyById = (items) => Object.fromEntries(items.map((b) => [b.id ?? b.blockI
 
 // Load everything the runtime needs for one execution: the pinned workflow plus
 // the library blocks (stages/agents/sensors/rules/artifacts) it references.
-export const loadLibrary = async ({ workflowId, workflowVersion }) => {
+export const loadLibrary = async ({ workflowId, workflowVersion, methodologyPins = null }) => {
   const wf = await loadWorkflow({ workflowId, workflowVersion });
   if (!wf) return { workflow: null, library: null };
   const workflow = assembleWorkflow(wf.items, { workflowId, workflowVersion });
 
   const [stages, agents, sensors, rules, artifacts, knowledge] = await Promise.all([
-    loadPlacedStages(workflow.placements),
-    listMergedBlocks('AGENT'),
-    listMergedBlocks('SENSOR'),
-    listMergedBlocks('RULE'),
-    listMergedBlocks('ARTIFACT'),
-    listMergedBlocks('KNOWLEDGE'),
+    loadPlacedStages(workflow.placements, methodologyPins?.STAGE),
+    loadLibraryType('AGENT', methodologyPins),
+    loadLibraryType('SENSOR', methodologyPins),
+    loadLibraryType('RULE', methodologyPins),
+    loadLibraryType('ARTIFACT', methodologyPins),
+    loadLibraryType('KNOWLEDGE', methodologyPins),
   ]);
 
   const library = {
@@ -208,4 +253,10 @@ export const loadRuntimeFile = async (ref, repoPath) =>
 export const loadConductor = async (ref) =>
   ref ? getObjectText(`aidlc-runtime/${ref}/core/aidlc-common/conductor.md`) : '';
 
-export const __test = { assembleWorkflow, keyById, streamToString, loadPlacedStages };
+export const __test = {
+  assembleWorkflow,
+  keyById,
+  streamToString,
+  loadPlacedStages,
+  loadPinnedBlocks,
+};

--- a/lambda/agentcore/commands/create-workflow-checkpoint.js
+++ b/lambda/agentcore/commands/create-workflow-checkpoint.js
@@ -6,7 +6,13 @@ import { closeGraphSource } from '../mcp/graph-writer.js';
 // Capture the latest completed workflow boundary and atomically replace the
 // execution's latest-checkpoint pointer. Failures leave the prior checkpoint.
 const createWorkflowCheckpoint = async (payload, deps) => {
-  const { projectId, intentId, executionId, sourceStageInstanceId = null } = payload ?? {};
+  const {
+    projectId,
+    intentId,
+    executionId,
+    orchestratorRunId,
+    sourceStageInstanceId = null,
+  } = payload ?? {};
   const {
     store,
     openGraph,
@@ -15,7 +21,9 @@ const createWorkflowCheckpoint = async (payload, deps) => {
     clock = () => new Date().toISOString(),
     snapshotArtifacts = snapshotCurrentArtifactHeads,
   } = deps;
-  if (!intentId || !executionId) return { ok: false, reason: 'missing_identity' };
+  if (!intentId || !executionId || !orchestratorRunId) {
+    return { ok: false, reason: 'missing_identity' };
+  }
 
   let g;
   try {
@@ -38,7 +46,7 @@ const createWorkflowCheckpoint = async (payload, deps) => {
       artifactRefs,
       customRuleRefs,
     });
-    await store.putWorkflowCheckpoint(checkpoint);
+    await store.putWorkflowCheckpoint({ ...checkpoint, orchestratorRunId });
     return {
       ok: true,
       checkpointId: checkpoint.checkpointId,

--- a/lambda/agentcore/commands/create-workflow-checkpoint.js
+++ b/lambda/agentcore/commands/create-workflow-checkpoint.js
@@ -1,0 +1,56 @@
+import { snapshotCurrentArtifactHeads } from '../../shared/artifact-versioning.js';
+import { pinCustomRuleVersions } from '../../shared/custom-rule-versions.js';
+import { buildWorkflowCheckpoint } from '../../shared/workflow-checkpoint.js';
+import { closeGraphSource } from '../mcp/graph-writer.js';
+
+// Capture the latest completed workflow boundary and atomically replace the
+// execution's latest-checkpoint pointer. Failures leave the prior checkpoint.
+const createWorkflowCheckpoint = async (payload, deps) => {
+  const { projectId, intentId, executionId, sourceStageInstanceId = null } = payload ?? {};
+  const {
+    store,
+    openGraph,
+    s3,
+    bucket,
+    clock = () => new Date().toISOString(),
+    snapshotArtifacts = snapshotCurrentArtifactHeads,
+  } = deps;
+  if (!intentId || !executionId) return { ok: false, reason: 'missing_identity' };
+
+  let g;
+  try {
+    const records = await store.getExecutionRecords(executionId, { includeOutputs: false });
+    if (!records.meta || records.meta.projectId !== projectId || intentId !== executionId) {
+      return { ok: false, reason: 'execution_not_found' };
+    }
+    g = await openGraph();
+    const artifactRefs = await snapshotArtifacts({ g, intentId, clock });
+    const customRuleRefs = await pinCustomRuleVersions({
+      s3,
+      bucket,
+      rules: records.meta.customRules ?? [],
+    });
+    const checkpoint = buildWorkflowCheckpoint({
+      executionId,
+      createdAt: clock(),
+      sourceStageInstanceId,
+      records,
+      artifactRefs,
+      customRuleRefs,
+    });
+    await store.putWorkflowCheckpoint(checkpoint);
+    return {
+      ok: true,
+      checkpointId: checkpoint.checkpointId,
+      artifactCount: artifactRefs.length,
+      customRuleCount: customRuleRefs.length,
+    };
+  } catch (error) {
+    return { ok: false, reason: 'checkpoint_failed', detail: error.message };
+  } finally {
+    await closeGraphSource(g);
+  }
+};
+
+export { createWorkflowCheckpoint };
+export default createWorkflowCheckpoint;

--- a/lambda/agentcore/commands/run-stage.js
+++ b/lambda/agentcore/commands/run-stage.js
@@ -1159,7 +1159,7 @@ export const runStage = async (
   // agentRef, merge, then resolve against the enriched library.
   let loaded;
   try {
-    loaded = await loadLibrary({ workflowId, workflowVersion, methodologyPins });
+    loaded = await loadLibrary({ workflowId, workflowVersion, methodologyPins, aidlcRepoRef });
   } catch (error) {
     return fail(null, 'methodology_snapshot_unavailable', error.message);
   }

--- a/lambda/agentcore/commands/run-stage.js
+++ b/lambda/agentcore/commands/run-stage.js
@@ -921,6 +921,8 @@ export const runStage = async (
     stageId,
     workflowId,
     workflowVersion,
+    aidlcRepoRef = null,
+    methodologyPins = null,
     scope,
     // Per-run skip overlay (shared/stage-skip.js): intent-level deselections +
     // accumulated gate-time skips, forwarded by the orchestrator on EVERY
@@ -1155,7 +1157,12 @@ export const runStage = async (
   // knowledge is held for the prompt. Reading the agentRef needs the stage, but
   // the merge needs to precede resolution — so we resolve once to read the
   // agentRef, merge, then resolve against the enriched library.
-  const loaded = await loadLibrary({ workflowId, workflowVersion });
+  let loaded;
+  try {
+    loaded = await loadLibrary({ workflowId, workflowVersion, methodologyPins });
+  } catch (error) {
+    return fail(null, 'methodology_snapshot_unavailable', error.message);
+  }
   if (!loaded.workflow || !loaded.library)
     return fail(null, 'workflow_not_found', `${workflowId}@${workflowVersion}`);
 
@@ -1501,6 +1508,13 @@ export const runStage = async (
   // stage row + threaded to the MCP scope for read-time token pricing.
   const model = resolveStageModel({ cliModels, tierModels, agentBlock, cli, env });
   const priorStageRow = await store.getStage(executionId, stageInstanceId).catch(() => null);
+  if (priorStageRow?.aidlcRepoRef && aidlcRepoRef && priorStageRow.aidlcRepoRef !== aidlcRepoRef) {
+    return fail(
+      stageInstanceId,
+      'aidlc_ref_mismatch',
+      `stage ${stageInstanceId} started with ${priorStageRow.aidlcRepoRef}, received ${aidlcRepoRef}`,
+    );
+  }
   const stageScope = {
     executionId,
     intentId,
@@ -1581,6 +1595,7 @@ export const runStage = async (
       cliSessionId,
       resolvedModel: model,
       stageCallbackId,
+      aidlcRepoRef,
     });
   } else {
     await store.putStage({
@@ -1596,6 +1611,7 @@ export const runStage = async (
       cliSessionId,
       resolvedModel: model,
       stageCallbackId,
+      aidlcRepoRef,
     });
   }
   await store.updateExecution({
@@ -1782,7 +1798,7 @@ export const runStage = async (
     const [stageBody, agentPersona, conductor] = await Promise.all([
       loadBlockBody(stageBlock).catch(() => ''),
       agentBlock ? loadBlockBody(agentBlock).catch(() => '') : Promise.resolve(''),
-      loadConductor(env.AIDLC_REPO_REF).catch(() => ''),
+      loadConductor(aidlcRepoRef || env.AIDLC_REPO_REF).catch(() => ''),
     ]);
     // Knowledge has two tiers: the authored methodology (library blocks) and the
     // project's accrued team knowledge (already read from Neptune above). Both are

--- a/lambda/agentcore/commands/run-stage.js
+++ b/lambda/agentcore/commands/run-stage.js
@@ -1505,6 +1505,7 @@ export const runStage = async (
     executionId,
     intentId,
     projectId,
+    stageId,
     stageInstanceId,
     unitSlug,
     sectionIndex,

--- a/lambda/agentcore/http-server.js
+++ b/lambda/agentcore/http-server.js
@@ -27,6 +27,9 @@
 //     → rebuild the fine-grained graph projection from canonical artifact markdown.
 //       `enrichment` ('off'|'llm') is the Admin toggle snapshotted on the execution;
 //       'llm' adds bounded summary metadata via a one-shot agent-CLI call.
+//   { "command": "create-workflow-checkpoint", projectId, intentId, executionId,
+//     sourceStageInstanceId? }
+//     → freeze the latest completed workflow boundary for native export.
 //   { "command": "init-lane",  ...initLane args }   → WP5: prepare a unit
 //       lane's session workspace (clone + unit branch off intent HEAD + push).
 //   { "command": "merge-lane", ...mergeLane args }  → WP5: serialized --no-ff
@@ -177,6 +180,7 @@ export const createServer = ({
 const main = async () => {
   const {
     ddb,
+    s3,
     openGraph,
     broadcastToIntent,
     sendStageCallbackSuccess,
@@ -192,6 +196,7 @@ const main = async () => {
   const { repairStructure } = await import('./commands/repair-structure.js');
   const { promoteUnits } = await import('./commands/promote-units.js');
   const { deriveArtifacts } = await import('./commands/derive-artifacts.js');
+  const { createWorkflowCheckpoint } = await import('./commands/create-workflow-checkpoint.js');
   const { recordPr } = await import('./commands/record-pr.js');
   const { recordUnitPr } = await import('./commands/record-unit-pr.js');
   const { initLane, mergeLane, reconcileLane, refreshIntentWorkspace } =
@@ -272,6 +277,13 @@ const main = async () => {
         broadcast,
         availableClis: context.availableClis,
         env: context.env,
+      }),
+    createWorkflowCheckpoint: (p) =>
+      createWorkflowCheckpoint(p, {
+        store,
+        openGraph,
+        s3,
+        bucket: process.env.ARTIFACTS_BUCKET,
       }),
     // Fan-in PR record: write the opened PR(s) into the graph (the orchestrator
     // has no Neptune access, so it forwards the structured PR data here).

--- a/lambda/agentcore/mcp/index.js
+++ b/lambda/agentcore/mcp/index.js
@@ -4,7 +4,8 @@
 // process store, and registers the role-appropriate tools.
 //
 // ENV (set by the container's run-stage / reviewer path, never by the agent):
-//   V2_EXECUTION_ID, V2_INTENT_ID, V2_PROJECT_ID, V2_STAGE_INSTANCE_ID
+//   V2_EXECUTION_ID, V2_INTENT_ID, V2_PROJECT_ID, V2_STAGE_ID,
+//   V2_STAGE_INSTANCE_ID
 //   V2_MCP_ROLE          author | reviewer | reader
 //   V2_PROCESS_TABLE, NEPTUNE_ENDPOINT, CONNECTIONS_TABLE, WEBSOCKET_ENDPOINT
 
@@ -22,6 +23,7 @@ const scopeFromEnv = (env = process.env) => ({
   executionId: env.V2_EXECUTION_ID,
   intentId: env.V2_INTENT_ID,
   projectId: env.V2_PROJECT_ID,
+  stageId: env.V2_STAGE_ID || null,
   stageInstanceId: env.V2_STAGE_INSTANCE_ID ?? null,
   sectionIndex:
     env.V2_SECTION_INDEX === undefined || env.V2_SECTION_INDEX === ''
@@ -65,7 +67,7 @@ export const startMcpServer = async ({ env = process.env } = {}) => {
 
   const handlers = buildToolHandlers({ graph, bridge });
   const server = new McpServer({ name: 'aidlc-v2-mcp', version: '1.0.0' });
-  const registered = registerTools({ server, handlers, role, z, env });
+  const registered = registerTools({ server, handlers, role, stageId: scope.stageId, z, env });
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/lambda/agentcore/mcp/process-bridge.js
+++ b/lambda/agentcore/mcp/process-bridge.js
@@ -39,6 +39,7 @@ export const createProcessBridge = ({
   const {
     executionId,
     intentId = null,
+    stageId = null,
     stageInstanceId = null,
     unitSlug = null,
     sectionIndex = null,
@@ -180,6 +181,32 @@ export const createProcessBridge = ({
     return { seq: row.seq, kind };
   };
 
+  const recordProjectType = async ({ projectType }) => {
+    if (stageId !== 'workspace-detection') {
+      throw new Error('record_project_type is available only during workspace-detection');
+    }
+    if (projectType !== 'greenfield' && projectType !== 'brownfield') {
+      throw new Error('projectType must be greenfield or brownfield');
+    }
+    await store.updateExecution({ executionId, projectType });
+    await store.appendEvent({
+      executionId,
+      type: 'v2.workspace.classified',
+      stageInstanceId,
+      actor: stageInstanceId ?? 'agent',
+      summary: `Workspace classified as ${projectType}`,
+    });
+    await broadcast({
+      action: 'agent.note',
+      executionId,
+      intentId,
+      stageInstanceId,
+      noteType: 'v2.workspace.classified',
+      summary: `Workspace classified as ${projectType}`,
+    });
+    return { projectType };
+  };
+
   // Record a numeric metric sample (token usage, context-window %, etc.) and
   // broadcast it live so the UI can render usage in real time.
   const collectMetric = async ({ metrics }) => {
@@ -305,5 +332,13 @@ export const createProcessBridge = ({
     });
   };
 
-  return { askQuestion, sendOutput, collectMetric, emitStageNote, recordGraphRead, submitReview };
+  return {
+    askQuestion,
+    sendOutput,
+    recordProjectType,
+    collectMetric,
+    emitStageNote,
+    recordGraphRead,
+    submitReview,
+  };
 };

--- a/lambda/agentcore/mcp/server.js
+++ b/lambda/agentcore/mcp/server.js
@@ -183,6 +183,8 @@ export const buildToolHandlers = ({ writer, graph, bridge }) => {
     ask_question: ({ questions }) => guard(() => bridge.askQuestion({ questions })),
     send_output: ({ content, kind }) =>
       guard(() => bridge.sendOutput({ content, kind: kind ?? 'text' })),
+    record_project_type: ({ projectType }) =>
+      guard(() => bridge.recordProjectType({ projectType })),
     collect_metric: ({ metrics }) => guard(() => bridge.collectMetric({ metrics })),
     emit_stage_note: ({ summary, type }) => guard(() => bridge.emitStageNote({ summary, type })),
     submit_review: ({ reviewer, verdict, findings, round }) =>
@@ -223,12 +225,20 @@ export const AUTHOR_TOOLS = [
 ];
 
 export const REVIEWER_TOOLS = [...READ_TOOLS, 'collect_metric', 'submit_review'];
+export const WORKSPACE_DETECTION_TOOLS = ['record_project_type'];
+
+const toolsForRole = (role, stageId = null) => {
+  if (role === 'reader') return READ_TOOLS;
+  if (role === 'reviewer') return REVIEWER_TOOLS;
+  return stageId === 'workspace-detection'
+    ? [...AUTHOR_TOOLS, ...WORKSPACE_DETECTION_TOOLS]
+    : AUTHOR_TOOLS;
+};
 
 // The handler subset for a given role. `reader` → read-only; `reviewer` adds
 // review verdict/metrics; `author` → all.
-export const handlersForRole = (allHandlers, role) => {
-  const names =
-    role === 'reader' ? READ_TOOLS : role === 'reviewer' ? REVIEWER_TOOLS : AUTHOR_TOOLS;
+export const handlersForRole = (allHandlers, role, stageId = null) => {
+  const names = toolsForRole(role, stageId);
   return Object.fromEntries(names.map((n) => [n, allHandlers[n]]));
 };
 
@@ -374,6 +384,11 @@ export const toolSchemas = (z) => ({
       'Stream a unit of human-facing output (markdown) to the UI. Persisted so it survives a page reload.',
     shape: { content: z.string(), kind: z.enum(['text', 'thought', 'tool']).optional() },
   },
+  record_project_type: {
+    description:
+      'Workspace Detection only: persist the deterministic workspace classification for later stages and native exports.',
+    shape: { projectType: z.enum(['greenfield', 'brownfield']) },
+  },
   collect_metric: {
     description:
       'Record a numeric metric sample (e.g. tokensInput, tokensOutput, contextWindowPct).',
@@ -421,10 +436,9 @@ const traceHandler = (name, fn, { enabled }) => {
 // Register the role-appropriate tools on an McpServer. Pure of transport so it
 // is unit-testable with a fake server that records registrations. Each handler
 // is wrapped in a stderr trace (see traceHandler) unless env disables it.
-export const registerTools = ({ server, handlers, role, z, env = process.env }) => {
+export const registerTools = ({ server, handlers, role, stageId = null, z, env = process.env }) => {
   const schemas = toolSchemas(z);
-  const names =
-    role === 'reader' ? READ_TOOLS : role === 'reviewer' ? REVIEWER_TOOLS : AUTHOR_TOOLS;
+  const names = toolsForRole(role, stageId);
   const enabled = env.V2_MCP_TRACE !== 'off';
   for (const name of names) {
     const { description, shape } = schemas[name];

--- a/lambda/agentcore/stage-materializer.js
+++ b/lambda/agentcore/stage-materializer.js
@@ -53,6 +53,18 @@ export const OUTPUT_CONTRACT = [
   '- Do exactly THIS stage. Do not start other stages or invent status.',
 ].join('\n');
 
+const renderWorkspaceDetectionContract = (stageId) => {
+  if (stageId !== 'workspace-detection') return '';
+  return [
+    '## Workspace classification contract',
+    '',
+    'After scanning the workspace and deciding its project type, call',
+    '`record_project_type` exactly once with `greenfield` or `brownfield`.',
+    'Do this before `send_output`; the structured value is required by later',
+    'workflow stages and native workspace exports.',
+  ].join('\n');
+};
+
 // Render the resolved input artifacts as a prompt section. An `expectedAbsent`
 // input (its producer exists in the workflow but is out of the selected scope —
 // the plan resolver's scope-shortcut classification) is called out explicitly:
@@ -177,6 +189,8 @@ export const buildStagePrompt = ({
   // worded once-per-workflow) so the agent reads its lane boundary first.
   const unitScope = renderUnitScope(unit);
   if (unitScope) sections.push('', unitScope);
+  const workspaceDetectionContract = renderWorkspaceDetectionContract(stage.stageId);
+  if (workspaceDetectionContract) sections.push('', workspaceDetectionContract);
   sections.push(
     '',
     '## Stage instructions',
@@ -253,6 +267,7 @@ export const buildMcpConfig = ({ mcpEntry, scope, env = {}, customServers = {} }
         V2_EXECUTION_ID: scope.executionId,
         V2_INTENT_ID: scope.intentId,
         V2_PROJECT_ID: scope.projectId ?? '',
+        V2_STAGE_ID: scope.stageId ?? '',
         V2_STAGE_INSTANCE_ID: scope.stageInstanceId ?? '',
         V2_SECTION_INDEX:
           scope.sectionIndex === undefined || scope.sectionIndex === null

--- a/lambda/agentcore/test/block-loader.test.js
+++ b/lambda/agentcore/test/block-loader.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { __test, loadLibrary } from '../block-loader.js';
 
-const { assembleWorkflow, keyById } = __test;
+const { assembleWorkflow, keyById, loadPlacedStages } = __test;
 
 describe('assembleWorkflow', () => {
   // Version snapshot rows are keyed V#<n>#<liveSk>; the loader strips the prefix.
@@ -13,6 +13,8 @@ describe('assembleWorkflow', () => {
     {
       sk: 'V#2#PLACEMENT#requirements-analysis',
       stageId: 'requirements-analysis',
+      stageTenant: 'default',
+      pinnedVersion: 7,
       order: 5,
       phasePath: '03',
       scopeMembership: { feature: 'EXECUTE' },
@@ -27,6 +29,8 @@ describe('assembleWorkflow', () => {
     expect(wf.placements).toEqual([
       {
         stageId: 'requirements-analysis',
+        stageTenant: 'default',
+        pinnedVersion: 7,
         order: 5,
         phasePath: '03',
         scopeMembership: { feature: 'EXECUTE' },
@@ -41,6 +45,26 @@ describe('assembleWorkflow', () => {
     const wf = assembleWorkflow(rows, { workflowId: 'aidlc-v2', workflowVersion: 2 });
     // scopeRefs present → scope resolves from refs.
     expect(wf.scopeRefs.map((r) => r.scopeId)).toContain('feature');
+  });
+
+  it('preserves missing ownership metadata in legacy workflow snapshots', () => {
+    const wf = assembleWorkflow(
+      [
+        { sk: 'V#2#META' },
+        {
+          sk: 'V#2#PLACEMENT#legacy-stage',
+          stageId: 'legacy-stage',
+          scopeMembership: { feature: 'EXECUTE' },
+        },
+      ],
+      { workflowId: 'legacy', workflowVersion: 2 },
+    );
+
+    expect(wf.placements[0]).toMatchObject({
+      stageId: 'legacy-stage',
+      stageTenant: null,
+      pinnedVersion: null,
+    });
   });
 });
 
@@ -66,6 +90,22 @@ describe('loadLibrary — paginated table reads', () => {
     delete process.env.BLOCKS_TABLE;
   });
 
+  it('resolves legacy placements without ownership metadata through the merged catalog', async () => {
+    const legacyStage = {
+      GSI1PK: 'TENANT#default#STAGE',
+      id: 'legacy-stage',
+      blockId: 'legacy-stage',
+      version: 3,
+    };
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      const pk = input.ExpressionAttributeValues?.[':pk'];
+      return { Items: pk === 'TENANT#default#STAGE' ? [legacyStage] : [] };
+    });
+
+    await expect(loadPlacedStages([{ stageId: 'legacy-stage' }])).resolves.toEqual([legacyStage]);
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+  });
+
   it('drains 1MB-truncated workflow + catalog pages (a dropped page silently narrows the plan)', async () => {
     const wfRows = [
       { pk: 'WF#SYSTEM#aidlc-v2', sk: 'V#1#META' },
@@ -73,6 +113,8 @@ describe('loadLibrary — paginated table reads', () => {
         pk: 'WF#SYSTEM#aidlc-v2',
         sk: 'V#1#PLACEMENT#stage-a',
         stageId: 'stage-a',
+        stageTenant: 'SYSTEM',
+        pinnedVersion: 1,
         order: 0,
         scopeMembership: { feature: 'EXECUTE' },
       },
@@ -80,14 +122,23 @@ describe('loadLibrary — paginated table reads', () => {
         pk: 'WF#SYSTEM#aidlc-v2',
         sk: 'V#1#PLACEMENT#stage-b',
         stageId: 'stage-b',
+        stageTenant: 'SYSTEM',
+        pinnedVersion: 2,
         order: 1,
         scopeMembership: { feature: 'EXECUTE' },
       },
     ];
     const stageRows = [
       { GSI1PK: 'TENANT#SYSTEM#STAGE', id: 'stage-a', version: 1 },
-      { GSI1PK: 'TENANT#SYSTEM#STAGE', id: 'stage-b', version: 1 },
+      { GSI1PK: 'TENANT#SYSTEM#STAGE', id: 'stage-b', version: 2 },
     ];
+    ddbMock.on(GetCommand).callsFake((input) => ({
+      Item: stageRows.find(
+        (stage) =>
+          input.Key.pk === `BLOCK#SYSTEM#STAGE#${stage.id}` &&
+          input.Key.sk === `V#${stage.version}`,
+      ),
+    }));
     ddbMock.on(QueryCommand).callsFake((input) => {
       const values = input.ExpressionAttributeValues || {};
       if (input.IndexName === 'GSI1') {
@@ -111,5 +162,9 @@ describe('loadLibrary — paginated table reads', () => {
     const { workflow, library } = await loadLibrary({ workflowId: 'aidlc-v2', workflowVersion: 1 });
     expect(workflow.placements.map((p) => p.stageId)).toEqual(['stage-a', 'stage-b']);
     expect(Object.keys(library.stagesById).toSorted()).toEqual(['stage-a', 'stage-b']);
+    expect(ddbMock.commandCalls(GetCommand).map((call) => call.args[0].input.Key)).toContainEqual({
+      pk: 'BLOCK#SYSTEM#STAGE#stage-b',
+      sk: 'V#2',
+    });
   });
 });

--- a/lambda/agentcore/test/block-loader.test.js
+++ b/lambda/agentcore/test/block-loader.test.js
@@ -174,6 +174,7 @@ describe('loadLibrary — paginated table reads', () => {
       blockId: 'agent-x',
       version: 3,
       name: 'Pinned agent',
+      sourceRef: 'a'.repeat(40),
     };
     ddbMock.on(GetCommand).callsFake((input) => ({
       Item: input.Key.pk === 'BLOCK#SYSTEM#AGENT#agent-x' && input.Key.sk === 'V#3' ? agent : null,
@@ -181,7 +182,7 @@ describe('loadLibrary — paginated table reads', () => {
     ddbMock.on(QueryCommand).callsFake((input) => {
       const values = input.ExpressionAttributeValues || {};
       if (values[':pk'] === 'WF#SYSTEM#aidlc-v2') {
-        return { Items: [{ sk: 'V#1#META' }] };
+        return { Items: [{ sk: 'V#1#META', sourceRef: 'a'.repeat(40) }] };
       }
       return { Items: [] };
     });
@@ -189,6 +190,7 @@ describe('loadLibrary — paginated table reads', () => {
     const { library } = await loadLibrary({
       workflowId: 'aidlc-v2',
       workflowVersion: 1,
+      aidlcRepoRef: 'a'.repeat(40),
       methodologyPins: {
         AGENT: { 'agent-x': { tenantId: 'SYSTEM', version: 3 } },
         SENSOR: {},
@@ -202,6 +204,75 @@ describe('loadLibrary — paginated table reads', () => {
     expect(ddbMock.commandCalls(GetCommand).map((call) => call.args[0].input.Key)).toContainEqual({
       pk: 'BLOCK#SYSTEM#AGENT#agent-x',
       sk: 'V#3',
+    });
+  });
+
+  it('rejects SYSTEM blocks that were reseeded from a different methodology revision', async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        tenantId: 'SYSTEM',
+        blockId: 'agent-x',
+        version: 3,
+        sourceRef: 'b'.repeat(40),
+      },
+    });
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      const values = input.ExpressionAttributeValues || {};
+      if (values[':pk'] === 'WF#SYSTEM#aidlc-v2') {
+        return { Items: [{ sk: 'V#1#META', sourceRef: 'a'.repeat(40) }] };
+      }
+      return { Items: [] };
+    });
+
+    await expect(
+      loadLibrary({
+        workflowId: 'aidlc-v2',
+        workflowVersion: 1,
+        aidlcRepoRef: 'a'.repeat(40),
+        methodologyPins: {
+          AGENT: { 'agent-x': { tenantId: 'SYSTEM', version: 3 } },
+          SENSOR: {},
+          RULE: {},
+          ARTIFACT: {},
+          KNOWLEDGE: {},
+        },
+      }),
+    ).rejects.toThrow(
+      `Pinned methodology snapshot does not match AI-DLC repository ref ${'a'.repeat(40)}: AGENT agent-x@3 has sourceRef ${'b'.repeat(40)}`,
+    );
+  });
+
+  it('does not apply SYSTEM source validation to custom tenant blocks', async () => {
+    const customAgent = {
+      tenantId: 'default',
+      blockId: 'agent-x',
+      version: 3,
+      sourceRef: 'custom-source',
+    };
+    ddbMock.on(GetCommand).resolves({ Item: customAgent });
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      const values = input.ExpressionAttributeValues || {};
+      if (values[':pk'] === 'WF#default#custom-workflow') {
+        return { Items: [{ sk: 'V#1#META', sourceRef: 'custom-source' }] };
+      }
+      return { Items: [] };
+    });
+
+    await expect(
+      loadLibrary({
+        workflowId: 'custom-workflow',
+        workflowVersion: 1,
+        aidlcRepoRef: 'a'.repeat(40),
+        methodologyPins: {
+          AGENT: { 'agent-x': { tenantId: 'default', version: 3 } },
+          SENSOR: {},
+          RULE: {},
+          ARTIFACT: {},
+          KNOWLEDGE: {},
+        },
+      }),
+    ).resolves.toMatchObject({
+      library: { agentsById: { 'agent-x': customAgent } },
     });
   });
 });

--- a/lambda/agentcore/test/block-loader.test.js
+++ b/lambda/agentcore/test/block-loader.test.js
@@ -167,4 +167,41 @@ describe('loadLibrary — paginated table reads', () => {
       sk: 'V#2',
     });
   });
+
+  it('loads supporting blocks from exact execution pins instead of catalog heads', async () => {
+    const agent = {
+      tenantId: 'SYSTEM',
+      blockId: 'agent-x',
+      version: 3,
+      name: 'Pinned agent',
+    };
+    ddbMock.on(GetCommand).callsFake((input) => ({
+      Item: input.Key.pk === 'BLOCK#SYSTEM#AGENT#agent-x' && input.Key.sk === 'V#3' ? agent : null,
+    }));
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      const values = input.ExpressionAttributeValues || {};
+      if (values[':pk'] === 'WF#SYSTEM#aidlc-v2') {
+        return { Items: [{ sk: 'V#1#META' }] };
+      }
+      return { Items: [] };
+    });
+
+    const { library } = await loadLibrary({
+      workflowId: 'aidlc-v2',
+      workflowVersion: 1,
+      methodologyPins: {
+        AGENT: { 'agent-x': { tenantId: 'SYSTEM', version: 3 } },
+        SENSOR: {},
+        RULE: {},
+        ARTIFACT: {},
+        KNOWLEDGE: {},
+      },
+    });
+
+    expect(library.agentsById['agent-x']).toEqual(agent);
+    expect(ddbMock.commandCalls(GetCommand).map((call) => call.args[0].input.Key)).toContainEqual({
+      pk: 'BLOCK#SYSTEM#AGENT#agent-x',
+      sk: 'V#3',
+    });
+  });
 });

--- a/lambda/agentcore/test/create-workflow-checkpoint.test.js
+++ b/lambda/agentcore/test/create-workflow-checkpoint.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import { createWorkflowCheckpoint } from '../commands/create-workflow-checkpoint.js';
+
+describe('create-workflow-checkpoint', () => {
+  it('freezes artifact and custom-rule references into the latest checkpoint', async () => {
+    const putWorkflowCheckpoint = vi.fn(async (checkpoint) => checkpoint);
+    const s3 = {
+      send: vi.fn(async (command) => {
+        expect(command).toBeInstanceOf(HeadObjectCommand);
+        return { VersionId: 'rule-version-1' };
+      }),
+    };
+    const result = await createWorkflowCheckpoint(
+      {
+        projectId: 'p1',
+        intentId: 'i1',
+        executionId: 'i1',
+        sourceStageInstanceId: 's1',
+      },
+      {
+        store: {
+          getExecutionRecords: vi.fn(async () => ({
+            meta: {
+              executionId: 'i1',
+              projectId: 'p1',
+              customRules: [{ filename: 'rules.md', s3Key: 'custom-rules/p1/rules.md' }],
+            },
+            stages: [],
+            humanTasks: [],
+            units: [],
+          })),
+          putWorkflowCheckpoint,
+        },
+        openGraph: vi.fn(async () => ({})),
+        snapshotArtifacts: vi.fn(async () => [
+          { artifactId: 'a1', versionId: 'a1:sha256:abc', snapshotHash: 'abc' },
+        ]),
+        s3,
+        bucket: 'artifacts',
+        clock: () => '2026-08-14T10:00:00.000Z',
+      },
+    );
+    expect(result).toMatchObject({ ok: true, artifactCount: 1, customRuleCount: 1 });
+    expect(putWorkflowCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceStageInstanceId: 's1',
+        customRuleRefs: [
+          {
+            filename: 'rules.md',
+            s3Key: 'custom-rules/p1/rules.md',
+            versionId: 'rule-version-1',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('keeps the previous checkpoint when publication fails', async () => {
+    const putWorkflowCheckpoint = vi.fn();
+    const result = await createWorkflowCheckpoint(
+      { projectId: 'p1', intentId: 'i1', executionId: 'i1' },
+      {
+        store: {
+          getExecutionRecords: vi.fn(async () => {
+            throw new Error('DynamoDB unavailable');
+          }),
+          putWorkflowCheckpoint,
+        },
+        openGraph: vi.fn(),
+        s3: { send: vi.fn() },
+        bucket: 'artifacts',
+      },
+    );
+    expect(result).toEqual({
+      ok: false,
+      reason: 'checkpoint_failed',
+      detail: 'DynamoDB unavailable',
+    });
+    expect(putWorkflowCheckpoint).not.toHaveBeenCalled();
+  });
+});

--- a/lambda/agentcore/test/create-workflow-checkpoint.test.js
+++ b/lambda/agentcore/test/create-workflow-checkpoint.test.js
@@ -16,6 +16,7 @@ describe('create-workflow-checkpoint', () => {
         projectId: 'p1',
         intentId: 'i1',
         executionId: 'i1',
+        orchestratorRunId: 'run-1',
         sourceStageInstanceId: 's1',
       },
       {
@@ -45,6 +46,7 @@ describe('create-workflow-checkpoint', () => {
     expect(putWorkflowCheckpoint).toHaveBeenCalledWith(
       expect.objectContaining({
         sourceStageInstanceId: 's1',
+        orchestratorRunId: 'run-1',
         customRuleRefs: [
           {
             filename: 'rules.md',
@@ -57,17 +59,28 @@ describe('create-workflow-checkpoint', () => {
   });
 
   it('keeps the previous checkpoint when publication fails', async () => {
-    const putWorkflowCheckpoint = vi.fn();
+    const putWorkflowCheckpoint = vi.fn(async () => {
+      throw new Error('checkpoint ownership lost');
+    });
     const result = await createWorkflowCheckpoint(
-      { projectId: 'p1', intentId: 'i1', executionId: 'i1' },
+      {
+        projectId: 'p1',
+        intentId: 'i1',
+        executionId: 'i1',
+        orchestratorRunId: 'run-1',
+      },
       {
         store: {
-          getExecutionRecords: vi.fn(async () => {
-            throw new Error('DynamoDB unavailable');
-          }),
+          getExecutionRecords: vi.fn(async () => ({
+            meta: { executionId: 'i1', projectId: 'p1', customRules: [] },
+            stages: [],
+            humanTasks: [],
+            units: [],
+          })),
           putWorkflowCheckpoint,
         },
-        openGraph: vi.fn(),
+        openGraph: vi.fn(async () => ({})),
+        snapshotArtifacts: vi.fn(async () => []),
         s3: { send: vi.fn() },
         bucket: 'artifacts',
       },
@@ -75,8 +88,8 @@ describe('create-workflow-checkpoint', () => {
     expect(result).toEqual({
       ok: false,
       reason: 'checkpoint_failed',
-      detail: 'DynamoDB unavailable',
+      detail: 'checkpoint ownership lost',
     });
-    expect(putWorkflowCheckpoint).not.toHaveBeenCalled();
+    expect(putWorkflowCheckpoint).toHaveBeenCalledOnce();
   });
 });

--- a/lambda/agentcore/test/http-server.test.js
+++ b/lambda/agentcore/test/http-server.test.js
@@ -147,6 +147,28 @@ describe('dispatchInvocation', () => {
     });
   });
 
+  it('routes workflow checkpoint publication', async () => {
+    const r = await dispatchInvocation({
+      payload: { command: 'create-workflow-checkpoint', intentId: 'i1', executionId: 'e1' },
+      handlers: {
+        createWorkflowCheckpoint: async (p) => ({
+          ok: true,
+          checkpointId: 'cp1',
+          executionId: p.executionId,
+        }),
+      },
+    });
+    expect(r).toMatchObject({
+      statusCode: 200,
+      body: {
+        ok: true,
+        checkpointId: 'cp1',
+        executionId: 'e1',
+        command: 'create-workflow-checkpoint',
+      },
+    });
+  });
+
   it('routes discussion-assist-start for Quorum discussion jobs', async () => {
     const r = await dispatchInvocation({
       payload: {

--- a/lambda/agentcore/test/mcp-server.test.js
+++ b/lambda/agentcore/test/mcp-server.test.js
@@ -90,6 +90,10 @@ const stubBridge = () => ({
     this.calls.push(['sendOutput', args]);
     return { seq: 1, kind: args.kind };
   },
+  recordProjectType(args) {
+    this.calls.push(['recordProjectType', args]);
+    return args;
+  },
   collectMetric(args) {
     this.calls.push(['collectMetric', args]);
     return { metricId: 'm1' };
@@ -119,6 +123,12 @@ describe('buildToolHandlers — routing + envelopes', () => {
     expect(parse(env)).toEqual({ id: 'd1' });
     expect(writer.calls[0][0]).toBe('createArtifact');
     expect(writer.calls[0][1]).toMatchObject({ artifactType: 'design', id: 'd1', links: [] });
+  });
+
+  it('routes record_project_type through the process bridge', async () => {
+    const env = await h.record_project_type({ projectType: 'brownfield' });
+    expect(parse(env)).toEqual({ projectType: 'brownfield' });
+    expect(bridge.calls).toContainEqual(['recordProjectType', { projectType: 'brownfield' }]);
   });
 
   it('create_artifact emits a v2.artifact.created note so the UI updates live', async () => {
@@ -319,6 +329,13 @@ describe('role gating', () => {
     const author = handlersForRole(h, 'author');
     expect(Object.keys(author).toSorted()).toEqual([...AUTHOR_TOOLS].toSorted());
   });
+
+  it('workspace detection gets the classification tool in addition to the author surface', () => {
+    const h = buildToolHandlers({ writer: stubWriter(), bridge: stubBridge() });
+    const author = handlersForRole(h, 'author', 'workspace-detection');
+    expect(author.record_project_type).toBeDefined();
+    expect(Object.keys(author)).toHaveLength(AUTHOR_TOOLS.length + 1);
+  });
 });
 
 describe('registerTools', () => {
@@ -357,6 +374,20 @@ describe('registerTools', () => {
     const server = { tool: (name) => registered.push(name) };
     registerTools({ server, handlers: {}, role: 'author', z: fakeZod });
     expect(registered.toSorted()).toEqual([...AUTHOR_TOOLS].toSorted());
+  });
+
+  it('registers project classification for workspace detection', () => {
+    const registered = [];
+    const server = { tool: (name) => registered.push(name) };
+    registerTools({
+      server,
+      handlers: {},
+      role: 'author',
+      stageId: 'workspace-detection',
+      z: fakeZod,
+    });
+    expect(registered).toContain('record_project_type');
+    expect(registered).toHaveLength(AUTHOR_TOOLS.length + 1);
   });
 
   it('traces each call with the result-envelope byte size, and passes the envelope through', async () => {

--- a/lambda/agentcore/test/process-bridge.test.js
+++ b/lambda/agentcore/test/process-bridge.test.js
@@ -88,6 +88,44 @@ describe('sendOutput', () => {
   });
 });
 
+describe('recordProjectType', () => {
+  it('persists and audits the workspace classification', async () => {
+    const store = fakeStore();
+    const sent = [];
+    const bridge = createProcessBridge({
+      store,
+      scope: { ...SCOPE, stageId: 'workspace-detection' },
+      broadcast: (payload) => sent.push(payload),
+    });
+
+    await expect(bridge.recordProjectType({ projectType: 'greenfield' })).resolves.toEqual({
+      projectType: 'greenfield',
+    });
+    expect(store.execPatches).toContainEqual({
+      executionId: 'exec-1',
+      projectType: 'greenfield',
+    });
+    expect(store.events.at(-1)).toMatchObject({
+      type: 'v2.workspace.classified',
+      summary: 'Workspace classified as greenfield',
+    });
+    expect(sent.at(-1)).toMatchObject({
+      action: 'agent.note',
+      noteType: 'v2.workspace.classified',
+    });
+  });
+
+  it('restricts classification recording to workspace detection', async () => {
+    const bridge = createProcessBridge({
+      store: fakeStore(),
+      scope: { ...SCOPE, stageId: 'requirements-analysis' },
+    });
+    await expect(bridge.recordProjectType({ projectType: 'greenfield' })).rejects.toThrow(
+      /workspace-detection/,
+    );
+  });
+});
+
 describe('collectMetric + emitStageNote', () => {
   it('records a metric bag and broadcasts it live', async () => {
     const store = fakeStore();

--- a/lambda/agentcore/test/run-stage.test.js
+++ b/lambda/agentcore/test/run-stage.test.js
@@ -1435,6 +1435,38 @@ describe('runStage — fresh run persists the CLI session + parks on a pending g
     expect(putStage).toMatchObject({ cli: 'claude', cliSessionId: 'forced-uuid' });
   });
 
+  it('uses and records the intent-pinned AI-DLC methodology revision', async () => {
+    const methodologyPins = {
+      AGENT: { 'aidlc-product-agent': { tenantId: 'SYSTEM', version: 2 } },
+    };
+    const loadLibrary = vi.fn(async () => ({ workflow: workflow(), library: library() }));
+    const loadConductor = vi.fn(async () => '# pinned conductor');
+    const deps = baseDeps({
+      spawnFn: okSpawn,
+      ids: () => 'forced-uuid',
+      loadLibrary,
+      loadConductor,
+    });
+    await runStage(
+      {
+        ...baseArgs,
+        aidlcRepoRef: 'a'.repeat(40),
+        methodologyPins,
+      },
+      deps,
+    );
+
+    expect(loadLibrary).toHaveBeenCalledWith({
+      workflowId: 'aidlc-v2',
+      workflowVersion: 1,
+      methodologyPins,
+    });
+    expect(loadConductor).toHaveBeenCalledWith('a'.repeat(40));
+    expect(deps.store.calls.find((call) => call[0] === 'putStage')[1]).toMatchObject({
+      aidlcRepoRef: 'a'.repeat(40),
+    });
+  });
+
   it('parks WAITING_FOR_HUMAN (no SUCCEEDED) when a gate is still pending at exit', async () => {
     const deps = baseDeps({
       spawnFn: okSpawn,

--- a/lambda/agentcore/test/run-stage.test.js
+++ b/lambda/agentcore/test/run-stage.test.js
@@ -1766,7 +1766,10 @@ describe('runStage — resume mode', () => {
         stage: { cli: 'claude', cliSessionId: 'sess-7' },
       }),
     });
-    const res = await runStage({ ...baseArgs, resumeFrom: 'q-1' }, deps);
+    const res = await runStage(
+      { ...baseArgs, resumeFrom: 'q-1', aidlcRepoRef: 'a'.repeat(40) },
+      deps,
+    );
     expect(res).toMatchObject({ ok: true, state: 'SUCCEEDED', cli: 'claude' });
     // Built a --resume invocation targeting the persisted session id.
     expect(cap.get().command).toBe('claude');
@@ -1787,6 +1790,9 @@ describe('runStage — resume mode', () => {
     // which would re-stamp startedAt (the "duration resets on answer" bug).
     expect(deps.store.calls.some((c) => c[0] === 'resumeStageRow')).toBe(true);
     expect(deps.store.calls.some((c) => c[0] === 'putStage')).toBe(false);
+    expect(deps.store.calls.find((c) => c[0] === 'resumeStageRow')[1]).toMatchObject({
+      aidlcRepoRef: 'a'.repeat(40),
+    });
   });
 
   it('a fresh run carries the existing row attempt forward (rewind reset sets attempt+1)', async () => {

--- a/lambda/agentcore/test/run-stage.test.js
+++ b/lambda/agentcore/test/run-stage.test.js
@@ -890,6 +890,20 @@ describe('runStage — failure paths (always records terminal state)', () => {
     expect(res).toMatchObject({ ok: false, reason: 'workflow_not_found' });
   });
 
+  it('fails loudly when the pinned methodology snapshot was replaced', async () => {
+    const deps = baseDeps({
+      loadLibrary: async () => {
+        throw new Error('Pinned methodology snapshot does not match AI-DLC repository ref abc');
+      },
+    });
+    const res = await runStage({ ...baseArgs, aidlcRepoRef: 'abc' }, deps);
+    expect(res).toMatchObject({
+      ok: false,
+      reason: 'methodology_snapshot_unavailable',
+      detail: 'Pinned methodology snapshot does not match AI-DLC repository ref abc',
+    });
+  });
+
   it('fails when the stage is not in scope', async () => {
     const res = await runStage({ ...baseArgs, stageId: 'ghost' }, baseDeps());
     expect(res).toMatchObject({ ok: false, reason: 'stage_not_in_scope' });
@@ -1460,6 +1474,7 @@ describe('runStage — fresh run persists the CLI session + parks on a pending g
       workflowId: 'aidlc-v2',
       workflowVersion: 1,
       methodologyPins,
+      aidlcRepoRef: 'a'.repeat(40),
     });
     expect(loadConductor).toHaveBeenCalledWith('a'.repeat(40));
     expect(deps.store.calls.find((call) => call[0] === 'putStage')[1]).toMatchObject({

--- a/lambda/agentcore/test/stage-materializer.test.js
+++ b/lambda/agentcore/test/stage-materializer.test.js
@@ -121,6 +121,18 @@ describe('buildStagePrompt', () => {
     });
     expect(prompt).not.toContain('# Artifact structure contracts');
   });
+
+  it('requires workspace detection to record its structured classification', () => {
+    const prompt = buildStagePrompt({
+      stage: stage({ stageId: 'workspace-detection', phase: 'initialization' }),
+      stageBody: 'Scan the workspace.',
+    });
+    expect(prompt).toContain('## Workspace classification contract');
+    expect(prompt).toContain('`record_project_type` exactly once');
+    expect(prompt.indexOf('record_project_type')).toBeLessThan(
+      prompt.indexOf('## Stage instructions'),
+    );
+  });
 });
 
 describe('buildStagePrompt — MCP execution annex binding', () => {
@@ -195,6 +207,7 @@ describe('buildMcpConfig', () => {
         executionId: 'e1',
         intentId: 'i1',
         projectId: 'p1',
+        stageId: 'workspace-detection',
         stageInstanceId: 'si1',
         sectionIndex: 2,
         stageAttempt: 3,
@@ -213,6 +226,7 @@ describe('buildMcpConfig', () => {
       V2_EXECUTION_ID: 'e1',
       V2_INTENT_ID: 'i1',
       V2_PROJECT_ID: 'p1',
+      V2_STAGE_ID: 'workspace-detection',
       V2_STAGE_INSTANCE_ID: 'si1',
       V2_SECTION_INDEX: '2',
       V2_STAGE_ATTEMPT: '3',

--- a/lambda/building-blocks/index.js
+++ b/lambda/building-blocks/index.js
@@ -60,6 +60,7 @@ const RESERVED_FIELDS = new Set([
   'version',
   'bodyRef',
   'scriptRef',
+  'sourceRef',
   'createdAt',
   'updatedAt',
 ]);

--- a/lambda/building-blocks/test/building-blocks.test.js
+++ b/lambda/building-blocks/test/building-blocks.test.js
@@ -147,6 +147,21 @@ describe('building-blocks handler', () => {
     expect(tableStore.has('BLOCK#default#AGENT#architect|V#1')).toBe(true);
   });
 
+  it('strips the managed sourceRef from caller input', async () => {
+    const res = parse(
+      await handler(
+        event({
+          method: 'POST',
+          type: 'agent',
+          body: { id: 'pinned', name: 'Pinned', sourceRef: 'attacker-controlled' },
+        }),
+      ),
+    );
+    expect(res.status).toBe(201);
+    const stored = tableStore.get('BLOCK#default#AGENT#pinned|V#1');
+    expect(stored.sourceRef).toBeUndefined();
+  });
+
   it('rejects a duplicate id with 409', async () => {
     const make = () =>
       handler(event({ method: 'POST', type: 'agent', body: { id: 'dup', name: 'Dup' } }));

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -74,6 +74,10 @@ import { pinCustomRuleVersions } from '../shared/custom-rule-versions.js';
 import { canonicalJson, checkpointProjection } from '../shared/workflow-checkpoint.js';
 import { resolveAidlcRepoRef } from '../shared/aidlc-ref.js';
 import { assignNativeRepositoryDirectories, repositoryId } from '../shared/native-repositories.js';
+import {
+  executionPlanFromMethodologyCatalog,
+  loadOrCreateMethodologyCatalog,
+} from '../shared/methodology-catalog.js';
 import { parseLambdaPayload } from '../shared/lambda-payload.js';
 import { mapWithConcurrency } from '../shared/concurrency.js';
 import { credentialProviderForCli } from '../shared/agent-credentials.js';
@@ -1404,6 +1408,71 @@ const findNativeIncompatibleBlocks = async (plan) => {
   return [...new Set(custom)].toSorted();
 };
 
+const hasNonSystemMethodologyPins = (methodologyPins) =>
+  Object.values(methodologyPins ?? {}).some((pins) =>
+    Object.values(pins ?? {}).some((pin) => pin?.tenantId !== SYSTEM_TENANT),
+  );
+
+const methodologyRefsMatch = (planResult, expectedRef) => {
+  const refs = planResult?.methodologySourceRefs ?? [];
+  return refs.length === 1 && refs[0] === expectedRef;
+};
+
+// Prefer the normal DynamoDB workflow snapshot. If a SYSTEM reseed replaced
+// those version keys, reconstruct the same plan from the intent's commit-pinned
+// S3 catalog instead. Customer-edited methodology remains intentionally
+// unsupported by native export and never falls back to the SYSTEM catalog.
+const loadNativeExportPlan = async (meta) => {
+  const options = {
+    workflowId: meta.workflowId,
+    workflowVersion: meta.workflowVersion,
+    scope: meta.scope,
+    ...(Array.isArray(meta.skipStageIds) && meta.skipStageIds.length
+      ? { skipStageIds: meta.skipStageIds }
+      : {}),
+    ...(meta.composedGrid ? { composedGrid: meta.composedGrid } : {}),
+    ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
+  };
+  let currentResult = null;
+  let currentError = null;
+  try {
+    currentResult = await loadExecutionPlan({
+      ddb,
+      tableName: BLOCKS_TABLE(),
+      ...options,
+    });
+  } catch (error) {
+    currentError = error;
+  }
+
+  const canUseCatalog = meta.aidlcRepoRef && !hasNonSystemMethodologyPins(meta.methodologyPins);
+  if (
+    currentResult?.valid &&
+    currentResult.plan &&
+    (!canUseCatalog || methodologyRefsMatch(currentResult, meta.aidlcRepoRef))
+  ) {
+    return currentResult;
+  }
+  if (!canUseCatalog) {
+    if (currentError) throw currentError;
+    return currentResult;
+  }
+
+  const catalog = await loadOrCreateMethodologyCatalog({
+    s3,
+    bucket: ARTIFACTS_BUCKET(),
+    ref: meta.aidlcRepoRef,
+  });
+  return executionPlanFromMethodologyCatalog({
+    catalog,
+    workflowId: meta.workflowId,
+    workflowVersion: meta.workflowVersion,
+    scope: meta.scope,
+    skipStageIds: options.skipStageIds,
+    composedGrid: options.composedGrid,
+  });
+};
+
 // Map a QEDIT# row (Quorum-supported artifact edit session) to the wire shape.
 const mapQuorumEdit = (q) => ({
   editId: q.editId,
@@ -1695,18 +1764,19 @@ export const handler = async (event) => {
       if (!NATIVE_EXPORT_HARNESSES.has(harness)) {
         return response(400, { error: `Unsupported native AI-DLC harness: ${harness}` });
       }
-      const planResult = await loadExecutionPlan({
-        ddb,
-        tableName: BLOCKS_TABLE(),
-        workflowId: meta.workflowId,
-        workflowVersion: meta.workflowVersion,
-        scope: meta.scope,
-        ...(Array.isArray(meta.skipStageIds) && meta.skipStageIds.length
-          ? { skipStageIds: meta.skipStageIds }
-          : {}),
-        ...(meta.composedGrid ? { composedGrid: meta.composedGrid } : {}),
-        ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
-      });
+      const executionRefs = new Set(
+        (records.stages ?? []).map((stage) => stage.aidlcRepoRef).filter(Boolean),
+      );
+      if (
+        executionRefs.size > 1 ||
+        (meta.aidlcRepoRef && [...executionRefs].some((ref) => ref !== meta.aidlcRepoRef))
+      ) {
+        return response(409, {
+          error: 'This workflow was executed with multiple AI-DLC revisions and cannot be exported',
+          code: 'export_mixed_aidlc_refs',
+        });
+      }
+      const planResult = await loadNativeExportPlan(meta);
       if (!planResult.valid || !planResult.plan) {
         return response(409, {
           error: 'The workflow snapshot cannot be resolved for native export',
@@ -1778,19 +1848,6 @@ export const handler = async (event) => {
           };
         };
         const projection = buildProjection(records, artifactRows, customRules);
-        const executionRefs = new Set(
-          (records.stages ?? []).map((stage) => stage.aidlcRepoRef).filter(Boolean),
-        );
-        if (
-          executionRefs.size > 1 ||
-          (meta.aidlcRepoRef && [...executionRefs].some((ref) => ref !== meta.aidlcRepoRef))
-        ) {
-          return response(409, {
-            error:
-              'This workflow was executed with multiple AI-DLC revisions and cannot be exported',
-            code: 'export_mixed_aidlc_refs',
-          });
-        }
         const initialSnapshotToken = checkpoint ? null : exportSnapshotToken(projection);
         const legacyRefWarning = meta.aidlcRepoRef
           ? []

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -3922,6 +3922,7 @@ export const handler = async (event) => {
 
       const fromStageId = sectionStages[0].stageId;
       const durableExecutionName = durableExecutionNameForIntent(intentId);
+      await store.deleteWorkflowCheckpoint(intentId);
       const updated = await store.updateExecution({
         executionId: intentId,
         projectId,
@@ -4257,6 +4258,7 @@ export const handler = async (event) => {
         .catch((err) => console.error('Rewind event append failed:', err.message));
       // Relaunch at the rewind point. Same CAS + rollback discipline as /start.
       const durableExecutionName = durableExecutionNameForIntent(intentId);
+      await store.deleteWorkflowCheckpoint(intentId);
       const updated = await store.updateExecution({
         executionId: intentId,
         projectId,
@@ -4487,6 +4489,11 @@ export const handler = async (event) => {
       });
 
       // Retire only after every affected artifact was durably snapshotted.
+      await store.updateExecution({
+        executionId: intentId,
+        fromStatus: meta.status,
+        orchestratorRunId: `retired-${randomBytes(8).toString('hex')}`,
+      });
       await retireParkedRun(intentId, `recomposed from ${fromStage.stageId}`);
       await stopRuntimeSessions(intentId, meta);
       for (const stageInstanceId of resetIds) {
@@ -4502,6 +4509,7 @@ export const handler = async (event) => {
         .catch((err) => console.error('Recompose event append failed:', err.message));
       const priorStatus = meta.status;
       const durableExecutionName = durableExecutionNameForIntent(intentId);
+      await store.deleteWorkflowCheckpoint(intentId);
       const updated = await store.updateExecution({
         executionId: intentId,
         projectId,

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -72,6 +72,7 @@ import {
 } from '../shared/artifact-versioning.js';
 import { pinCustomRuleVersions } from '../shared/custom-rule-versions.js';
 import { canonicalJson, checkpointProjection } from '../shared/workflow-checkpoint.js';
+import { resolveAidlcRepoRef } from '../shared/aidlc-ref.js';
 import { parseLambdaPayload } from '../shared/lambda-payload.js';
 import { mapWithConcurrency } from '../shared/concurrency.js';
 import { credentialProviderForCli } from '../shared/agent-credentials.js';
@@ -1708,6 +1709,7 @@ export const handler = async (event) => {
           ? { skipStageIds: meta.skipStageIds }
           : {}),
         ...(meta.composedGrid ? { composedGrid: meta.composedGrid } : {}),
+        ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
       });
       if (!planResult.valid || !planResult.plan) {
         return response(409, {
@@ -1780,6 +1782,19 @@ export const handler = async (event) => {
           };
         };
         const projection = buildProjection(records, artifactRows, customRules);
+        const executionRefs = new Set(
+          (records.stages ?? []).map((stage) => stage.aidlcRepoRef).filter(Boolean),
+        );
+        if (
+          executionRefs.size > 1 ||
+          (meta.aidlcRepoRef && [...executionRefs].some((ref) => ref !== meta.aidlcRepoRef))
+        ) {
+          return response(409, {
+            error:
+              'This workflow was executed with multiple AI-DLC revisions and cannot be exported',
+            code: 'export_mixed_aidlc_refs',
+          });
+        }
         const initialSnapshotToken = checkpoint ? null : exportSnapshotToken(projection);
         const legacyRefWarning = meta.aidlcRepoRef
           ? []
@@ -1963,6 +1978,9 @@ export const handler = async (event) => {
             ? { skipStageIds: records.meta.skipStageIds }
             : {}),
           ...(records.meta.composedGrid ? { composedGrid: records.meta.composedGrid } : {}),
+          ...(records.meta.methodologyPins
+            ? { methodologyPins: records.meta.methodologyPins }
+            : {}),
         });
         plan = planResult.valid ? planResult.plan : null;
       } catch {
@@ -2629,6 +2647,7 @@ export const handler = async (event) => {
           scope: meta.scope,
           ...(effectiveSkips?.length ? { skipStageIds: effectiveSkips } : {}),
           ...(effectiveGrid ? { composedGrid: effectiveGrid } : {}),
+          ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
         });
         if (!planCheck.valid) {
           return response(400, {
@@ -3035,6 +3054,7 @@ export const handler = async (event) => {
             workflowId: meta.workflowId,
             workflowVersion: meta.workflowVersion,
             scope: match.scopeId,
+            ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
           });
           if (planCheck.valid) {
             const row = await store.createCompose({
@@ -3321,6 +3341,7 @@ export const handler = async (event) => {
           scope: effScope,
           ...(effSkips?.length ? { skipStageIds: effSkips } : {}),
           ...(effGrid ? { composedGrid: effGrid } : {}),
+          ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
         });
         if (!planCheck.valid) {
           return response(400, {
@@ -3568,6 +3589,7 @@ export const handler = async (event) => {
           ? { skipStageIds: meta.skipStageIds }
           : {}),
         ...(meta.composedGrid ? { composedGrid: meta.composedGrid } : {}),
+        ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
       });
       if (!planResult.valid || !planResult.plan) {
         return response(409, {
@@ -3945,6 +3967,7 @@ export const handler = async (event) => {
         scope: meta.scope,
         ...(rewindSkipIds.length ? { skipStageIds: rewindSkipIds } : {}),
         ...(meta.composedGrid ? { composedGrid: meta.composedGrid } : {}),
+        ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
       });
       if (!planResult.valid || !planResult.plan) {
         return response(409, {
@@ -4327,6 +4350,7 @@ export const handler = async (event) => {
           scope: meta.scope,
           ...(priorSkipIds.length ? { skipStageIds: priorSkipIds } : {}),
           ...(meta.composedGrid ? { composedGrid: meta.composedGrid } : {}),
+          ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
         });
         const currentSectionIds = new Set(
           (currentPlanResult.plan?.stages ?? [])
@@ -4359,6 +4383,7 @@ export const handler = async (event) => {
         scope: newScope,
         composedGrid: newGrid,
         ...(priorSkipIds.length ? { skipStageIds: priorSkipIds } : {}),
+        ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
         strict: true,
       });
       if (!planResult.valid || !planResult.plan) {
@@ -4760,6 +4785,24 @@ export const handler = async (event) => {
         });
       }
       const planWarnings = planCheck.warnings?.length ? planCheck.warnings : null;
+      let aidlcRepoRef = null;
+      if (AIDLC_REPO_REF()) {
+        try {
+          aidlcRepoRef = await resolveAidlcRepoRef(AIDLC_REPO_REF());
+        } catch (error) {
+          return response(503, {
+            error: 'The configured AI-DLC repository ref could not be resolved',
+            detail: error.message,
+          });
+        }
+      }
+      if ((planCheck.methodologySourceRefs ?? []).length > 1) {
+        return response(409, {
+          error: 'The selected workflow combines blocks from multiple AI-DLC revisions',
+          refs: planCheck.methodologySourceRefs,
+        });
+      }
+      aidlcRepoRef = planCheck.methodologySourceRefs?.[0] ?? aidlcRepoRef;
       // Optional per-repo base-branch override (see validateBaseBranches) —
       // validated against THIS intent's repo set before anything is written.
       const { value: baseBranches, error: baseBranchesError } = validateBaseBranches(
@@ -4816,7 +4859,8 @@ export const handler = async (event) => {
         status: 'DRAFT',
         workflowId,
         workflowVersion,
-        aidlcRepoRef: AIDLC_REPO_REF(),
+        aidlcRepoRef,
+        methodologyPins: planCheck.methodologyPins,
         scope,
         startedBy: sub,
         title: data.title || null,

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -1854,10 +1854,11 @@ export const handler = async (event) => {
           : [
               'This legacy intent did not pin a native upstream ref; the current deployment ref was used.',
             ];
+        const upstreamRef = meta.aidlcRepoRef || (await resolveAidlcRepoRef(AIDLC_REPO_REF()));
         const exported = await createNativeExport({
           s3,
           bucket: ARTIFACTS_BUCKET(),
-          upstreamRef: meta.aidlcRepoRef || AIDLC_REPO_REF(),
+          upstreamRef,
           harness,
           warnings: legacyRefWarning,
           projection,

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -66,9 +66,12 @@ import {
   artifactAliases,
   artifactLogicalKeyFromRow,
   legacyVersionId,
+  readCheckpointArtifactVersions,
   readIntentArtifactEntries,
   selectCanonicalArtifact,
 } from '../shared/artifact-versioning.js';
+import { pinCustomRuleVersions } from '../shared/custom-rule-versions.js';
+import { canonicalJson, checkpointProjection } from '../shared/workflow-checkpoint.js';
 import { parseLambdaPayload } from '../shared/lambda-payload.js';
 import { mapWithConcurrency } from '../shared/concurrency.js';
 import { credentialProviderForCli } from '../shared/agent-credentials.js';
@@ -904,6 +907,15 @@ const mapArtifactHead = (row, legacyVersionCount = 0) => ({
   content: row.content ?? null,
 });
 
+const mapCheckpointArtifact = (row) =>
+  mapArtifactHead(
+    {
+      ...row,
+      id: row.artifact_id,
+    },
+    0,
+  );
+
 // The fan-in PR record(s), anchored Intent --HAS_PR--> PullRequest.
 const fetchPullRequests = async (g, intentId) => {
   const rows = await g
@@ -1259,7 +1271,44 @@ const mapIntent = (meta) => ({
 });
 
 const NATIVE_EXPORT_HARNESSES = new Set(['claude', 'codex', 'kiro', 'kiro-ide', 'opencode']);
-const NATIVE_EXPORT_STATUSES = new Set(['DRAFT', 'WAITING', 'FAILED', 'CANCELLED', 'SUCCEEDED']);
+const NATIVE_EXPORT_BLOCKED_STATUSES = new Set(['DRAFT', 'CREATED']);
+const ACTIVE_UNIT_STATES = new Set([
+  'RUNNING',
+  'MERGING',
+  'PR_DRAFT',
+  'RECONCILING',
+  'PR_READY',
+  'ADDRESSING_FEEDBACK',
+]);
+
+// Parallel lane questions do not park execution-level META. Treat RUNNING as
+// safely parked only when every active lane is waiting on a persisted human
+// task and no sibling stage can still mutate the snapshot.
+const isGloballyParkedForExport = (records) => {
+  if (records?.meta?.status !== 'RUNNING') return true;
+  const pendingStageIds = new Set(
+    (records.humanTasks ?? [])
+      .filter((task) => task.status === 'pending' && task.stageInstanceId)
+      .map((task) => task.stageInstanceId),
+  );
+  const parkedStages = (records.stages ?? []).filter(
+    (stage) => stage.state === 'WAITING_FOR_HUMAN' && pendingStageIds.has(stage.stageInstanceId),
+  );
+  if (parkedStages.length === 0) return false;
+  if ((records.stages ?? []).some((stage) => stage.state === 'RUNNING')) return false;
+
+  return (records.units ?? [])
+    .filter((unit) => ACTIVE_UNIT_STATES.has(unit.state))
+    .every(
+      (unit) =>
+        unit.state === 'RUNNING' &&
+        parkedStages.some(
+          (stage) =>
+            stage.unitSlug === unit.slug &&
+            Number(stage.sectionIndex) === Number(unit.sectionIndex),
+        ),
+    );
+};
 
 const repositoryName = (repository) => {
   const value = String(repository ?? '')
@@ -1285,6 +1334,27 @@ const exportRepositories = (meta) =>
       branch: meta.branch || meta.baseBranches?.[repository] || meta.baseBranch || '',
     };
   });
+
+const exportSnapshotToken = (projection) =>
+  createHash('sha256')
+    .update(
+      canonicalJson({
+        ...projection,
+        artifacts: [...(projection.artifacts ?? [])].toSorted((a, b) =>
+          String(a.id).localeCompare(String(b.id)),
+        ),
+        stageRows: [...(projection.stageRows ?? [])].toSorted((a, b) =>
+          String(a.stageInstanceId).localeCompare(String(b.stageInstanceId)),
+        ),
+        humanTasks: [...(projection.humanTasks ?? [])].toSorted((a, b) =>
+          String(a.humanTaskId).localeCompare(String(b.humanTaskId)),
+        ),
+        unitRows: [...(projection.unitRows ?? [])].toSorted((a, b) =>
+          String(a.slug).localeCompare(String(b.slug)),
+        ),
+      }),
+    )
+    .digest('hex');
 
 const findNativeIncompatibleBlocks = async (plan) => {
   const agentIds = new Set();
@@ -1599,20 +1669,30 @@ export const handler = async (event) => {
 
     // POST /projects/{projectId}/intents/{intentId}/export — materialize a
     // native AI-DLC workspace snapshot and return a short-lived S3 download.
-    // RUNNING is intentionally refused: stage and artifact rows can change
-    // while the archive is assembled, producing an internally inconsistent
-    // checkpoint.
+    // RUNNING executions export their latest completed immutable checkpoint.
+    // Parked and terminal executions export current live state with a final
+    // consistency recheck so post-stage human edits are preserved.
     if (intentId && httpMethod === 'POST' && path?.endsWith('/export')) {
-      const records = await store.getExecutionRecords(intentId, { includeOutputs: false });
-      const meta = records.meta;
-      if (!meta || meta.projectId !== projectId) {
+      const liveRecords = await store.getExecutionRecords(intentId, { includeOutputs: false });
+      const liveMeta = liveRecords.meta;
+      if (!liveMeta || liveMeta.projectId !== projectId) {
         return response(404, { error: 'Intent not found' });
       }
-      if (!NATIVE_EXPORT_STATUSES.has(meta.status)) {
+      if (NATIVE_EXPORT_BLOCKED_STATUSES.has(liveMeta.status)) {
         return response(409, {
-          error: 'Wait for the intent to reach a stable state before exporting',
+          error: 'The intent is not in an exportable state',
         });
       }
+      const useLiveSnapshot = isGloballyParkedForExport(liveRecords);
+      const checkpoint = useLiveSnapshot ? null : await store.getWorkflowCheckpoint(intentId);
+      if (!useLiveSnapshot && !checkpoint) {
+        return response(409, {
+          error: 'No completed workflow checkpoint is available yet',
+          code: 'export_checkpoint_unavailable',
+        });
+      }
+      const records = checkpoint ? checkpointProjection(checkpoint) : liveRecords;
+      const meta = records.meta;
       const data = body ? JSON.parse(body) : {};
       const harness = data.harness || meta.agentCli || 'kiro';
       if (!NATIVE_EXPORT_HARNESSES.has(harness)) {
@@ -1642,23 +1722,65 @@ export const handler = async (event) => {
           incompatibleBlocks,
         });
       }
-      const stagesByInstance = new Map(
-        (records.stages ?? []).map((stage) => [stage.stageInstanceId, stage]),
-      );
-      const artifacts = (await fetchArtifacts(g, intentId)).map((artifact) => {
-        const producer = stagesByInstance.get(artifact.createdByStageInstanceId);
-        return {
-          ...artifact,
-          stageId: producer?.stageId ?? null,
-          phase: producer?.phase ?? null,
-          repository: artifact.repository ?? producer?.repository ?? null,
-        };
-      });
       const stages = [
         ...planResult.plan.stages,
         ...(planResult.plan.skippedStages ?? []).map((stage) => ({ ...stage, excluded: true })),
       ];
       try {
+        const artifactRows = checkpoint
+          ? (
+              await readCheckpointArtifactVersions({
+                g,
+                intentId,
+                refs: checkpoint.artifactRefs ?? [],
+              })
+            ).map(mapCheckpointArtifact)
+          : await fetchArtifacts(g, intentId);
+        const customRules = checkpoint
+          ? (checkpoint.customRuleRefs ?? [])
+          : await pinCustomRuleVersions({
+              s3,
+              bucket: ARTIFACTS_BUCKET(),
+              rules: meta.customRules ?? [],
+            });
+        const buildProjection = (projectionRecords, projectionArtifacts, projectionRules) => {
+          const projectionMeta = projectionRecords.meta;
+          const projectionStagesByInstance = new Map(
+            (projectionRecords.stages ?? []).map((stage) => [stage.stageInstanceId, stage]),
+          );
+          return {
+            intent: {
+              intentId,
+              projectId,
+              title: projectionMeta.title,
+              prompt: projectionMeta.prompt,
+              scope: projectionMeta.scope,
+              workflowId: projectionMeta.workflowId,
+              workflowVersion: projectionMeta.workflowVersion,
+              createdAt: projectionMeta.startedAt,
+              branch: projectionMeta.branch,
+              projectType: projectionMeta.projectType,
+              customRules: projectionRules,
+            },
+            stages,
+            stageRows: projectionRecords.stages ?? [],
+            artifacts: projectionArtifacts.map((artifact) => {
+              const producer = projectionStagesByInstance.get(artifact.createdByStageInstanceId);
+              return {
+                ...artifact,
+                stageId: producer?.stageId ?? null,
+                phase: producer?.phase ?? null,
+                repository: artifact.repository ?? producer?.repository ?? null,
+              };
+            }),
+            humanTasks: projectionRecords.humanTasks ?? [],
+            repositories: exportRepositories(projectionMeta),
+            unitPlan: projectionRecords.unitPlan,
+            unitRows: projectionRecords.units ?? [],
+          };
+        };
+        const projection = buildProjection(records, artifactRows, customRules);
+        const initialSnapshotToken = checkpoint ? null : exportSnapshotToken(projection);
         const legacyRefWarning = meta.aidlcRepoRef
           ? []
           : [
@@ -1670,32 +1792,56 @@ export const handler = async (event) => {
           upstreamRef: meta.aidlcRepoRef || AIDLC_REPO_REF(),
           harness,
           warnings: legacyRefWarning,
-          projection: {
-            intent: {
-              intentId,
-              projectId,
-              title: meta.title,
-              prompt: meta.prompt,
-              scope: meta.scope,
-              workflowId: meta.workflowId,
-              workflowVersion: meta.workflowVersion,
-              createdAt: meta.startedAt,
-              branch: meta.branch,
-              projectType: meta.projectType,
-              customRules: meta.customRules ?? [],
-            },
-            stages,
-            stageRows: records.stages ?? [],
-            artifacts,
-            humanTasks: records.humanTasks ?? [],
-            repositories: exportRepositories(meta),
-            unitPlan: records.unitPlan,
-            unitRows: records.units ?? [],
-          },
+          projection,
+          sourceCheckpoint: checkpoint
+            ? {
+                checkpointId: checkpoint.checkpointId,
+                createdAt: checkpoint.createdAt,
+                sourceStageInstanceId: checkpoint.sourceStageInstanceId ?? null,
+              }
+            : null,
+          validateSnapshot: checkpoint
+            ? null
+            : async () => {
+                const latestRecords = await store.getExecutionRecords(intentId, {
+                  includeOutputs: false,
+                });
+                if (
+                  !latestRecords.meta ||
+                  latestRecords.meta.projectId !== projectId ||
+                  NATIVE_EXPORT_BLOCKED_STATUSES.has(latestRecords.meta.status) ||
+                  !isGloballyParkedForExport(latestRecords)
+                ) {
+                  return false;
+                }
+                const latestArtifacts = await fetchArtifacts(g, intentId);
+                const latestRules = await pinCustomRuleVersions({
+                  s3,
+                  bucket: ARTIFACTS_BUCKET(),
+                  rules: latestRecords.meta.customRules ?? [],
+                });
+                return (
+                  exportSnapshotToken(
+                    buildProjection(latestRecords, latestArtifacts, latestRules),
+                  ) === initialSnapshotToken
+                );
+              },
         });
         return response(201, exported);
       } catch (error) {
         console.error('Native workflow export failed:', error);
+        if (error.code === 'export_snapshot_changed') {
+          return response(409, {
+            error: error.message,
+            code: error.code,
+          });
+        }
+        if (error.code === 'export_checkpoint_unavailable') {
+          return response(409, {
+            error: 'The latest completed checkpoint is incomplete or unavailable',
+            code: error.code,
+          });
+        }
         return response(409, {
           error: 'This workflow snapshot is not compatible with native AI-DLC export',
           detail: error.message,

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -1278,6 +1278,12 @@ const mapIntent = (meta) => ({
 
 const NATIVE_EXPORT_HARNESSES = new Set(['claude', 'codex', 'kiro', 'kiro-ide', 'opencode']);
 const NATIVE_EXPORT_BLOCKED_STATUSES = new Set(['DRAFT', 'CREATED']);
+const NATIVE_EXPORT_REF_REQUIRED_STAGE_STATES = new Set([
+  'SUCCEEDED',
+  'FAILED',
+  'RUNNING',
+  'WAITING_FOR_HUMAN',
+]);
 const ACTIVE_UNIT_STATES = new Set([
   'RUNNING',
   'MERGING',
@@ -1764,15 +1770,16 @@ export const handler = async (event) => {
       if (!NATIVE_EXPORT_HARNESSES.has(harness)) {
         return response(400, { error: `Unsupported native AI-DLC harness: ${harness}` });
       }
-      const executionRefs = new Set(
-        (records.stages ?? []).map((stage) => stage.aidlcRepoRef).filter(Boolean),
+      const refRequiredStages = (records.stages ?? []).filter((stage) =>
+        NATIVE_EXPORT_REF_REQUIRED_STAGE_STATES.has(stage.state),
       );
-      if (
-        executionRefs.size > 1 ||
-        (meta.aidlcRepoRef && [...executionRefs].some((ref) => ref !== meta.aidlcRepoRef))
-      ) {
+      const executionRefsMatch = meta.aidlcRepoRef
+        ? refRequiredStages.every((stage) => stage.aidlcRepoRef === meta.aidlcRepoRef)
+        : new Set(refRequiredStages.map((stage) => stage.aidlcRepoRef).filter(Boolean)).size <= 1;
+      if (!executionRefsMatch) {
         return response(409, {
-          error: 'This workflow was executed with multiple AI-DLC revisions and cannot be exported',
+          error:
+            'This workflow has incomplete or mixed AI-DLC revision attribution and cannot be exported',
           code: 'export_mixed_aidlc_refs',
         });
       }

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -87,7 +87,11 @@ import { SYSTEM_TENANT } from '../shared/tenant.js';
 import { fetchKnowledgeGraph } from './knowledge-graph.js';
 import { buildIntentAudit } from './audit.js';
 import { buildArtifactImpact, editBlockReason, activeQuorumEdit } from './impact.js';
-import { createNativeExport } from './native-export.js';
+import {
+  createNativeExport,
+  EXPORT_MISCONFIGURED,
+  EXPORT_SOURCE_UNAVAILABLE,
+} from './native-export.js';
 import {
   ATTACHMENT_UPLOAD_TTL_SECONDS,
   MAX_ATTACHMENTS,
@@ -1903,6 +1907,15 @@ export const handler = async (event) => {
                 );
               },
         });
+        const exporter = getResponder(event);
+        await store
+          .appendEvent({
+            executionId: intentId,
+            type: 'v2.execution.exported',
+            actor: exporter.displayName || exporter.sub,
+            summary: `${exporter.displayName || 'Someone'} exported the ${harness} native workspace (export ${exported.exportId})`,
+          })
+          .catch((err) => console.error('Export event append failed:', err.message));
         return response(201, exported);
       } catch (error) {
         console.error('Native workflow export failed:', error);
@@ -1918,8 +1931,44 @@ export const handler = async (event) => {
             code: error.code,
           });
         }
-        return response(409, {
-          error: 'This workflow snapshot is not compatible with native AI-DLC export',
+        // A configured AI-DLC ref that cannot be resolved is a deployment
+        // misconfiguration; name it rather than blaming the workflow snapshot.
+        if (/AI-DLC repository ref/.test(String(error.message ?? ''))) {
+          return response(409, {
+            error: 'The deployment AI-DLC repository ref is misconfigured',
+            detail: error.message,
+          });
+        }
+        // A transient upstream fetch failure is retryable and not the caller's
+        // fault, so surface it as 502 rather than an un-exportable workflow.
+        if (error.code === EXPORT_SOURCE_UNAVAILABLE) {
+          return response(502, {
+            error: 'The AI-DLC distribution source is temporarily unavailable',
+            code: error.code,
+            detail: error.message,
+          });
+        }
+        // A server-side invariant violation (unset bucket/ref) is a deployment
+        // bug the caller cannot fix -- surface it as 500.
+        if (error.code === EXPORT_MISCONFIGURED) {
+          return response(500, {
+            error: 'The native workspace export is misconfigured',
+            code: error.code,
+            detail: error.message,
+          });
+        }
+        // `native-export:`-prefixed errors are deterministic snapshot/distribution
+        // incompatibilities the caller cannot retry away (409). Anything else is an
+        // unexpected runtime failure (S3, bug) and must surface as 500 so it is not
+        // mistaken for an un-exportable workflow.
+        if (String(error.message ?? '').startsWith('native-export:')) {
+          return response(409, {
+            error: 'This workflow snapshot is not compatible with native AI-DLC export',
+            detail: error.message,
+          });
+        }
+        return response(500, {
+          error: 'The native workspace export failed unexpectedly',
           detail: error.message,
         });
       }

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -74,9 +74,11 @@ import { mapWithConcurrency } from '../shared/concurrency.js';
 import { credentialProviderForCli } from '../shared/agent-credentials.js';
 import { resolveEffectiveCredentialBindingsViaBroker } from '../shared/agent-credential-metadata.js';
 import { issueAgentCredentialGrant } from '../shared/agent-credential-grants.js';
+import { SYSTEM_TENANT } from '../shared/tenant.js';
 import { fetchKnowledgeGraph } from './knowledge-graph.js';
 import { buildIntentAudit } from './audit.js';
 import { buildArtifactImpact, editBlockReason, activeQuorumEdit } from './impact.js';
+import { createNativeExport } from './native-export.js';
 import {
   ATTACHMENT_UPLOAD_TTL_SECONDS,
   MAX_ATTACHMENTS,
@@ -112,6 +114,7 @@ const SOURCE_CONTROL_FN = () => process.env.SOURCE_CONTROL_FUNCTION || '';
 // Compose report uploads land here (presigned PUT) and are read back at
 // compose dispatch. Key shape: compose-reports/<intentId>/<uuid>.json.
 const ARTIFACTS_BUCKET = () => process.env.ARTIFACTS_BUCKET || '';
+const AIDLC_REPO_REF = () => process.env.AIDLC_REPO_REF || '';
 const attachmentCleanup = createAttachmentCleanupService({
   s3,
   store,
@@ -880,6 +883,7 @@ const mapArtifactHead = (row, legacyVersionCount = 0) => ({
   sectionIndex:
     row.section_index === undefined || row.section_index === '' ? null : Number(row.section_index),
   unitSlug: row.unit_slug || null,
+  repository: row.repository || null,
   stageAttempt: Number(row.stage_attempt) || 0,
   generation: Math.max(1, Number(row.generation) || 1),
   versionCount: Math.max(0, Number(row.version_count) || 0) + legacyVersionCount,
@@ -1225,6 +1229,7 @@ const mapIntent = (meta) => ({
   gitProvider: meta.gitProvider ?? null,
   workflowId: meta.workflowId,
   workflowVersion: meta.workflowVersion ?? null,
+  aidlcRepoRef: meta.aidlcRepoRef ?? null,
   scope: meta.scope ?? null,
   currentPhase: meta.currentPhase ?? null,
   currentStage: meta.currentStage ?? null,
@@ -1252,6 +1257,85 @@ const mapIntent = (meta) => ({
   updatedAt: meta.updatedAt ?? null,
   completedAt: meta.completedAt ?? null,
 });
+
+const NATIVE_EXPORT_HARNESSES = new Set(['claude', 'codex', 'kiro', 'kiro-ide', 'opencode']);
+const NATIVE_EXPORT_STATUSES = new Set(['DRAFT', 'WAITING', 'FAILED', 'CANCELLED', 'SUCCEEDED']);
+
+const repositoryName = (repository) => {
+  const value = String(repository ?? '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/, '');
+  return value.split('/').at(-1) || value.split(':').at(-1) || 'repository';
+};
+
+const repositoryCloneUrl = (repository, provider) => {
+  const value = String(repository ?? '');
+  if (/^(?:https?|ssh):\/\//.test(value) || value.startsWith('git@')) return value;
+  if (provider === 'gitlab') return `git@gitlab.com:${value}.git`;
+  if (provider === 'bitbucket') return `git@bitbucket.org:${value}.git`;
+  return `git@github.com:${value}.git`;
+};
+
+const exportRepositories = (meta) =>
+  (meta.repos ?? []).map((repository) => {
+    const provider = meta.repoProviders?.[repository] || meta.gitProvider || 'github';
+    return {
+      name: repositoryName(repository),
+      url: repositoryCloneUrl(repository, provider),
+      branch: meta.branch || meta.baseBranches?.[repository] || meta.baseBranch || '',
+    };
+  });
+
+const findNativeIncompatibleBlocks = async (plan) => {
+  const agentIds = new Set();
+  const sensorIds = new Set();
+  const ruleIds = new Set();
+  for (const stage of plan.stages) {
+    for (const id of [
+      stage.agentRef,
+      ...(stage.supportAgentRefs ?? []),
+      stage.reviewer?.reviewerAgent,
+    ]) {
+      if (id && id !== 'orchestrator') agentIds.add(id);
+    }
+    for (const sensor of stage.sensors ?? []) sensorIds.add(sensor.sensorId);
+    for (const id of [...(stage.rules?.universal ?? []), ...(stage.rules?.phase ?? [])]) {
+      ruleIds.add(id);
+    }
+  }
+  const [agents, sensors, rules, knowledge] = await Promise.all([
+    listMergedBlocks(ddb, BLOCKS_TABLE(), 'AGENT'),
+    listMergedBlocks(ddb, BLOCKS_TABLE(), 'SENSOR'),
+    listMergedBlocks(ddb, BLOCKS_TABLE(), 'RULE'),
+    listMergedBlocks(ddb, BLOCKS_TABLE(), 'KNOWLEDGE'),
+  ]);
+  const custom = [
+    ...plan.stages
+      .filter((stage) => stage.stageTenant && stage.stageTenant !== SYSTEM_TENANT)
+      .map((stage) => `STAGE:${stage.stageId}`),
+    ...agents
+      .filter(
+        (block) => block.tenantId !== SYSTEM_TENANT && agentIds.has(block.id ?? block.blockId),
+      )
+      .map((block) => `AGENT:${block.id ?? block.blockId}`),
+    ...sensors
+      .filter(
+        (block) => block.tenantId !== SYSTEM_TENANT && sensorIds.has(block.id ?? block.blockId),
+      )
+      .map((block) => `SENSOR:${block.id ?? block.blockId}`),
+    ...rules
+      .filter((block) => block.tenantId !== SYSTEM_TENANT && ruleIds.has(block.id ?? block.blockId))
+      .map((block) => `RULE:${block.id ?? block.blockId}`),
+    ...knowledge
+      .filter(
+        (block) =>
+          block.tenantId !== SYSTEM_TENANT &&
+          (block.agentRef === 'shared' || agentIds.has(block.agentRef)),
+      )
+      .map((block) => `KNOWLEDGE:${block.id ?? block.blockId}`),
+  ];
+  return [...new Set(custom)].toSorted();
+};
 
 // Map a QEDIT# row (Quorum-supported artifact edit session) to the wire shape.
 const mapQuorumEdit = (q) => ({
@@ -1511,6 +1595,109 @@ export const handler = async (event) => {
         return response(created.created ? 202 : 200, mapFeedbackBatch(created.item));
       }
       return response(405, { error: 'Method not allowed' });
+    }
+
+    // POST /projects/{projectId}/intents/{intentId}/export — materialize a
+    // native AI-DLC workspace snapshot and return a short-lived S3 download.
+    // RUNNING is intentionally refused: stage and artifact rows can change
+    // while the archive is assembled, producing an internally inconsistent
+    // checkpoint.
+    if (intentId && httpMethod === 'POST' && path?.endsWith('/export')) {
+      const records = await store.getExecutionRecords(intentId, { includeOutputs: false });
+      const meta = records.meta;
+      if (!meta || meta.projectId !== projectId) {
+        return response(404, { error: 'Intent not found' });
+      }
+      if (!NATIVE_EXPORT_STATUSES.has(meta.status)) {
+        return response(409, {
+          error: 'Wait for the intent to reach a stable state before exporting',
+        });
+      }
+      const data = body ? JSON.parse(body) : {};
+      const harness = data.harness || meta.agentCli || 'kiro';
+      if (!NATIVE_EXPORT_HARNESSES.has(harness)) {
+        return response(400, { error: `Unsupported native AI-DLC harness: ${harness}` });
+      }
+      const planResult = await loadExecutionPlan({
+        ddb,
+        tableName: BLOCKS_TABLE(),
+        workflowId: meta.workflowId,
+        workflowVersion: meta.workflowVersion,
+        scope: meta.scope,
+        ...(Array.isArray(meta.skipStageIds) && meta.skipStageIds.length
+          ? { skipStageIds: meta.skipStageIds }
+          : {}),
+        ...(meta.composedGrid ? { composedGrid: meta.composedGrid } : {}),
+      });
+      if (!planResult.valid || !planResult.plan) {
+        return response(409, {
+          error: 'The workflow snapshot cannot be resolved for native export',
+          errors: planResult.errors ?? [],
+        });
+      }
+      const incompatibleBlocks = await findNativeIncompatibleBlocks(planResult.plan);
+      if (incompatibleBlocks.length > 0) {
+        return response(409, {
+          error: 'The workflow uses edited methodology blocks that cannot yet be exported',
+          incompatibleBlocks,
+        });
+      }
+      const stagesByInstance = new Map(
+        (records.stages ?? []).map((stage) => [stage.stageInstanceId, stage]),
+      );
+      const artifacts = (await fetchArtifacts(g, intentId)).map((artifact) => {
+        const producer = stagesByInstance.get(artifact.createdByStageInstanceId);
+        return {
+          ...artifact,
+          stageId: producer?.stageId ?? null,
+          phase: producer?.phase ?? null,
+          repository: artifact.repository ?? producer?.repository ?? null,
+        };
+      });
+      const stages = [
+        ...planResult.plan.stages,
+        ...(planResult.plan.skippedStages ?? []).map((stage) => ({ ...stage, excluded: true })),
+      ];
+      try {
+        const legacyRefWarning = meta.aidlcRepoRef
+          ? []
+          : [
+              'This legacy intent did not pin a native upstream ref; the current deployment ref was used.',
+            ];
+        const exported = await createNativeExport({
+          s3,
+          bucket: ARTIFACTS_BUCKET(),
+          upstreamRef: meta.aidlcRepoRef || AIDLC_REPO_REF(),
+          harness,
+          warnings: legacyRefWarning,
+          projection: {
+            intent: {
+              intentId,
+              projectId,
+              title: meta.title,
+              prompt: meta.prompt,
+              scope: meta.scope,
+              workflowId: meta.workflowId,
+              workflowVersion: meta.workflowVersion,
+              createdAt: meta.startedAt,
+              branch: meta.branch,
+              customRules: meta.customRules ?? [],
+            },
+            stages,
+            stageRows: records.stages ?? [],
+            artifacts,
+            humanTasks: records.humanTasks ?? [],
+            repositories: exportRepositories(meta),
+          },
+        });
+        return response(201, exported);
+      } catch (error) {
+        console.error('Native workflow export failed:', error);
+        return response(409, {
+          error: 'This workflow snapshot is not compatible with native AI-DLC export',
+          detail: error.message,
+        });
+      }
     }
 
     // POST /projects/{projectId}/intents/{intentId}/realtime-token
@@ -4480,6 +4667,7 @@ export const handler = async (event) => {
         status: 'DRAFT',
         workflowId,
         workflowVersion,
+        aidlcRepoRef: AIDLC_REPO_REF(),
         scope,
         startedBy: sub,
         title: data.title || null,

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -1681,6 +1681,7 @@ export const handler = async (event) => {
               workflowVersion: meta.workflowVersion,
               createdAt: meta.startedAt,
               branch: meta.branch,
+              projectType: meta.projectType,
               customRules: meta.customRules ?? [],
             },
             stages,
@@ -1688,6 +1689,8 @@ export const handler = async (event) => {
             artifacts,
             humanTasks: records.humanTasks ?? [],
             repositories: exportRepositories(meta),
+            unitPlan: records.unitPlan,
+            unitRows: records.units ?? [],
           },
         });
         return response(201, exported);

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -73,6 +73,7 @@ import {
 import { pinCustomRuleVersions } from '../shared/custom-rule-versions.js';
 import { canonicalJson, checkpointProjection } from '../shared/workflow-checkpoint.js';
 import { resolveAidlcRepoRef } from '../shared/aidlc-ref.js';
+import { assignNativeRepositoryDirectories, repositoryId } from '../shared/native-repositories.js';
 import { parseLambdaPayload } from '../shared/lambda-payload.js';
 import { mapWithConcurrency } from '../shared/concurrency.js';
 import { credentialProviderForCli } from '../shared/agent-credentials.js';
@@ -1311,13 +1312,6 @@ const isGloballyParkedForExport = (records) => {
     );
 };
 
-const repositoryName = (repository) => {
-  const value = String(repository ?? '')
-    .replace(/\/+$/, '')
-    .replace(/\.git$/, '');
-  return value.split('/').at(-1) || value.split(':').at(-1) || 'repository';
-};
-
 const repositoryCloneUrl = (repository, provider) => {
   const value = String(repository ?? '');
   if (/^(?:https?|ssh):\/\//.test(value) || value.startsWith('git@')) return value;
@@ -1327,14 +1321,16 @@ const repositoryCloneUrl = (repository, provider) => {
 };
 
 const exportRepositories = (meta) =>
-  (meta.repos ?? []).map((repository) => {
-    const provider = meta.repoProviders?.[repository] || meta.gitProvider || 'github';
-    return {
-      name: repositoryName(repository),
-      url: repositoryCloneUrl(repository, provider),
-      branch: meta.branch || meta.baseBranches?.[repository] || meta.baseBranch || '',
-    };
-  });
+  assignNativeRepositoryDirectories(
+    (meta.repos ?? []).map((repository) => {
+      const provider = meta.repoProviders?.[repository] || meta.gitProvider || 'github';
+      return {
+        id: repositoryId(repository),
+        url: repositoryCloneUrl(repository, provider),
+        branch: meta.branch || meta.baseBranches?.[repository] || meta.baseBranch || '',
+      };
+    }),
+  );
 
 const exportSnapshotToken = (projection) =>
   createHash('sha256')

--- a/lambda/intents/native-export.js
+++ b/lambda/intents/native-export.js
@@ -28,6 +28,12 @@ const HARNESS_SESSION_COMMANDS = {
 };
 const harnessRootDir = (harness) =>
   HARNESS_DATA_DIRS[harness]?.replace(/\/tools\/data$/, '') ?? null;
+const workspaceSyncCommand = ({ distributionFiles, harness }) => {
+  const harnessDir = harnessRootDir(harness);
+  if (!harnessDir) return null;
+  const tool = `${harnessDir}/tools/aidlc-workspace-sync.ts`;
+  return distributionFiles.has(tool) ? `bun ${tool}` : null;
+};
 const sha256 = (body) => createHash('sha256').update(body).digest('hex');
 const isCommitSha = (value) => /^[0-9a-f]{40}$/i.test(String(value ?? ''));
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
@@ -622,12 +628,15 @@ const createNativeExport = async ({
     }),
     { expiresIn: DOWNLOAD_TTL_SECONDS },
   );
+  const syncCommand = workspaceSyncCommand({ distributionFiles, harness });
   const setupMode =
     projected.manifest.repositories.length === 0
       ? 'extract-only'
-      : distribution.workspaceLayout === 'spaces'
+      : syncCommand
         ? 'workspace-sync'
-        : 'manual-clone';
+        : distribution.workspaceLayout === 'spaces'
+          ? 'manual-workspace'
+          : 'manual-clone';
   return {
     exportId,
     filename: `${projected.recordDir}-${harness}.zip`,
@@ -651,9 +660,7 @@ const createNativeExport = async ({
             },
           }
         : {}),
-      ...(setupMode === 'workspace-sync' && harnessRootDir(harness)
-        ? { syncCommand: `bun ${harnessRootDir(harness)}/tools/aidlc-workspace-sync.ts` }
-        : {}),
+      ...(syncCommand ? { syncCommand } : {}),
     },
   };
 };
@@ -674,6 +681,7 @@ export {
   resolveRulesDir,
   safeArchivePath,
   shouldShowWorkspaceSetup,
+  workspaceSyncCommand,
 };
 
 export default { createNativeExport };

--- a/lambda/intents/native-export.js
+++ b/lambda/intents/native-export.js
@@ -64,8 +64,14 @@ const bodyToBuffer = async (body) => {
   return Buffer.concat(chunks);
 };
 
-const readObject = async ({ s3, bucket, key }) => {
-  const result = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+const readObject = async ({ s3, bucket, key, versionId = null }) => {
+  const result = await s3.send(
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      ...(versionId ? { VersionId: versionId } : {}),
+    }),
+  );
   return bodyToBuffer(result.Body);
 };
 
@@ -330,7 +336,12 @@ const loadCustomRules = async ({ s3, bucket, harness, distributionFiles, customR
     if (!key.startsWith('custom-rules/') || !/^[A-Za-z0-9._-]+\.md$/i.test(filename)) {
       throw new Error(`native-export: invalid custom rule reference ${key || filename}`);
     }
-    const body = await readObject({ s3, bucket, key });
+    const body = await readObject({
+      s3,
+      bucket,
+      key,
+      versionId: rule.versionId ?? null,
+    });
     if (body.length > 100 * 1024) {
       throw new Error(`native-export: custom rule ${filename} exceeds the 100 KB limit`);
     }
@@ -539,6 +550,8 @@ const createNativeExport = async ({
   now = new Date().toISOString(),
   presign = getSignedUrl,
   warnings = [],
+  sourceCheckpoint = null,
+  validateSnapshot = null,
 }) => {
   if (!bucket) throw new Error('native-export: artifacts bucket is not configured');
   if (!upstreamRef) throw new Error('native-export: upstream ref is not configured');
@@ -594,6 +607,7 @@ const createNativeExport = async ({
 
   const manifest = {
     ...projected.manifest,
+    ...(sourceCheckpoint ? { checkpoint: sourceCheckpoint } : {}),
     native: {
       ...projected.manifest.native,
       scopeRegistered: registeredScope.registered,
@@ -611,6 +625,12 @@ const createNativeExport = async ({
   files.set('export-manifest.json', Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`));
 
   const zip = await buildZip(files);
+  if (validateSnapshot && !(await validateSnapshot())) {
+    throw Object.assign(
+      new Error('The intent changed while the workspace was being exported. Retry the export.'),
+      { code: 'export_snapshot_changed' },
+    );
+  }
   const exportId = randomUUID();
   const key = `workflow-exports/${projection.intent.intentId}/${exportId}.zip`;
   await s3.send(
@@ -651,6 +671,7 @@ const createNativeExport = async ({
     downloadUrl,
     expiresAt: new Date(Date.parse(now) + DOWNLOAD_TTL_SECONDS * 1000).toISOString(),
     warnings: effectiveWarnings,
+    ...(sourceCheckpoint ? { checkpoint: sourceCheckpoint } : {}),
     setup: {
       workspaceLayout: distribution.workspaceLayout,
       mode: setupMode,

--- a/lambda/intents/native-export.js
+++ b/lambda/intents/native-export.js
@@ -40,6 +40,33 @@ const workspaceSyncCommand = ({ distributionFiles, harness }) => {
 const sha256 = (body) => createHash('sha256').update(body).digest('hex');
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 
+// Typed export failures so callers classify by `code`, not message text:
+//  - `export_source_unavailable`: a transient upstream fetch the caller can
+//    retry (network/GitHub failure) -> 502.
+//  - `export_misconfigured`: a server-side invariant violation (unset bucket
+//    or ref) that no caller can fix -> 500.
+//  - untyped `native-export:`-prefixed errors: deterministic snapshot or
+//    distribution incompatibilities the caller cannot retry away -> 409.
+const EXPORT_SOURCE_UNAVAILABLE = 'export_source_unavailable';
+const EXPORT_MISCONFIGURED = 'export_misconfigured';
+const sourceUnavailable = (message, options) =>
+  Object.assign(new Error(message, options), { code: EXPORT_SOURCE_UNAVAILABLE });
+const misconfigured = (message, options) =>
+  Object.assign(new Error(message, options), { code: EXPORT_MISCONFIGURED });
+
+// Classify a repo-fetch failure. Only a network-layer failure or an upstream
+// 5xx/429 is worth retrying (502). Everything repo-fetch raises deterministically
+// -- a 4xx status, no matching distribution files, or a size-limit breach --
+// cannot change on retry and is a 409.
+const isTransientFetchError = (error) => {
+  const message = String(error?.message ?? '');
+  const status = message.match(/returned (\d{3})/)?.[1];
+  if (status) return Number(status) >= 500 || Number(status) === 429;
+  // A raw network rejection (DNS/timeout/reset) never carries the repo-fetch
+  // prefix -- fetch() threw before any response.
+  return !message.startsWith('repo-fetch:');
+};
+
 const safeArchivePath = (value) => {
   const path = String(value ?? '').replaceAll('\\', '/');
   if (
@@ -228,8 +255,17 @@ const fetchAndCacheDistribution = async ({ s3, bucket, upstreamRef, harness }) =
       maxRetainedBytes: MAX_DISTRIBUTION_BYTES,
     });
   } catch (error) {
+    // repo-fetch throws on an absent/oversized distribution AND on a missing
+    // `dist/<harness>/` (it never returns an empty map), so this is the only
+    // place either can surface. Retry only the transient class.
+    if (isTransientFetchError(error)) {
+      throw sourceUnavailable(
+        `native-export: ${harness} distribution is temporarily unavailable for ${upstreamRef}: ${error.message}`,
+        { cause: error },
+      );
+    }
     throw new Error(
-      `native-export: ${harness} distribution is unavailable for ${upstreamRef}: ${error.message}`,
+      `native-export: ${harness} distribution could not be loaded for ${upstreamRef}: ${error.message}`,
       { cause: error },
     );
   }
@@ -238,11 +274,6 @@ const fetchAndCacheDistribution = async ({ s3, bucket, upstreamRef, harness }) =
       .filter(([path]) => path.startsWith(repoPrefix))
       .map(([path, body]) => [safeArchivePath(path.slice(repoPrefix.length)), body]),
   );
-  if (files.size === 0) {
-    throw new Error(
-      `native-export: ${harness} distribution is unavailable for ${upstreamRef}: dist/${harness}/ is missing`,
-    );
-  }
   const workspaceLayout = detectWorkspaceLayout({ files, harness });
   const archive = await buildDistributionArchive(files);
   const manifest = {
@@ -315,7 +346,7 @@ const detectConstructionCapabilities = ({ distributionFiles, harness }) => {
 };
 
 const shouldShowWorkspaceSetup = (stages = []) => {
-  const activeIndex = stages.findIndex((stage) => stage.marker === '-');
+  const activeIndex = stages.findIndex((stage) => ['-', '?', 'R'].includes(stage.marker));
   if (activeIndex < 0) {
     return stages.some((stage) => stage.phase === 'construction' && stage.marker !== 'S');
   }
@@ -555,8 +586,8 @@ const createNativeExport = async ({
   sourceCheckpoint = null,
   validateSnapshot = null,
 }) => {
-  if (!bucket) throw new Error('native-export: artifacts bucket is not configured');
-  if (!upstreamRef) throw new Error('native-export: upstream ref is not configured');
+  if (!bucket) throw misconfigured('native-export: artifacts bucket is not configured');
+  if (!upstreamRef) throw misconfigured('native-export: upstream ref is not configured');
 
   const distribution = await loadDistribution({
     s3,
@@ -595,7 +626,7 @@ const createNativeExport = async ({
     now,
   });
   const nextUnit = projected.manifest.construction?.nextUnit ?? null;
-  const effectiveWarnings = [...warnings];
+  const effectiveWarnings = [...new Set([...warnings, ...(projected.warnings ?? [])])];
   if (nextUnit && !constructionCapabilities.perUnitIteration) {
     effectiveWarnings.push(
       `This pinned AI-DLC runtime predates deterministic per-unit Construction iteration. ` +
@@ -698,6 +729,8 @@ const createNativeExport = async ({
 
 export {
   DOWNLOAD_TTL_SECONDS,
+  EXPORT_MISCONFIGURED,
+  EXPORT_SOURCE_UNAVAILABLE,
   MAX_EXPORT_BYTES,
   bodyToBuffer,
   alignProjectionToDistribution,

--- a/lambda/intents/native-export.js
+++ b/lambda/intents/native-export.js
@@ -1,0 +1,629 @@
+import { createHash, randomUUID } from 'node:crypto';
+import archiver from 'archiver';
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import yaml from 'js-yaml';
+import {
+  buildDistributionArchive,
+  extractDistributionArchive,
+} from '../shared/distribution-archive.js';
+import { projectNativeWorkspace } from '../shared/native-workspace-projector.js';
+import { fetchRepoFiles } from '../shared/repo-fetch.js';
+
+const MAX_EXPORT_BYTES = 100 * 1024 * 1024;
+const DOWNLOAD_TTL_SECONDS = 15 * 60;
+const HARNESS_DATA_DIRS = {
+  claude: '.claude/tools/data',
+  codex: '.codex/tools/data',
+  kiro: '.kiro/tools/data',
+  'kiro-ide': '.kiro/tools/data',
+  opencode: '.aidlc/tools/data',
+};
+const HARNESS_SESSION_COMMANDS = {
+  claude: { launchCommand: 'claude', continueCommand: '/aidlc' },
+  codex: { launchCommand: 'codex', continueCommand: '$aidlc' },
+  kiro: { launchCommand: 'kiro-cli chat', continueCommand: '/aidlc' },
+  'kiro-ide': { launchCommand: null, continueCommand: '/aidlc' },
+  opencode: { launchCommand: 'opencode', continueCommand: '/aidlc' },
+};
+const harnessRootDir = (harness) =>
+  HARNESS_DATA_DIRS[harness]?.replace(/\/tools\/data$/, '') ?? null;
+const sha256 = (body) => createHash('sha256').update(body).digest('hex');
+const isCommitSha = (value) => /^[0-9a-f]{40}$/i.test(String(value ?? ''));
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+const safeArchivePath = (value) => {
+  const path = String(value ?? '').replaceAll('\\', '/');
+  if (
+    !path ||
+    path.startsWith('/') ||
+    path.split('/').some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    throw new Error(`native-export: unsafe distribution path ${value}`);
+  }
+  return path;
+};
+
+const bodyToBuffer = async (body) => {
+  if (!body) return Buffer.alloc(0);
+  if (Buffer.isBuffer(body)) return body;
+  if (body instanceof Uint8Array) return Buffer.from(body);
+  if (typeof body.transformToByteArray === 'function') {
+    return Buffer.from(await body.transformToByteArray());
+  }
+  const chunks = [];
+  for await (const chunk of body) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+};
+
+const readObject = async ({ s3, bucket, key }) => {
+  const result = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  return bodyToBuffer(result.Body);
+};
+
+const isNotFound = (error) =>
+  error?.name === 'NoSuchKey' ||
+  error?.name === 'NotFound' ||
+  error?.$metadata?.httpStatusCode === 404;
+
+const readObjectIfPresent = async (options) => {
+  try {
+    return await readObject(options);
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    throw error;
+  }
+};
+
+const distributionPrefix = (upstreamRef) => `aidlc-distributions/${upstreamRef}`;
+const distributionArchiveKey = (upstreamRef, harness) =>
+  `${distributionPrefix(upstreamRef)}/${harness}.tar.gz`;
+const distributionManifestKey = (upstreamRef, harness) =>
+  `${distributionPrefix(upstreamRef)}/${harness}.manifest.json`;
+
+const distributionFileManifest = (files) =>
+  [...files]
+    .map(([path, body]) => ({
+      path: safeArchivePath(path),
+      bytes: body.length,
+      sha256: sha256(body),
+    }))
+    .toSorted((a, b) => a.path.localeCompare(b.path));
+
+const detectWorkspaceLayout = ({ files, harness }) => {
+  if ([...files.keys()].some((path) => path.startsWith('aidlc/'))) return 'spaces';
+
+  const dataDir = HARNESS_DATA_DIRS[harness];
+  const graphBody = dataDir ? files.get(`${dataDir}/stage-graph.json`) : null;
+  if (!graphBody) {
+    throw new Error(`native-export: ${harness} distribution has no stage graph`);
+  }
+  const graph = JSON.parse(graphBody.toString('utf8'));
+  const scaffold = Array.isArray(graph)
+    ? graph.find(
+        (stage) => stage?.slug === 'workspace-scaffold' || stage?.name === 'Workspace Scaffold',
+      )
+    : null;
+  if (String(scaffold?.outputs ?? '').includes('aidlc-docs/')) return 'flat';
+  throw new Error(
+    `native-export: ${harness} distribution does not declare a supported workspace layout`,
+  );
+};
+
+const validateDistribution = async ({ archive, manifest, upstreamRef, harness }) => {
+  if (
+    manifest?.ref !== upstreamRef ||
+    manifest?.harness !== harness ||
+    !Array.isArray(manifest.files) ||
+    !manifest.archiveSha256
+  ) {
+    throw new Error(`native-export: invalid ${harness} distribution manifest`);
+  }
+  if (
+    archive.length !== Number(manifest.archiveBytes) ||
+    sha256(archive) !== manifest.archiveSha256
+  ) {
+    throw new Error(`native-export: ${harness} distribution archive checksum mismatch`);
+  }
+  const files = await extractDistributionArchive(archive);
+  if (files.size !== manifest.files.length) {
+    throw new Error(`native-export: ${harness} distribution file count mismatch`);
+  }
+  for (const entry of manifest.files) {
+    const path = safeArchivePath(entry.path);
+    const body = files.get(path);
+    if (
+      !body ||
+      body.length !== Number(entry.bytes) ||
+      !entry.sha256 ||
+      sha256(body) !== entry.sha256
+    ) {
+      throw new Error(`native-export: distribution checksum mismatch for ${path}`);
+    }
+  }
+  const workspaceLayout = detectWorkspaceLayout({ files, harness });
+  if (manifest.workspaceLayout && manifest.workspaceLayout !== workspaceLayout) {
+    throw new Error(`native-export: ${harness} distribution workspace layout mismatch`);
+  }
+  return { files, workspaceLayout };
+};
+
+const loadCurrentCacheEntry = async ({ s3, bucket, upstreamRef, harness }) => {
+  const manifestBody = await readObjectIfPresent({
+    s3,
+    bucket,
+    key: distributionManifestKey(upstreamRef, harness),
+  });
+  if (!manifestBody) return null;
+  const archive = await readObject({
+    s3,
+    bucket,
+    key: distributionArchiveKey(upstreamRef, harness),
+  });
+  return validateDistribution({
+    archive,
+    manifest: JSON.parse(manifestBody.toString('utf8')),
+    upstreamRef,
+    harness,
+  });
+};
+
+// Compatibility with archives warmed by the initial seed-time implementation.
+const loadLegacyCacheEntry = async ({ s3, bucket, upstreamRef, harness }) => {
+  const prefix = `aidlc-distributions/${upstreamRef}`;
+  const manifestBody = await readObjectIfPresent({
+    s3,
+    bucket,
+    key: `${prefix}/manifest.json`,
+  });
+  if (!manifestBody) return null;
+  const manifest = JSON.parse(manifestBody.toString('utf8'));
+  const distribution = manifest?.harnesses?.[harness];
+  if (manifest?.ref !== upstreamRef) {
+    throw new Error(`native-export: invalid distribution manifest for ${upstreamRef}`);
+  }
+  if (!distribution?.available) return null;
+  if (!Array.isArray(distribution.files) || !distribution.archive || !distribution.archiveSha256) {
+    throw new Error(`native-export: invalid ${harness} distribution manifest`);
+  }
+  const archivePath = safeArchivePath(distribution.archive);
+  const archive = await readObject({ s3, bucket, key: `${prefix}/${archivePath}` });
+  return validateDistribution({
+    archive,
+    manifest: {
+      ...distribution,
+      ref: upstreamRef,
+      harness,
+    },
+    upstreamRef,
+    harness,
+  });
+};
+
+const fetchAndCacheDistribution = async ({ s3, bucket, upstreamRef, harness }) => {
+  const repoPrefix = `dist/${harness}/`;
+  let fetched;
+  try {
+    fetched = await fetchRepoFiles(upstreamRef, { prefixes: [repoPrefix] });
+  } catch (error) {
+    throw new Error(
+      `native-export: ${harness} distribution is unavailable for ${upstreamRef}: ${error.message}`,
+      { cause: error },
+    );
+  }
+  const files = new Map(
+    [...fetched]
+      .filter(([path]) => path.startsWith(repoPrefix))
+      .map(([path, body]) => [safeArchivePath(path.slice(repoPrefix.length)), body]),
+  );
+  if (files.size === 0) {
+    throw new Error(
+      `native-export: ${harness} distribution is unavailable for ${upstreamRef}: dist/${harness}/ is missing`,
+    );
+  }
+  const workspaceLayout = detectWorkspaceLayout({ files, harness });
+  const archive = await buildDistributionArchive(files);
+  const manifest = {
+    schemaVersion: 1,
+    ref: upstreamRef,
+    harness,
+    workspaceLayout,
+    archive: `${harness}.tar.gz`,
+    archiveBytes: archive.length,
+    archiveSha256: sha256(archive),
+    files: distributionFileManifest(files),
+  };
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: distributionArchiveKey(upstreamRef, harness),
+      Body: archive,
+      ContentType: 'application/gzip',
+    }),
+  );
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: distributionManifestKey(upstreamRef, harness),
+      Body: `${JSON.stringify(manifest, null, 2)}\n`,
+      ContentType: 'application/json',
+    }),
+  );
+  return { files, workspaceLayout };
+};
+
+const loadDistribution = async ({ s3, bucket, upstreamRef, harness }) => {
+  if (!isCommitSha(upstreamRef)) {
+    throw new Error('native-export: upstream ref must be a full commit SHA');
+  }
+  if (!HARNESS_DATA_DIRS[harness]) {
+    throw new Error(`native-export: unsupported harness ${harness}`);
+  }
+  const cached = await loadCurrentCacheEntry({ s3, bucket, upstreamRef, harness });
+  if (cached) return cached;
+  const legacy = await loadLegacyCacheEntry({ s3, bucket, upstreamRef, harness });
+  if (legacy) return legacy;
+  return fetchAndCacheDistribution({ s3, bucket, upstreamRef, harness });
+};
+
+const loadHarnessMetadata = ({ distributionFiles, harness }) => {
+  const dataDir = HARNESS_DATA_DIRS[harness];
+  const body = dataDir ? distributionFiles.get(`${dataDir}/harness.json`) : null;
+  if (!body) throw new Error(`native-export: ${harness} distribution has no harness metadata`);
+  const metadata = JSON.parse(body.toString('utf8'));
+  return {
+    ...metadata,
+    harnessDir: safeArchivePath(metadata.harnessDir),
+    rulesSubdir: safeArchivePath(metadata.rulesSubdir),
+  };
+};
+
+const resolveRulesDir = ({ distributionFiles, harness }) => {
+  const { harnessDir, rulesSubdir } = loadHarnessMetadata({ distributionFiles, harness });
+  return `${harnessDir}/${rulesSubdir}`;
+};
+
+const loadCustomRules = async ({ s3, bucket, harness, distributionFiles, customRules = [] }) => {
+  const files = new Map();
+  if (customRules.length === 0) return files;
+  const rulesDir = resolveRulesDir({ distributionFiles, harness });
+  for (const rule of customRules) {
+    const key = String(rule?.s3Key ?? '');
+    const filename = String(rule?.filename ?? key.split('/').at(-1) ?? '');
+    if (!key.startsWith('custom-rules/') || !/^[A-Za-z0-9._-]+\.md$/i.test(filename)) {
+      throw new Error(`native-export: invalid custom rule reference ${key || filename}`);
+    }
+    const body = await readObject({ s3, bucket, key });
+    if (body.length > 100 * 1024) {
+      throw new Error(`native-export: custom rule ${filename} exceeds the 100 KB limit`);
+    }
+    files.set(`${rulesDir}/custom--${filename}`, body);
+  }
+  return files;
+};
+
+const assertNativeScopeName = (value) => {
+  const scope = String(value ?? '');
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(scope) || scope === '.' || scope === '..') {
+    throw new Error(`native-export: scope "${scope}" is not a valid native scope identifier`);
+  }
+  return scope;
+};
+
+const parseMarkdownFrontmatter = (body, path) => {
+  const source = body.toString('utf8');
+  const match = source.match(FRONTMATTER_RE);
+  if (!match) throw new Error(`native-export: stage file has no frontmatter: ${path}`);
+  const data = yaml.load(match[1]);
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error(`native-export: stage file has invalid frontmatter: ${path}`);
+  }
+  return { data, frontmatter: match[1], markdown: match[2] ?? '' };
+};
+
+const renderStageScopes = ({ frontmatter, markdown }, scopes) => {
+  const lines = frontmatter.split(/\r?\n/);
+  const start = lines.findIndex((line) => /^scopes\s*:/.test(line));
+  if (start < 0) {
+    lines.push('scopes:', ...scopes.map((scope) => `  - ${scope}`));
+    return `---\n${lines.join('\n')}\n---\n${markdown}`;
+  }
+  let end = start + 1;
+  while (end < lines.length && !/^[A-Za-z_][A-Za-z0-9_-]*\s*:/.test(lines[end])) end += 1;
+  lines.splice(start, end - start, 'scopes:', ...scopes.map((scope) => `  - ${scope}`));
+  return `---\n${lines.join('\n')}\n---\n${markdown}`;
+};
+
+const renderScopeDefinition = (scope) => `---
+name: ${scope}
+depth: Standard
+keywords: []
+description: Exported Collaborative AI-DLC workflow composition
+---
+
+# ${scope} scope
+
+This scope was materialized from the workflow composition captured by the export.
+Its stage membership is defined by the installed stage frontmatter and compiled
+scope grid.
+`;
+
+const registerNativeScope = ({ distributionFiles, harness, stages, scope }) => {
+  const nativeScope = assertNativeScopeName(scope);
+  const dataDir = HARNESS_DATA_DIRS[harness];
+  const graphPath = `${dataDir}/stage-graph.json`;
+  const gridPath = `${dataDir}/scope-grid.json`;
+  const graphBody = distributionFiles.get(graphPath);
+  const gridBody = distributionFiles.get(gridPath);
+  if (!graphBody) throw new Error(`native-export: ${harness} distribution has no stage graph`);
+  if (!gridBody) throw new Error(`native-export: ${harness} distribution has no scope grid`);
+
+  const graph = JSON.parse(graphBody.toString('utf8'));
+  const grid = JSON.parse(gridBody.toString('utf8'));
+  if (!Array.isArray(graph) || !grid || typeof grid !== 'object' || Array.isArray(grid)) {
+    throw new Error(`native-export: ${harness} distribution has invalid scope data`);
+  }
+
+  const desiredByStage = new Map(stages.map((stage) => [stage.stageId, !stage.excluded]));
+  const desiredGrid = {};
+  for (const stage of graph) {
+    if (!desiredByStage.has(stage.slug)) {
+      throw new Error(`native-export: projected plan is missing native stage ${stage.slug}`);
+    }
+    desiredGrid[stage.slug] = desiredByStage.get(stage.slug) ? 'EXECUTE' : 'SKIP';
+  }
+
+  const { harnessDir } = loadHarnessMetadata({ distributionFiles, harness });
+  const scopePath = `${harnessDir}/scopes/aidlc-${nativeScope}.md`;
+  const existingGrid = grid[nativeScope]?.stages;
+  const graphMatches = graph.every(
+    (stage) =>
+      (Array.isArray(stage.scopes) && stage.scopes.includes(nativeScope)) ===
+      desiredByStage.get(stage.slug),
+  );
+  const gridMatches =
+    existingGrid &&
+    graph.every((stage) => existingGrid[stage.slug] === desiredGrid[stage.slug]) &&
+    Object.keys(existingGrid).length === graph.length;
+  if (distributionFiles.has(scopePath) && graphMatches && gridMatches) {
+    return { files: distributionFiles, registered: false, scope: nativeScope };
+  }
+
+  const files = new Map(distributionFiles);
+  const updatedGraph = graph.map((stage) => {
+    const execute = desiredByStage.get(stage.slug);
+    const currentScopes = Array.isArray(stage.scopes) ? stage.scopes : [];
+    const scopes = execute
+      ? [...new Set([...currentScopes, nativeScope])]
+      : currentScopes.filter((name) => name !== nativeScope);
+    if (
+      scopes.length !== currentScopes.length ||
+      scopes.some((name, index) => name !== currentScopes[index])
+    ) {
+      const phase = safeArchivePath(stage.phase);
+      const slug = safeArchivePath(stage.slug);
+      const stagePath = `${harnessDir}/aidlc-common/stages/${phase}/${slug}.md`;
+      const stageBody = files.get(stagePath);
+      if (!stageBody) throw new Error(`native-export: native stage file is missing: ${stagePath}`);
+      const parsed = parseMarkdownFrontmatter(stageBody, stagePath);
+      files.set(stagePath, Buffer.from(renderStageScopes(parsed, scopes)));
+    }
+    return { ...stage, scopes };
+  });
+
+  if (!files.has(scopePath)) {
+    files.set(scopePath, Buffer.from(renderScopeDefinition(nativeScope)));
+  }
+  grid[nativeScope] = { stages: desiredGrid };
+  const sortedGrid = Object.fromEntries(
+    Object.entries(grid).toSorted(([left], [right]) => left.localeCompare(right)),
+  );
+  files.set(graphPath, Buffer.from(`${JSON.stringify(updatedGraph, null, 2)}\n`));
+  files.set(gridPath, Buffer.from(`${JSON.stringify(sortedGrid, null, 2)}\n`));
+  return { files, registered: true, scope: nativeScope };
+};
+
+const alignProjectionToDistribution = ({ projection, distributionFiles, harness }) => {
+  const dataDir = HARNESS_DATA_DIRS[harness];
+  const graphBody = distributionFiles.get(`${dataDir}/stage-graph.json`);
+  if (!graphBody) throw new Error(`native-export: ${harness} distribution has no stage graph`);
+  const graph = JSON.parse(graphBody.toString('utf8'));
+  if (!Array.isArray(graph) || graph.length === 0) {
+    throw new Error(`native-export: ${harness} distribution stage graph is invalid`);
+  }
+  const requested = new Map(projection.stages.map((stage) => [stage.stageId, stage]));
+  const nativeIds = new Set(graph.map((stage) => stage.slug));
+  const unknown = [...requested.keys()].filter((stageId) => !nativeIds.has(stageId));
+  if (unknown.length > 0) {
+    throw new Error(
+      `native-export: stages are not present in the native harness: ${unknown.join(', ')}`,
+    );
+  }
+  const requestedOrder = projection.stages
+    .filter((stage) => !stage.excluded)
+    .map((stage) => stage.stageId);
+  const nativeOrder = graph
+    .map((stage) => stage.slug)
+    .filter((stageId) => requested.has(stageId) && !requested.get(stageId).excluded);
+  if (requestedOrder.join('\0') !== nativeOrder.join('\0')) {
+    throw new Error('native-export: workflow stage order differs from the native harness');
+  }
+  const stages = graph.map((nativeStage) => {
+    const cloudStage = requested.get(nativeStage.slug);
+    return {
+      stageId: nativeStage.slug,
+      phase: nativeStage.phase,
+      number: nativeStage.number,
+      leadAgent: cloudStage?.agentRef ?? nativeStage.lead_agent,
+      produces:
+        cloudStage?.outputArtifacts?.map((artifact) => artifact.artifact) ??
+        nativeStage.produces ??
+        [],
+      ...cloudStage,
+      excluded: cloudStage?.excluded ?? !cloudStage,
+    };
+  });
+  const nativeScope = assertNativeScopeName(projection.intent?.scope);
+  return { ...projection, stages, nativeScope };
+};
+
+const buildZip = async (files) => {
+  const archive = archiver('zip', { zlib: { level: 9 } });
+  const chunks = [];
+  let bytes = 0;
+  const completed = new Promise((resolve, reject) => {
+    archive.on('data', (chunk) => {
+      bytes += chunk.length;
+      if (bytes > MAX_EXPORT_BYTES) {
+        archive.abort();
+        reject(new Error('native-export: archive exceeds the 100 MB limit'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    archive.on('warning', reject);
+    archive.on('error', reject);
+    archive.on('end', () => resolve(Buffer.concat(chunks)));
+  });
+  for (const [path, body] of files) {
+    archive.append(body, { name: safeArchivePath(path) });
+  }
+  await archive.finalize();
+  return completed;
+};
+
+const createNativeExport = async ({
+  s3,
+  bucket,
+  upstreamRef,
+  harness,
+  projection,
+  now = new Date().toISOString(),
+  presign = getSignedUrl,
+  warnings = [],
+}) => {
+  if (!bucket) throw new Error('native-export: artifacts bucket is not configured');
+  if (!upstreamRef) throw new Error('native-export: upstream ref is not configured');
+
+  const distribution = await loadDistribution({
+    s3,
+    bucket,
+    upstreamRef,
+    harness,
+  });
+  const alignedProjection = alignProjectionToDistribution({
+    projection,
+    distributionFiles: distribution.files,
+    harness,
+  });
+  const registeredScope = registerNativeScope({
+    distributionFiles: distribution.files,
+    harness,
+    stages: alignedProjection.stages,
+    scope: alignedProjection.nativeScope,
+  });
+  const distributionFiles = registeredScope.files;
+  const customRuleFiles = await loadCustomRules({
+    s3,
+    bucket,
+    harness,
+    distributionFiles,
+    customRules: projection.intent.customRules,
+  });
+  const projected = projectNativeWorkspace({
+    ...alignedProjection,
+    upstreamRef,
+    harness,
+    workspaceLayout: distribution.workspaceLayout,
+    now,
+  });
+  const files = new Map(distributionFiles);
+  for (const [path, body] of customRuleFiles) files.set(path, body);
+  for (const [path, body] of projected.files) files.set(path, Buffer.from(body));
+
+  const manifest = {
+    ...projected.manifest,
+    native: {
+      ...projected.manifest.native,
+      scopeRegistered: registeredScope.registered,
+    },
+    warnings,
+    files: [...files]
+      .filter(([path]) => path !== 'export-manifest.json')
+      .map(([path, body]) => ({
+        path,
+        bytes: body.length,
+        sha256: sha256(body),
+      }))
+      .toSorted((a, b) => a.path.localeCompare(b.path)),
+  };
+  files.set('export-manifest.json', Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`));
+
+  const zip = await buildZip(files);
+  const exportId = randomUUID();
+  const key = `workflow-exports/${projection.intent.intentId}/${exportId}.zip`;
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: zip,
+      ContentType: 'application/zip',
+      ContentDisposition: `attachment; filename="${projected.recordDir}-${harness}.zip"`,
+      Metadata: {
+        intentId: projection.intent.intentId,
+        upstreamRef,
+        harness,
+      },
+    }),
+  );
+  const downloadUrl = await presign(
+    s3,
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      ResponseContentDisposition: `attachment; filename="${projected.recordDir}-${harness}.zip"`,
+    }),
+    { expiresIn: DOWNLOAD_TTL_SECONDS },
+  );
+  const setupMode =
+    projected.manifest.repositories.length === 0
+      ? 'extract-only'
+      : distribution.workspaceLayout === 'spaces'
+        ? 'workspace-sync'
+        : 'manual-clone';
+  return {
+    exportId,
+    filename: `${projected.recordDir}-${harness}.zip`,
+    downloadUrl,
+    expiresAt: new Date(Date.parse(now) + DOWNLOAD_TTL_SECONDS * 1000).toISOString(),
+    warnings,
+    setup: {
+      workspaceLayout: distribution.workspaceLayout,
+      mode: setupMode,
+      harnessDir: harnessRootDir(harness),
+      ...HARNESS_SESSION_COMMANDS[harness],
+      repositories: projected.manifest.repositories,
+      ...(setupMode === 'workspace-sync' && harnessRootDir(harness)
+        ? { syncCommand: `bun ${harnessRootDir(harness)}/tools/aidlc-workspace-sync.ts` }
+        : {}),
+    },
+  };
+};
+
+export {
+  DOWNLOAD_TTL_SECONDS,
+  MAX_EXPORT_BYTES,
+  bodyToBuffer,
+  alignProjectionToDistribution,
+  buildZip,
+  createNativeExport,
+  detectWorkspaceLayout,
+  fetchAndCacheDistribution,
+  loadDistribution,
+  loadCustomRules,
+  registerNativeScope,
+  resolveRulesDir,
+  safeArchivePath,
+};
+
+export default { createNativeExport };

--- a/lambda/intents/native-export.js
+++ b/lambda/intents/native-export.js
@@ -11,6 +11,7 @@ import {
 } from '../shared/distribution-archive.js';
 import { projectNativeWorkspace } from '../shared/native-workspace-projector.js';
 import { fetchRepoFiles } from '../shared/repo-fetch.js';
+import { isCommitSha } from '../shared/aidlc-ref.js';
 
 const MAX_EXPORT_BYTES = 100 * 1024 * 1024;
 const DOWNLOAD_TTL_SECONDS = 15 * 60;
@@ -37,7 +38,6 @@ const workspaceSyncCommand = ({ distributionFiles, harness }) => {
   return distributionFiles.has(tool) ? `bun ${tool}` : null;
 };
 const sha256 = (body) => createHash('sha256').update(body).digest('hex');
-const isCommitSha = (value) => /^[0-9a-f]{40}$/i.test(String(value ?? ''));
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
 
 const safeArchivePath = (value) => {

--- a/lambda/intents/native-export.js
+++ b/lambda/intents/native-export.js
@@ -75,16 +75,18 @@ const readObject = async ({ s3, bucket, key, versionId = null }) => {
   return bodyToBuffer(result.Body);
 };
 
-const isNotFound = (error) =>
+const isCacheMiss = (error) =>
   error?.name === 'NoSuchKey' ||
   error?.name === 'NotFound' ||
-  error?.$metadata?.httpStatusCode === 404;
+  [403, 404].includes(error?.$metadata?.httpStatusCode);
 
 const readObjectIfPresent = async (options) => {
   try {
     return await readObject(options);
   } catch (error) {
-    if (isNotFound(error)) return null;
+    // S3 may mask a missing object as 403 when ListBucket is unavailable or
+    // its prefix condition is not present in the GetObject request context.
+    if (isCacheMiss(error)) return null;
     throw error;
   }
 };

--- a/lambda/intents/native-export.js
+++ b/lambda/intents/native-export.js
@@ -4,6 +4,8 @@ import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import yaml from 'js-yaml';
 import {
+  MAX_DISTRIBUTION_BYTES,
+  MAX_DISTRIBUTION_FILES,
   buildDistributionArchive,
   extractDistributionArchive,
 } from '../shared/distribution-archive.js';
@@ -161,11 +163,12 @@ const loadCurrentCacheEntry = async ({ s3, bucket, upstreamRef, harness }) => {
     key: distributionManifestKey(upstreamRef, harness),
   });
   if (!manifestBody) return null;
-  const archive = await readObject({
+  const archive = await readObjectIfPresent({
     s3,
     bucket,
     key: distributionArchiveKey(upstreamRef, harness),
   });
+  if (!archive) return null;
   return validateDistribution({
     archive,
     manifest: JSON.parse(manifestBody.toString('utf8')),
@@ -193,7 +196,8 @@ const loadLegacyCacheEntry = async ({ s3, bucket, upstreamRef, harness }) => {
     throw new Error(`native-export: invalid ${harness} distribution manifest`);
   }
   const archivePath = safeArchivePath(distribution.archive);
-  const archive = await readObject({ s3, bucket, key: `${prefix}/${archivePath}` });
+  const archive = await readObjectIfPresent({ s3, bucket, key: `${prefix}/${archivePath}` });
+  if (!archive) return null;
   return validateDistribution({
     archive,
     manifest: {
@@ -210,7 +214,11 @@ const fetchAndCacheDistribution = async ({ s3, bucket, upstreamRef, harness }) =
   const repoPrefix = `dist/${harness}/`;
   let fetched;
   try {
-    fetched = await fetchRepoFiles(upstreamRef, { prefixes: [repoPrefix] });
+    fetched = await fetchRepoFiles(upstreamRef, {
+      prefixes: [repoPrefix],
+      maxFiles: MAX_DISTRIBUTION_FILES,
+      maxRetainedBytes: MAX_DISTRIBUTION_BYTES,
+    });
   } catch (error) {
     throw new Error(
       `native-export: ${harness} distribution is unavailable for ${upstreamRef}: ${error.message}`,

--- a/lambda/intents/native-export.js
+++ b/lambda/intents/native-export.js
@@ -283,6 +283,29 @@ const resolveRulesDir = ({ distributionFiles, harness }) => {
   return `${harnessDir}/${rulesSubdir}`;
 };
 
+const detectConstructionCapabilities = ({ distributionFiles, harness }) => {
+  const { harnessDir } = loadHarnessMetadata({ distributionFiles, harness });
+  const orchestrator = distributionFiles.get(`${harnessDir}/tools/aidlc-orchestrate.ts`);
+  const source = orchestrator?.toString('utf8') ?? '';
+  return {
+    perUnitIteration: source.includes('emitPerUnitRunStage'),
+  };
+};
+
+const shouldShowWorkspaceSetup = (stages = []) => {
+  const activeIndex = stages.findIndex((stage) => stage.marker === '-');
+  if (activeIndex < 0) {
+    return stages.some((stage) => stage.phase === 'construction' && stage.marker !== 'S');
+  }
+  const active = stages[activeIndex];
+  if (['construction', 'operation'].includes(active.phase)) return true;
+  if (active.phase !== 'inception') return false;
+  const nextExecutable = stages
+    .slice(activeIndex + 1)
+    .find((stage) => !['x', 'S'].includes(stage.marker));
+  return nextExecutable?.phase === 'construction';
+};
+
 const loadCustomRules = async ({ s3, bucket, harness, distributionFiles, customRules = [] }) => {
   const files = new Map();
   if (customRules.length === 0) return files;
@@ -459,6 +482,7 @@ const alignProjectionToDistribution = ({ projection, distributionFiles, harness 
         cloudStage?.outputArtifacts?.map((artifact) => artifact.artifact) ??
         nativeStage.produces ??
         [],
+      forEach: cloudStage?.forEach ?? nativeStage.for_each ?? null,
       ...cloudStage,
       excluded: cloudStage?.excluded ?? !cloudStage,
     };
@@ -523,6 +547,10 @@ const createNativeExport = async ({
     scope: alignedProjection.nativeScope,
   });
   const distributionFiles = registeredScope.files;
+  const constructionCapabilities = detectConstructionCapabilities({
+    distributionFiles,
+    harness,
+  });
   const customRuleFiles = await loadCustomRules({
     s3,
     bucket,
@@ -537,6 +565,15 @@ const createNativeExport = async ({
     workspaceLayout: distribution.workspaceLayout,
     now,
   });
+  const nextUnit = projected.manifest.construction?.nextUnit ?? null;
+  const effectiveWarnings = [...warnings];
+  if (nextUnit && !constructionCapabilities.perUnitIteration) {
+    effectiveWarnings.push(
+      `This pinned AI-DLC runtime predates deterministic per-unit Construction iteration. ` +
+        `The complete Bolt DAG is included; explicitly ask AI-DLC to continue Construction ` +
+        `with unit "${nextUnit}" when resuming.`,
+    );
+  }
   const files = new Map(distributionFiles);
   for (const [path, body] of customRuleFiles) files.set(path, body);
   for (const [path, body] of projected.files) files.set(path, Buffer.from(body));
@@ -547,7 +584,7 @@ const createNativeExport = async ({
       ...projected.manifest.native,
       scopeRegistered: registeredScope.registered,
     },
-    warnings,
+    warnings: effectiveWarnings,
     files: [...files]
       .filter(([path]) => path !== 'export-manifest.json')
       .map(([path, body]) => ({
@@ -596,13 +633,24 @@ const createNativeExport = async ({
     filename: `${projected.recordDir}-${harness}.zip`,
     downloadUrl,
     expiresAt: new Date(Date.parse(now) + DOWNLOAD_TTL_SECONDS * 1000).toISOString(),
-    warnings,
+    warnings: effectiveWarnings,
     setup: {
       workspaceLayout: distribution.workspaceLayout,
       mode: setupMode,
       harnessDir: harnessRootDir(harness),
       ...HARNESS_SESSION_COMMANDS[harness],
+      showWorkspaceSetup: shouldShowWorkspaceSetup(projected.stages),
       repositories: projected.manifest.repositories,
+      ...(projected.manifest.construction
+        ? {
+            construction: {
+              nextUnit,
+              completedUnits: projected.manifest.construction.completedUnits,
+              readyUnits: projected.manifest.construction.readyUnits,
+              perUnitIteration: constructionCapabilities.perUnitIteration,
+            },
+          }
+        : {}),
       ...(setupMode === 'workspace-sync' && harnessRootDir(harness)
         ? { syncCommand: `bun ${harnessRootDir(harness)}/tools/aidlc-workspace-sync.ts` }
         : {}),
@@ -617,6 +665,7 @@ export {
   alignProjectionToDistribution,
   buildZip,
   createNativeExport,
+  detectConstructionCapabilities,
   detectWorkspaceLayout,
   fetchAndCacheDistribution,
   loadDistribution,
@@ -624,6 +673,7 @@ export {
   registerNativeScope,
   resolveRulesDir,
   safeArchivePath,
+  shouldShowWorkspaceSetup,
 };
 
 export default { createNativeExport };

--- a/lambda/intents/package.json
+++ b/lambda/intents/package.json
@@ -22,7 +22,10 @@
     "@aws-sdk/lib-dynamodb": "^3.1092.0",
     "@aws-sdk/s3-presigned-post": "^3.1092.0",
     "@aws-sdk/s3-request-presigner": "^3.1092.0",
+    "archiver": "^7.0.1",
     "gremlin": "^3.8.1",
-    "gremlin-aws-sigv4": "^3.6.1"
+    "gremlin-aws-sigv4": "^3.6.1",
+    "js-yaml": "^4.1.0",
+    "tar-stream": "^3.2.0"
   }
 }

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -1218,7 +1218,14 @@ describe('POST /projects/{id}/intents', () => {
 });
 
 describe('POST /projects/{id}/intents/{intentId}/export', () => {
+  const exportRef = 'a'.repeat(40);
+
   const seedExportPlan = () => {
+    procStore.set(keyOf('WF#default#aidlc-v2', 'V#4#META'), {
+      pk: 'WF#default#aidlc-v2',
+      sk: 'V#4#META',
+      sourceRef: exportRef,
+    });
     procStore.set(keyOf('WF#default#aidlc-v2', 'V#4#PLACEMENT#requirements-analysis'), {
       pk: 'WF#default#aidlc-v2',
       sk: 'V#4#PLACEMENT#requirements-analysis',
@@ -1242,6 +1249,7 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
       consumes: [],
       sensors: [],
       humanValidation: 'none',
+      sourceRef: exportRef,
     });
   };
 
@@ -1257,7 +1265,15 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
   const createExportableIntent = async (sub, status) => {
     const projectId = await seedV2Project(sub);
     seedExportPlan();
-    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+    const configuredRef = process.env.AIDLC_REPO_REF;
+    process.env.AIDLC_REPO_REF = exportRef;
+    let intent;
+    try {
+      intent = JSON.parse((await createIntent(sub, projectId)).body);
+    } finally {
+      if (configuredRef === undefined) delete process.env.AIDLC_REPO_REF;
+      else process.env.AIDLC_REPO_REF = configuredRef;
+    }
     const metaKey = keyOf(`EXEC#${intent.id}`, 'META');
     const meta = {
       ...procStore.get(metaKey),
@@ -1526,6 +1542,56 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
         }),
       }),
     );
+  });
+
+  it('resolves the configured tag before exporting a legacy intent', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
+    const sha = 'c'.repeat(40);
+    meta.aidlcRepoRef = null;
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'META'), meta);
+    process.env.AIDLC_REPO_REF = 'release/v2';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true, json: async () => ({ sha }) });
+    try {
+      const res = await exportIntent(sub, projectId, intent.id);
+
+      expect(res.statusCode).toBe(201);
+      expect(fetchSpy.mock.calls[0][0]).toContain('/commits/release%2Fv2');
+      expect(createNativeExportSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          upstreamRef: sha,
+          warnings: [
+            'This legacy intent did not pin a native upstream ref; the current deployment ref was used.',
+          ],
+        }),
+      );
+    } finally {
+      fetchSpy.mockRestore();
+      delete process.env.AIDLC_REPO_REF;
+    }
+  });
+
+  it('names a configured legacy ref that cannot be resolved', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
+    meta.aidlcRepoRef = null;
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'META'), meta);
+    process.env.AIDLC_REPO_REF = 'missing-tag';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 404 });
+    try {
+      const res = await exportIntent(sub, projectId, intent.id);
+
+      expect(res.statusCode).toBe(409);
+      expect(JSON.parse(res.body).detail).toBe(
+        'Unable to resolve AI-DLC repository ref "missing-tag" (404)',
+      );
+      expect(createNativeExportSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      delete process.env.AIDLC_REPO_REF;
+    }
   });
 
   it('preserves repository identities and assigns collision-safe export directories', async () => {

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -31,8 +31,10 @@ import {
 import {
   CopyObjectCommand,
   DeleteObjectCommand,
+  DeleteObjectsCommand,
   GetObjectCommand,
   HeadObjectCommand,
+  ListObjectVersionsCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
 // Used to compute the deterministic stage-instance ids the rewind flow resets/supersedes.
@@ -62,6 +64,8 @@ vi.mock('../../shared/artifact-versioning.js', async (importOriginal) => {
 });
 vi.mock('../native-export.js', () => ({
   createNativeExport: createNativeExportSpy,
+  EXPORT_SOURCE_UNAVAILABLE: 'export_source_unavailable',
+  EXPORT_MISCONFIGURED: 'export_misconfigured',
 }));
 
 const PARTITION = `t-${randomUUID()}`;
@@ -329,6 +333,9 @@ const installDdbFakes = () => {
     StopTimestamp: new Date('2026-07-17T00:00:00.000Z'),
   });
   s3Mock.reset();
+  // Deletion purges each attachment/export prefix; default to an empty listing
+  // so the cascade is a safe no-op unless a test opts into seeded versions.
+  s3Mock.on(ListObjectVersionsCommand).resolves({});
 };
 
 // Seed a HUMAN# gate row straight into the fake table (the runtime writes these;
@@ -1595,6 +1602,84 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
     }
   });
 
+  it('returns 500 when the export fails for an unexpected reason', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, 'WAITING');
+    createNativeExportSpy.mockRejectedValueOnce(new Error('S3 ServiceUnavailable'));
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).detail).toBe('S3 ServiceUnavailable');
+  });
+
+  it('returns 409 when the workflow snapshot is not natively exportable', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, 'WAITING');
+    createNativeExportSpy.mockRejectedValueOnce(
+      new Error('native-export: projected plan is missing native stage foo'),
+    );
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).detail).toBe(
+      'native-export: projected plan is missing native stage foo',
+    );
+  });
+
+  it('returns 502 when the distribution source is unavailable', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, 'WAITING');
+    createNativeExportSpy.mockRejectedValueOnce(
+      Object.assign(
+        new Error('native-export: codex distribution is unavailable for abc: timeout'),
+        {
+          code: 'export_source_unavailable',
+        },
+      ),
+    );
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(502);
+    expect(JSON.parse(res.body).code).toBe('export_source_unavailable');
+  });
+
+  it('returns 500 when the export is misconfigured', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, 'WAITING');
+    createNativeExportSpy.mockRejectedValueOnce(
+      Object.assign(new Error('native-export: artifacts bucket is not configured'), {
+        code: 'export_misconfigured',
+      }),
+    );
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).code).toBe('export_misconfigured');
+  });
+
+  it('records an audit event for a successful export', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, 'WAITING');
+    createNativeExportSpy.mockResolvedValueOnce({
+      exportId: 'export-xyz',
+      downloadUrl: 'https://example.test/export.zip',
+      expiresAt: '2026-08-14T16:00:00.000Z',
+    });
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(201);
+    const events = [...procStore.values()].filter((i) => (i.sk || '').startsWith('EVENT#'));
+    const exported = events.find((e) => e.eventType === 'v2.execution.exported');
+    expect(exported).toBeDefined();
+    expect(exported.summary).toContain('export-xyz');
+    expect(exported.actor).toBe(`${sub}@x`);
+  });
+
   it('preserves repository identities and assigns collision-safe export directories', async () => {
     const sub = `u-${randomUUID()}`;
     const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
@@ -2504,7 +2589,9 @@ describe('POST /compose — composer sessions', () => {
       expect(key).toMatch(new RegExp(`^compose-reports/${intent.id}/`));
       expect(uploadUrl).toContain('artifacts-test');
     } finally {
-      vi.stubEnv('ARTIFACTS_BUCKET', undefined);
+      // Restore the beforeAll default; leaving it undefined leaks an unset
+      // bucket into every later test (e.g. the deletion S3 purge).
+      vi.stubEnv('ARTIFACTS_BUCKET', 'artifacts-test');
     }
   });
 
@@ -4649,6 +4736,35 @@ describe('DELETE /projects/{id}/intents/{intentId}', () => {
     expect(leftover).toEqual([]);
     // Yjs: only the intent-scoped docs are removed.
     expect([...yjsStore.keys()]).toEqual(['unrelated-doc']);
+  });
+
+  it('purges every version of the intent native workspace exports from S3', async () => {
+    const sub = `u-${randomUUID()}`;
+    const projectId = await seedV2Project(sub);
+    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+    const intentId = intent.id;
+    await seedIntentAnchor(intentId);
+    setStatus(intentId, { status: 'SUCCEEDED' });
+
+    const exportPrefix = `workflow-exports/${intentId}/`;
+    const exportVersions = [
+      { Key: `${exportPrefix}e1.zip`, VersionId: 'v1' },
+      { Key: `${exportPrefix}e1.zip`, VersionId: 'v2' },
+    ];
+    s3Mock
+      .on(ListObjectVersionsCommand)
+      .callsFake((input) => (input.Prefix === exportPrefix ? { Versions: exportVersions } : {}));
+    s3Mock.on(DeleteObjectsCommand).resolves({});
+
+    const res = await del(sub, projectId, intentId);
+    expect(res.statusCode).toBe(204);
+
+    const deletes = s3Mock.commandCalls(DeleteObjectsCommand).map((call) => call.args[0].input);
+    const exportDelete = deletes.find((input) =>
+      input.Delete.Objects.some((object) => object.Key.startsWith(exportPrefix)),
+    );
+    expect(exportDelete).toBeDefined();
+    expect(exportDelete.Delete.Objects).toEqual(exportVersions);
   });
 
   it('cascade sweeps the derived layer AND spares a sibling intent that shares an artifact id', async () => {

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -37,17 +37,25 @@ import {
 // Used to compute the deterministic stage-instance ids the rewind flow resets/supersedes.
 import { stageInstanceId as planStageInstanceId } from '../../shared/v2-execution-plan.js';
 
-const { archiveArtifactsSpy } = vi.hoisted(() => ({
-  archiveArtifactsSpy: vi.fn(),
-}));
+const { archiveArtifactsSpy, createNativeExportSpy, readCheckpointArtifactVersionsSpy } =
+  vi.hoisted(() => ({
+    archiveArtifactsSpy: vi.fn(),
+    createNativeExportSpy: vi.fn(),
+    readCheckpointArtifactVersionsSpy: vi.fn(),
+  }));
 vi.mock('../../shared/artifact-versioning.js', async (importOriginal) => {
   const actual = await importOriginal();
   archiveArtifactsSpy.mockImplementation(actual.archiveArtifactsForStages);
+  readCheckpointArtifactVersionsSpy.mockImplementation(actual.readCheckpointArtifactVersions);
   return {
     ...actual,
     archiveArtifactsForStages: archiveArtifactsSpy,
+    readCheckpointArtifactVersions: readCheckpointArtifactVersionsSpy,
   };
 });
+vi.mock('../native-export.js', () => ({
+  createNativeExport: createNativeExportSpy,
+}));
 
 const PARTITION = `t-${randomUUID()}`;
 
@@ -398,6 +406,12 @@ beforeEach(() => {
   agentcoreMock.reset();
   attachmentUpdateConflict = null;
   archiveArtifactsSpy.mockClear();
+  readCheckpointArtifactVersionsSpy.mockClear();
+  createNativeExportSpy.mockReset();
+  createNativeExportSpy.mockResolvedValue({
+    downloadUrl: 'https://example.test/export.zip',
+    expiresAt: '2026-08-14T16:00:00.000Z',
+  });
 });
 
 const claims = (sub) => ({
@@ -1167,6 +1181,297 @@ describe('POST /projects/{id}/intents', () => {
       .next();
     const res = await createIntent(sub, projectId);
     expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('POST /projects/{id}/intents/{intentId}/export', () => {
+  const seedExportPlan = () => {
+    procStore.set(keyOf('WF#default#aidlc-v2', 'V#4#PLACEMENT#requirements-analysis'), {
+      pk: 'WF#default#aidlc-v2',
+      sk: 'V#4#PLACEMENT#requirements-analysis',
+      stageId: 'requirements-analysis',
+      order: 1,
+      scopeMembership: { feature: 'EXECUTE' },
+    });
+    procStore.set(keyOf('BLOCK#requirements-analysis', 'META'), {
+      pk: 'BLOCK#requirements-analysis',
+      sk: 'META',
+      GSI1PK: 'TENANT#default#STAGE',
+      GSI1SK: 'NAME#requirements-analysis',
+      id: 'requirements-analysis',
+      blockId: 'requirements-analysis',
+      type: 'STAGE',
+      version: 1,
+      phase: 'inception',
+      mode: 'inline',
+      leadAgent: 'orchestrator',
+      produces: [],
+      consumes: [],
+      sensors: [],
+      humanValidation: 'none',
+    });
+  };
+
+  const exportIntent = (sub, projectId, intentId) =>
+    handler({
+      httpMethod: 'POST',
+      path: `/projects/${projectId}/intents/${intentId}/export`,
+      pathParameters: { projectId, intentId },
+      body: JSON.stringify({ harness: 'codex' }),
+      ...claims(sub),
+    });
+
+  const createExportableIntent = async (sub, status) => {
+    const projectId = await seedV2Project(sub);
+    seedExportPlan();
+    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+    const metaKey = keyOf(`EXEC#${intent.id}`, 'META');
+    const meta = {
+      ...procStore.get(metaKey),
+      status,
+      title: 'Live title',
+      startedAt: '2026-08-14T10:00:00.000Z',
+    };
+    procStore.set(metaKey, meta);
+    return { projectId, intent, meta };
+  };
+
+  const seedCheckpoint = (intentId, meta) => {
+    const checkpoint = {
+      pk: `EXEC#${intentId}`,
+      sk: 'CHECKPOINT',
+      type: 'WorkflowCheckpoint',
+      executionId: intentId,
+      checkpointId: 'checkpoint-1',
+      createdAt: '2026-08-14T10:05:00.000Z',
+      sourceStageInstanceId: 'requirements-analysis@1',
+      process: {
+        meta: { ...meta, title: 'Checkpoint title' },
+        stages: [],
+        humanTasks: [],
+        unitPlan: null,
+        units: [],
+      },
+      artifactRefs: [
+        {
+          artifactId: 'requirements',
+          versionId: 'requirements:sha256:abc',
+          snapshotHash: 'abc',
+        },
+      ],
+      customRuleRefs: [],
+    };
+    procStore.set(keyOf(`EXEC#${intentId}`, 'CHECKPOINT'), checkpoint);
+    return checkpoint;
+  };
+
+  it.each(['DRAFT', 'CREATED'])('blocks %s intents before archive construction', async (status) => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, status);
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toBe('The intent is not in an exportable state');
+    expect(createNativeExportSpy).not.toHaveBeenCalled();
+  });
+
+  it('requires a completed checkpoint while RUNNING', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, 'RUNNING');
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'No completed workflow checkpoint is available yet',
+      code: 'export_checkpoint_unavailable',
+    });
+    expect(createNativeExportSpy).not.toHaveBeenCalled();
+  });
+
+  it('exports live state when a RUNNING parallel lane is globally parked', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, 'RUNNING');
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'STAGE#si-code'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'STAGE#si-code',
+      type: 'Stage',
+      executionId: intent.id,
+      stageInstanceId: 'si-code',
+      stageId: 'code-generation',
+      sectionIndex: 1,
+      unitSlug: 'identification',
+      state: 'WAITING_FOR_HUMAN',
+    });
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'HUMAN#q-code-plan'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'HUMAN#q-code-plan',
+      type: 'HumanTask',
+      executionId: intent.id,
+      humanTaskId: 'q-code-plan',
+      stageInstanceId: 'si-code',
+      sectionIndex: 1,
+      unitSlug: 'identification',
+      status: 'pending',
+    });
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'UNIT#S1#identification'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'UNIT#S1#identification',
+      type: 'Unit',
+      executionId: intent.id,
+      sectionIndex: 1,
+      slug: 'identification',
+      state: 'RUNNING',
+    });
+    createNativeExportSpy.mockImplementationOnce(async ({ validateSnapshot }) => {
+      await expect(validateSnapshot()).resolves.toBe(true);
+      return {
+        downloadUrl: 'https://example.test/export.zip',
+        expiresAt: '2026-08-14T16:00:00.000Z',
+      };
+    });
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(201);
+    expect(createNativeExportSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceCheckpoint: null,
+        validateSnapshot: expect.any(Function),
+      }),
+    );
+  });
+
+  it('requires a checkpoint when a sibling lane is still running', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent } = await createExportableIntent(sub, 'RUNNING');
+    for (const [slug, state, stageState] of [
+      ['identification', 'RUNNING', 'WAITING_FOR_HUMAN'],
+      ['display-results', 'RUNNING', 'RUNNING'],
+    ]) {
+      const stageInstanceId = `si-${slug}`;
+      procStore.set(keyOf(`EXEC#${intent.id}`, `STAGE#${stageInstanceId}`), {
+        pk: `EXEC#${intent.id}`,
+        sk: `STAGE#${stageInstanceId}`,
+        type: 'Stage',
+        executionId: intent.id,
+        stageInstanceId,
+        stageId: 'code-generation',
+        sectionIndex: 1,
+        unitSlug: slug,
+        state: stageState,
+      });
+      procStore.set(keyOf(`EXEC#${intent.id}`, `UNIT#S1#${slug}`), {
+        pk: `EXEC#${intent.id}`,
+        sk: `UNIT#S1#${slug}`,
+        type: 'Unit',
+        executionId: intent.id,
+        sectionIndex: 1,
+        slug,
+        state,
+      });
+    }
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'HUMAN#q-code-plan'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'HUMAN#q-code-plan',
+      type: 'HumanTask',
+      executionId: intent.id,
+      humanTaskId: 'q-code-plan',
+      stageInstanceId: 'si-identification',
+      sectionIndex: 1,
+      unitSlug: 'identification',
+      status: 'pending',
+    });
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).code).toBe('export_checkpoint_unavailable');
+    expect(createNativeExportSpy).not.toHaveBeenCalled();
+  });
+
+  it('exports the immutable checkpoint while RUNNING', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'RUNNING');
+    seedCheckpoint(intent.id, meta);
+    readCheckpointArtifactVersionsSpy.mockResolvedValueOnce([
+      {
+        artifact_id: 'requirements',
+        artifact_type: 'requirements',
+        content: '# Checkpoint requirements',
+        created_by_stage_instance_id: 'requirements-analysis@1',
+        snapshot_hash: 'abc',
+      },
+    ]);
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(201);
+    expect(createNativeExportSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projection: expect.objectContaining({
+          intent: expect.objectContaining({ title: 'Checkpoint title' }),
+          artifacts: [
+            expect.objectContaining({
+              id: 'requirements',
+              content: '# Checkpoint requirements',
+            }),
+          ],
+        }),
+        sourceCheckpoint: {
+          checkpointId: 'checkpoint-1',
+          createdAt: '2026-08-14T10:05:00.000Z',
+          sourceStageInstanceId: 'requirements-analysis@1',
+        },
+        validateSnapshot: null,
+      }),
+    );
+  });
+
+  it('exports and revalidates live state for stable statuses', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
+    seedCheckpoint(intent.id, meta);
+    createNativeExportSpy.mockImplementationOnce(async ({ projection, validateSnapshot }) => {
+      expect(projection.intent.title).toBe('Live title');
+      await expect(validateSnapshot()).resolves.toBe(true);
+      return {
+        downloadUrl: 'https://example.test/export.zip',
+        expiresAt: '2026-08-14T16:00:00.000Z',
+      };
+    });
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(201);
+    expect(readCheckpointArtifactVersionsSpy).not.toHaveBeenCalled();
+    expect(createNativeExportSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceCheckpoint: null,
+        validateSnapshot: expect.any(Function),
+      }),
+    );
+  });
+
+  it('maps checkpoint artifact integrity failures to a specific response', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'RUNNING');
+    seedCheckpoint(intent.id, meta);
+    readCheckpointArtifactVersionsSpy.mockRejectedValueOnce(
+      Object.assign(new Error('checkpoint version missing'), {
+        code: 'export_checkpoint_unavailable',
+      }),
+    );
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'The latest completed checkpoint is incomplete or unavailable',
+      code: 'export_checkpoint_unavailable',
+    });
+    expect(createNativeExportSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -1480,6 +1480,32 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
     );
   });
 
+  it('preserves repository identities and assigns collision-safe export directories', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
+    meta.repos = ['org-a/api', 'org-b/api'];
+    meta.repoProviders = { 'org-a/api': 'github', 'org-b/api': 'github' };
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'META'), meta);
+    createNativeExportSpy.mockImplementationOnce(async ({ projection }) => {
+      expect(projection.repositories.map((repository) => repository.id)).toEqual([
+        'org-a/api',
+        'org-b/api',
+      ]);
+      expect(projection.repositories.map((repository) => repository.directory)).toEqual([
+        'org-a_api',
+        'org-b_api',
+      ]);
+      return {
+        downloadUrl: 'https://example.test/export.zip',
+        expiresAt: '2026-08-14T16:00:00.000Z',
+      };
+    });
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(201);
+  });
+
   it('rejects an export whose stages record a different AI-DLC revision', async () => {
     const sub = `u-${randomUUID()}`;
     const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -2615,6 +2615,11 @@ describe('POST /recompose — in-flight reshape', () => {
         { stageInstanceId: 'si-optional', stageId: 'optional', state: 'WAITING_FOR_HUMAN' },
       ],
     });
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'CHECKPOINT'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'CHECKPOINT',
+      checkpointId: 'stale-checkpoint',
+    });
     const res = await recomposeReq(sub, projectId, intent.id, {
       composedGrid: { analyze: 'EXECUTE', optional: 'EXECUTE', build: 'SKIP' },
       scope: 'feature-lean',
@@ -2635,6 +2640,7 @@ describe('POST /recompose — in-flight reshape', () => {
     // The parked instance was reset for its fresh attempt.
     const row = procStore.get(keyOf(`EXEC#${intent.id}`, 'STAGE#si-optional'));
     expect(row.state).toBe('PENDING');
+    expect(procStore.has(keyOf(`EXEC#${intent.id}`, 'CHECKPOINT'))).toBe(false);
     // Audit trail carries the reshape.
     const events = [...procStore.values()].filter((i) => (i.sk || '').startsWith('EVENT#'));
     expect(events.map((e) => e.eventType)).toContain('v2.execution.recomposed');
@@ -4967,6 +4973,11 @@ describe('POST /rewind', () => {
     setStatus(intent.id, { status: 'SUCCEEDED' });
     seedStageRow(intent.id, 'design');
     seedStageRow(intent.id, 'implement');
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'CHECKPOINT'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'CHECKPOINT',
+      checkpointId: 'stale-checkpoint',
+    });
     await seedIntentAnchor(intent.id);
     const seedArtifact = async (id, stageId) => {
       await g
@@ -4998,6 +5009,7 @@ describe('POST /rewind', () => {
     expect(body.intent.status).toBe('CREATED');
     expect(body.intent.rewindFromStageId).toBe('implement');
     expect(body.steering).toMatchObject({ kind: 'rewind', targetStageId: 'implement' });
+    expect(procStore.has(keyOf(`EXEC#${intent.id}`, 'CHECKPOINT'))).toBe(false);
 
     // The target stage is reset (attempt+1, session cleared); upstream is untouched.
     const implRow = procStore.get(keyOf(`EXEC#${intent.id}`, `STAGE#${siOf('implement')}`));
@@ -5521,6 +5533,11 @@ describe('WP4 — rewind expands per-unit stage instances', () => {
       orchestratorRunId: 'old-run',
       pendingHumanTaskId: 'answered-gate',
     });
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'CHECKPOINT'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'CHECKPOINT',
+      checkpointId: 'stale-checkpoint',
+    });
     seedStageRow(intent.id, 'units-gen');
     seedStageRow(intent.id, 'cg', 'foundation', 'SUCCEEDED', 1);
     seedStageRow(intent.id, 'cg', 'asset-containment', 'WAITING_FOR_HUMAN', 1);
@@ -5579,6 +5596,7 @@ describe('WP4 — rewind expands per-unit stage instances', () => {
     const res = await repair(sub, projectId, intent.id);
 
     expect(res.statusCode).toBe(202);
+    expect(procStore.has(keyOf(`EXEC#${intent.id}`, 'CHECKPOINT'))).toBe(false);
     expect(JSON.parse(res.body).repair).toMatchObject({
       sectionIndex: 1,
       laneSlugs: [

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -1352,6 +1352,7 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
       sectionIndex: 1,
       unitSlug: 'identification',
       state: 'WAITING_FOR_HUMAN',
+      aidlcRepoRef: exportRef,
     });
     procStore.set(keyOf(`EXEC#${intent.id}`, 'HUMAN#q-code-plan'), {
       pk: `EXEC#${intent.id}`,
@@ -1641,6 +1642,58 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
     expect(res.statusCode).toBe(409);
     expect(JSON.parse(res.body).code).toBe('export_mixed_aidlc_refs');
     expect(createNativeExportSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(['SUCCEEDED', 'FAILED', 'RUNNING', 'WAITING_FOR_HUMAN'])(
+    'rejects a pinned export when a %s stage has no AI-DLC revision',
+    async (state) => {
+      const sub = `u-${randomUUID()}`;
+      const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
+      meta.aidlcRepoRef = exportRef;
+      procStore.set(keyOf(`EXEC#${intent.id}`, 'META'), meta);
+      procStore.set(keyOf(`EXEC#${intent.id}`, `STAGE#si-${state}`), {
+        pk: `EXEC#${intent.id}`,
+        sk: `STAGE#si-${state}`,
+        type: 'Stage',
+        executionId: intent.id,
+        stageInstanceId: `si-${state}`,
+        stageId: 'requirements-analysis',
+        state,
+      });
+
+      const res = await exportIntent(sub, projectId, intent.id);
+
+      expect(res.statusCode).toBe(409);
+      expect(JSON.parse(res.body).code).toBe('export_mixed_aidlc_refs');
+      expect(createNativeExportSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it('ignores PENDING and SKIPPED stage revision attribution', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
+    meta.aidlcRepoRef = exportRef;
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'META'), meta);
+    for (const [state, aidlcRepoRef] of [
+      ['PENDING', null],
+      ['SKIPPED', 'b'.repeat(40)],
+    ]) {
+      procStore.set(keyOf(`EXEC#${intent.id}`, `STAGE#si-${state}`), {
+        pk: `EXEC#${intent.id}`,
+        sk: `STAGE#si-${state}`,
+        type: 'Stage',
+        executionId: intent.id,
+        stageInstanceId: `si-${state}`,
+        stageId: 'requirements-analysis',
+        state,
+        aidlcRepoRef,
+      });
+    }
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(201);
+    expect(createNativeExportSpy).toHaveBeenCalled();
   });
 
   it('maps checkpoint artifact integrity failures to a specific response', async () => {

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -1047,6 +1047,32 @@ describe('POST /projects/{id}/intents', () => {
     expect(JSON.parse(res.body).scope).toBe('feature');
   });
 
+  it('resolves and persists an immutable AI-DLC commit when creating an intent', async () => {
+    const sha = 'a'.repeat(40);
+    process.env.AIDLC_REPO_REF = 'release/v2';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true, json: async () => ({ sha }) });
+    try {
+      const sub = `u-${randomUUID()}`;
+      const projectId = await seedV2Project(sub);
+      const res = await createIntent(sub, projectId, {
+        title: 'I',
+        prompt: 'Build X',
+        scope: 'feature',
+      });
+      expect(res.statusCode).toBe(201);
+      const intent = JSON.parse(res.body);
+      const meta = procStore.get(keyOf(`EXEC#${intent.id}`, 'META'));
+      expect(meta.aidlcRepoRef).toBe(sha);
+      expect(meta.methodologyPins).toBeTruthy();
+      expect(fetchSpy.mock.calls[0][0]).toContain('/commits/release%2Fv2');
+    } finally {
+      fetchSpy.mockRestore();
+      delete process.env.AIDLC_REPO_REF;
+    }
+  });
+
   it('rejects a scope not offered by the workflow', async () => {
     const sub = `u-${randomUUID()}`;
     const projectId = await seedV2Project(sub);
@@ -1452,6 +1478,29 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
         validateSnapshot: expect.any(Function),
       }),
     );
+  });
+
+  it('rejects an export whose stages record a different AI-DLC revision', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
+    meta.aidlcRepoRef = 'a'.repeat(40);
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'META'), meta);
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'STAGE#si-requirements'), {
+      pk: `EXEC#${intent.id}`,
+      sk: 'STAGE#si-requirements',
+      type: 'Stage',
+      executionId: intent.id,
+      stageInstanceId: 'si-requirements',
+      stageId: 'requirements-analysis',
+      state: 'SUCCEEDED',
+      aidlcRepoRef: 'b'.repeat(40),
+    });
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).code).toBe('export_mixed_aidlc_refs');
+    expect(createNativeExportSpy).not.toHaveBeenCalled();
   });
 
   it('maps checkpoint artifact integrity failures to a specific response', async () => {

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -31,11 +31,18 @@ import {
 import {
   CopyObjectCommand,
   DeleteObjectCommand,
+  GetObjectCommand,
   HeadObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
 // Used to compute the deterministic stage-instance ids the rewind flow resets/supersedes.
 import { stageInstanceId as planStageInstanceId } from '../../shared/v2-execution-plan.js';
+import { buildFromFiles } from '../../shared/block-mappers.js';
+import {
+  buildMethodologyCatalog,
+  methodologyCatalogKey,
+} from '../../shared/methodology-catalog.js';
+import { CORE_FILES } from '../../shared/test/fixtures/repo-files.js';
 
 const { archiveArtifactsSpy, createNativeExportSpy, readCheckpointArtifactVersionsSpy } =
   vi.hoisted(() => ({
@@ -1476,6 +1483,47 @@ describe('POST /projects/{id}/intents/{intentId}/export', () => {
       expect.objectContaining({
         sourceCheckpoint: null,
         validateSnapshot: expect.any(Function),
+      }),
+    );
+  });
+
+  it('uses the intent SHA catalog when SYSTEM workflow versions were reseeded', async () => {
+    const sub = `u-${randomUUID()}`;
+    const { projectId, intent, meta } = await createExportableIntent(sub, 'WAITING');
+    const oldRef = 'a'.repeat(40);
+    const catalog = buildMethodologyCatalog({
+      ref: oldRef,
+      ...buildFromFiles(CORE_FILES),
+    });
+    const updatedMeta = {
+      ...meta,
+      workflowVersion: 1,
+      aidlcRepoRef: oldRef,
+      methodologyPins: null,
+      scope: 'mvp',
+    };
+    procStore.set(keyOf(`EXEC#${intent.id}`, 'META'), updatedMeta);
+    s3Mock.on(GetObjectCommand).callsFake((input) => {
+      if (input.Key === methodologyCatalogKey(oldRef)) {
+        return { Body: Buffer.from(JSON.stringify(catalog)) };
+      }
+      const error = new Error('missing');
+      error.name = 'NoSuchKey';
+      throw error;
+    });
+
+    const res = await exportIntent(sub, projectId, intent.id);
+
+    expect(res.statusCode).toBe(201);
+    expect(s3Mock.commandCalls(GetObjectCommand)[0].args[0].input.Key).toBe(
+      methodologyCatalogKey(oldRef),
+    );
+    expect(createNativeExportSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        upstreamRef: oldRef,
+        projection: expect.objectContaining({
+          stages: expect.arrayContaining([expect.objectContaining({ stageId: 'intent-capture' })]),
+        }),
       }),
     );
   });

--- a/lambda/intents/test/native-export.test.js
+++ b/lambda/intents/test/native-export.test.js
@@ -1,0 +1,354 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it, vi } from 'vitest';
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { buildDistributionArchive } from '../../shared/distribution-archive.js';
+import { fetchRepoFiles } from '../../shared/repo-fetch.js';
+import {
+  alignProjectionToDistribution,
+  buildZip,
+  createNativeExport,
+  detectWorkspaceLayout,
+  loadDistribution,
+  loadCustomRules,
+  registerNativeScope,
+  resolveRulesDir,
+  safeArchivePath,
+} from '../native-export.js';
+
+vi.mock('../../shared/repo-fetch.js', () => ({
+  fetchRepoFiles: vi.fn(),
+}));
+
+const hash = (body) => createHash('sha256').update(body).digest('hex');
+const REF = '1111111111111111111111111111111111111111';
+
+const distribution = async () => {
+  const body = Buffer.from('# Native harness\n');
+  const activeSpace = Buffer.from('default\n');
+  const harnessMetadata = Buffer.from(
+    JSON.stringify({ harnessDir: '.codex', rulesSubdir: 'aidlc-rules' }),
+  );
+  const stageFile = Buffer.from(`---
+slug: intent-capture
+number: "1.1"
+name: Intent Capture
+phase: ideation
+execution: ALWAYS
+condition: Always
+lead_agent: aidlc-product-agent
+support_agents: []
+mode: inline
+produces:
+  - intent-statement
+consumes: []
+requires_stage: []
+sensors: []
+scopes:
+  - feature
+  - mvp
+inputs: task
+outputs: intent
+---
+
+# Intent Capture
+`);
+  const featureScope = Buffer.from(`---
+name: feature
+depth: Standard
+keywords: []
+description: Feature
+---
+
+# feature scope
+`);
+  const scopeGrid = Buffer.from(
+    `${JSON.stringify(
+      {
+        feature: { stages: { 'intent-capture': 'EXECUTE' } },
+        mvp: { stages: { 'intent-capture': 'EXECUTE' } },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const graph = Buffer.from(
+    `${JSON.stringify(
+      [
+        {
+          slug: 'intent-capture',
+          number: '1.1',
+          phase: 'ideation',
+          lead_agent: 'aidlc-product-agent',
+          produces: ['intent-statement'],
+          scopes: ['feature', 'mvp'],
+        },
+      ],
+      null,
+      2,
+    )}\n`,
+  );
+  const distributionFiles = new Map([
+    ['AGENTS.md', body],
+    ['aidlc/active-space', activeSpace],
+    ['.codex/aidlc-common/stages/ideation/intent-capture.md', stageFile],
+    ['.codex/scopes/aidlc-feature.md', featureScope],
+    ['.codex/tools/data/harness.json', harnessMetadata],
+    ['.codex/tools/data/scope-grid.json', scopeGrid],
+    ['.codex/tools/data/stage-graph.json', graph],
+  ]);
+  const archive = await buildDistributionArchive(distributionFiles);
+  const files = [...distributionFiles].map(([path, value]) => ({
+    path,
+    bytes: value.length,
+    sha256: hash(value),
+  }));
+  const manifest = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      ref: REF,
+      harness: 'codex',
+      workspaceLayout: 'spaces',
+      archive: 'codex.tar.gz',
+      archiveBytes: archive.length,
+      archiveSha256: hash(archive),
+      files,
+    }),
+  );
+  return {
+    activeSpace,
+    archive,
+    body,
+    distributionFiles,
+    graph,
+    harnessMetadata,
+    manifest,
+  };
+};
+
+describe('native workflow export', () => {
+  it('rejects unsafe archive paths', () => {
+    expect(() => safeArchivePath('../secret')).toThrow(/unsafe distribution path/);
+    expect(() => safeArchivePath('/absolute')).toThrow(/unsafe distribution path/);
+  });
+
+  it('loads only checksum-valid distribution files', async () => {
+    const { archive, body, manifest } = await distribution();
+    const s3 = {
+      send: vi.fn(async (command) => {
+        expect(command).toBeInstanceOf(GetObjectCommand);
+        return {
+          Body: command.input.Key.endsWith('codex.manifest.json') ? manifest : archive,
+        };
+      }),
+    };
+    const result = await loadDistribution({
+      s3,
+      bucket: 'artifacts',
+      upstreamRef: REF,
+      harness: 'codex',
+    });
+    expect(result.files.get('AGENTS.md')).toEqual(body);
+    expect(result.workspaceLayout).toBe('spaces');
+    expect(s3.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('detects legacy workspaces from the scaffold graph when aidlc/ is absent', () => {
+    const graph = Buffer.from(
+      JSON.stringify([
+        {
+          slug: 'workspace-scaffold',
+          name: 'Workspace Scaffold',
+          outputs: 'aidlc-docs/ directory tree',
+        },
+      ]),
+    );
+    expect(
+      detectWorkspaceLayout({
+        harness: 'codex',
+        files: new Map([['.codex/tools/data/stage-graph.json', graph]]),
+      }),
+    ).toBe('flat');
+  });
+
+  it('downloads and caches a missing harness for the exact commit', async () => {
+    const { distributionFiles } = await distribution();
+    fetchRepoFiles.mockResolvedValueOnce(
+      new Map([...distributionFiles].map(([path, value]) => [`dist/codex/${path}`, value])),
+    );
+    const puts = [];
+    const s3 = {
+      send: vi.fn(async (command) => {
+        if (command instanceof PutObjectCommand) {
+          puts.push(command.input);
+          return {};
+        }
+        const error = new Error('missing');
+        error.name = 'NoSuchKey';
+        throw error;
+      }),
+    };
+    const result = await loadDistribution({
+      s3,
+      bucket: 'artifacts',
+      upstreamRef: REF,
+      harness: 'codex',
+    });
+    expect(fetchRepoFiles).toHaveBeenCalledWith(REF, { prefixes: ['dist/codex/'] });
+    expect(result.workspaceLayout).toBe('spaces');
+    expect(puts.map((put) => put.Key)).toEqual([
+      `aidlc-distributions/${REF}/codex.tar.gz`,
+      `aidlc-distributions/${REF}/codex.manifest.json`,
+    ]);
+  });
+
+  it('creates a zip buffer', async () => {
+    const zip = await buildZip(new Map([['AGENTS.md', Buffer.from('# Agent\n')]]));
+    expect(zip.subarray(0, 2).toString()).toBe('PK');
+  });
+
+  it('marks every native stage omitted by the cloud plan as skipped', () => {
+    const graph = Buffer.from(
+      JSON.stringify([
+        { slug: 'intent-capture', phase: 'ideation', scopes: ['feature'] },
+        { slug: 'requirements-analysis', phase: 'inception', scopes: ['feature'] },
+      ]),
+    );
+    const aligned = alignProjectionToDistribution({
+      harness: 'codex',
+      distributionFiles: new Map([['.codex/tools/data/stage-graph.json', graph]]),
+      projection: {
+        intent: { scope: 'feature' },
+        stages: [{ stageId: 'requirements-analysis', phase: 'inception' }],
+      },
+    });
+    expect(aligned.stages).toEqual([
+      expect.objectContaining({ stageId: 'intent-capture', excluded: true }),
+      expect.objectContaining({ stageId: 'requirements-analysis', excluded: false }),
+    ]);
+  });
+
+  it('registers an arbitrary custom scope in stage metadata and compiled data', async () => {
+    const { distributionFiles } = await distribution();
+    const result = registerNativeScope({
+      distributionFiles,
+      harness: 'codex',
+      scope: 'payments-critical-path',
+      stages: [{ stageId: 'intent-capture', excluded: false }],
+    });
+    expect(result.scope).toBe('payments-critical-path');
+    expect(result.registered).toBe(true);
+    expect(result.files.get('.codex/scopes/aidlc-payments-critical-path.md').toString()).toContain(
+      'name: payments-critical-path',
+    );
+    expect(
+      result.files.get('.codex/aidlc-common/stages/ideation/intent-capture.md').toString(),
+    ).toContain('- payments-critical-path');
+    expect(
+      JSON.parse(result.files.get('.codex/tools/data/scope-grid.json').toString())[
+        'payments-critical-path'
+      ].stages,
+    ).toEqual({ 'intent-capture': 'EXECUTE' });
+    expect(
+      JSON.parse(result.files.get('.codex/tools/data/stage-graph.json').toString())[0].scopes,
+    ).toContain('payments-critical-path');
+  });
+
+  it('leaves an existing matching native scope unchanged', async () => {
+    const { distributionFiles } = await distribution();
+    const result = registerNativeScope({
+      distributionFiles,
+      harness: 'codex',
+      scope: 'feature',
+      stages: [{ stageId: 'intent-capture', excluded: false }],
+    });
+    expect(result.registered).toBe(false);
+    expect(result.files).toBe(distributionFiles);
+  });
+
+  it('resolves the native rules directory from harness metadata', () => {
+    expect(
+      resolveRulesDir({
+        harness: 'codex',
+        distributionFiles: new Map([
+          [
+            '.codex/tools/data/harness.json',
+            Buffer.from(JSON.stringify({ harnessDir: '.codex', rulesSubdir: 'aidlc-rules' })),
+          ],
+        ]),
+      }),
+    ).toBe('.codex/aidlc-rules');
+  });
+
+  it('copies project rules into the selected harness native rules directory', async () => {
+    const s3 = {
+      send: vi.fn().mockResolvedValue({ Body: Buffer.from('Always test.\n') }),
+    };
+    const files = await loadCustomRules({
+      s3,
+      bucket: 'artifacts',
+      harness: 'codex',
+      distributionFiles: new Map([
+        [
+          '.codex/tools/data/harness.json',
+          Buffer.from(JSON.stringify({ harnessDir: '.codex', rulesSubdir: 'aidlc-rules' })),
+        ],
+      ]),
+      customRules: [{ filename: 'standards.md', s3Key: 'custom-rules/p1/standards.md' }],
+    });
+    expect(files.get('.codex/aidlc-rules/custom--standards.md').toString()).toBe('Always test.\n');
+  });
+
+  it('stores a projected native workspace and returns a signed download', async () => {
+    const { archive, manifest } = await distribution();
+    const puts = [];
+    const s3 = {
+      send: vi.fn(async (command) => {
+        if (command instanceof PutObjectCommand) {
+          puts.push(command.input);
+          return {};
+        }
+        return {
+          Body: command.input.Key.endsWith('codex.manifest.json') ? manifest : archive,
+        };
+      }),
+    };
+    const presign = vi.fn().mockResolvedValue('https://download.example/export.zip');
+    const result = await createNativeExport({
+      s3,
+      bucket: 'artifacts',
+      upstreamRef: REF,
+      harness: 'codex',
+      now: '2026-08-11T12:00:00.000Z',
+      presign,
+      projection: {
+        intent: {
+          projectId: 'project-1',
+          intentId: 'intent-1',
+          title: 'Payment service',
+          prompt: 'Add payments',
+          scope: 'feature',
+          workflowId: 'aidlc-v2',
+          workflowVersion: 4,
+          createdAt: '2026-08-11T10:00:00.000Z',
+        },
+        stages: [{ stageId: 'intent-capture', phase: 'ideation' }],
+        stageRows: [],
+        artifacts: [],
+        repositories: [],
+      },
+    });
+    expect(result.downloadUrl).toBe('https://download.example/export.zip');
+    expect(result.filename).toBe('260811-payment-service-codex.zip');
+    expect(result.setup).toEqual({
+      workspaceLayout: 'spaces',
+      mode: 'extract-only',
+      harnessDir: '.codex',
+      launchCommand: 'codex',
+      continueCommand: '$aidlc',
+      repositories: [],
+    });
+    expect(puts).toHaveLength(1);
+    expect(puts[0].Key).toMatch(/^workflow-exports\/intent-1\/.+\.zip$/);
+    expect(puts[0].Body.subarray(0, 2).toString()).toBe('PK');
+  });
+});

--- a/lambda/intents/test/native-export.test.js
+++ b/lambda/intents/test/native-export.test.js
@@ -448,12 +448,14 @@ describe('native workflow export', () => {
         artifacts: [],
         repositories: [
           {
-            name: 'api',
+            id: 'example/api',
+            directory: 'api',
             url: 'git@github.com:example/api.git',
             branch: 'aidlc/payment-service',
           },
           {
-            name: 'web',
+            id: 'example/web',
+            directory: 'web',
             url: 'git@github.com:example/web.git',
             branch: 'aidlc/payment-service',
           },
@@ -472,12 +474,14 @@ describe('native workflow export', () => {
       showWorkspaceSetup: false,
       repositories: [
         {
-          name: 'api',
+          id: 'example/api',
+          directory: 'api',
           url: 'git@github.com:example/api.git',
           branch: 'aidlc/payment-service',
         },
         {
-          name: 'web',
+          id: 'example/web',
+          directory: 'web',
           url: 'git@github.com:example/web.git',
           branch: 'aidlc/payment-service',
         },

--- a/lambda/intents/test/native-export.test.js
+++ b/lambda/intents/test/native-export.test.js
@@ -236,7 +236,10 @@ describe('native workflow export', () => {
     ).toBe(true);
   });
 
-  it('downloads and caches a missing harness for the exact commit', async () => {
+  it.each([
+    ['NoSuchKey', { name: 'NoSuchKey' }],
+    ['a masked 403', { name: 'AccessDenied', $metadata: { httpStatusCode: 403 } }],
+  ])('downloads and caches a harness after %s cache misses', async (_name, errorFields) => {
     const { distributionFiles } = await distribution();
     fetchRepoFiles.mockResolvedValueOnce(
       new Map([...distributionFiles].map(([path, value]) => [`dist/codex/${path}`, value])),
@@ -249,7 +252,7 @@ describe('native workflow export', () => {
           return {};
         }
         const error = new Error('missing');
-        error.name = 'NoSuchKey';
+        Object.assign(error, errorFields);
         throw error;
       }),
     };

--- a/lambda/intents/test/native-export.test.js
+++ b/lambda/intents/test/native-export.test.js
@@ -259,12 +259,43 @@ describe('native workflow export', () => {
       upstreamRef: REF,
       harness: 'codex',
     });
-    expect(fetchRepoFiles).toHaveBeenCalledWith(REF, { prefixes: ['dist/codex/'] });
+    expect(fetchRepoFiles).toHaveBeenCalledWith(REF, {
+      prefixes: ['dist/codex/'],
+      maxFiles: 1_000,
+      maxRetainedBytes: 20 * 1024 * 1024,
+    });
     expect(result.workspaceLayout).toBe('spaces');
     expect(puts.map((put) => put.Key)).toEqual([
       `aidlc-distributions/${REF}/codex.tar.gz`,
       `aidlc-distributions/${REF}/codex.manifest.json`,
     ]);
+  });
+
+  it('refetches when a current cache manifest exists without its archive', async () => {
+    fetchRepoFiles.mockClear();
+    const { distributionFiles, manifest } = await distribution();
+    fetchRepoFiles.mockResolvedValueOnce(
+      new Map([...distributionFiles].map(([path, value]) => [`dist/codex/${path}`, value])),
+    );
+    const s3 = {
+      send: vi.fn(async (command) => {
+        if (command instanceof PutObjectCommand) return {};
+        if (command.input.Key.endsWith('codex.manifest.json')) return { Body: manifest };
+        const error = new Error('missing');
+        error.name = 'NoSuchKey';
+        throw error;
+      }),
+    };
+
+    const result = await loadDistribution({
+      s3,
+      bucket: 'artifacts',
+      upstreamRef: REF,
+      harness: 'codex',
+    });
+
+    expect(result.workspaceLayout).toBe('spaces');
+    expect(fetchRepoFiles).toHaveBeenCalledOnce();
   });
 
   it('creates a zip buffer', async () => {

--- a/lambda/intents/test/native-export.test.js
+++ b/lambda/intents/test/native-export.test.js
@@ -301,6 +301,64 @@ describe('native workflow export', () => {
     expect(fetchRepoFiles).toHaveBeenCalledOnce();
   });
 
+  // repo-fetch rejects (it never returns unmatched/empty results), so
+  // loadDistribution classifies its rejection into retryable vs deterministic.
+  const cacheMissS3 = () => ({
+    send: vi.fn(async () => {
+      const error = new Error('missing');
+      error.name = 'NoSuchKey';
+      throw error;
+    }),
+  });
+  const loadRejection = (s3) =>
+    loadDistribution({ s3, bucket: 'artifacts', upstreamRef: REF, harness: 'codex' }).then(
+      () => null,
+      (error) => error,
+    );
+
+  it('tags an upstream 5xx distribution-fetch failure as retryable (502)', async () => {
+    fetchRepoFiles.mockClear();
+    fetchRepoFiles.mockRejectedValueOnce(
+      new Error(`repo-fetch: https://codeload.github.com/x returned 503 Service Unavailable`),
+    );
+
+    await expect(loadRejection(cacheMissS3())).resolves.toMatchObject({
+      code: 'export_source_unavailable',
+    });
+  });
+
+  it('tags a raw network distribution-fetch failure as retryable (502)', async () => {
+    fetchRepoFiles.mockClear();
+    fetchRepoFiles.mockRejectedValueOnce(new Error('fetch failed'));
+
+    await expect(loadRejection(cacheMissS3())).resolves.toMatchObject({
+      code: 'export_source_unavailable',
+    });
+  });
+
+  it('treats a missing distribution (no matching files) as deterministic', async () => {
+    fetchRepoFiles.mockClear();
+    fetchRepoFiles.mockRejectedValueOnce(
+      new Error(`repo-fetch: no files found for prefixes dist/codex/ in tarball for ref ${REF}`),
+    );
+
+    const rejection = await loadRejection(cacheMissS3());
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection.code).toBeUndefined();
+    expect(rejection.message).toContain('could not be loaded');
+  });
+
+  it('treats a distribution size-limit breach as deterministic', async () => {
+    fetchRepoFiles.mockClear();
+    fetchRepoFiles.mockRejectedValueOnce(
+      new Error('repo-fetch: matching files exceed 20971520 bytes'),
+    );
+
+    const rejection = await loadRejection(cacheMissS3());
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection.code).toBeUndefined();
+  });
+
   it('creates a zip buffer', async () => {
     const zip = await buildZip(new Map([['AGENTS.md', Buffer.from('# Agent\n')]]));
     expect(zip.subarray(0, 2).toString()).toBe('PK');
@@ -435,6 +493,7 @@ describe('native workflow export', () => {
       now: '2026-08-11T12:00:00.000Z',
       presign,
       sourceCheckpoint,
+      warnings: ['Existing warning.'],
       projection: {
         intent: {
           projectId: 'project-1',
@@ -449,6 +508,13 @@ describe('native workflow export', () => {
         stages: [{ stageId: 'intent-capture', phase: 'ideation' }],
         stageRows: [],
         artifacts: [],
+        humanTasks: [
+          {
+            humanTaskId: 'approval-1',
+            kind: 'approval',
+            status: 'answered',
+          },
+        ],
         repositories: [
           {
             id: 'example/api',
@@ -468,6 +534,10 @@ describe('native workflow export', () => {
     expect(result.downloadUrl).toBe('https://download.example/export.zip');
     expect(result.filename).toBe('260811-payment-service-codex.zip');
     expect(result.checkpoint).toEqual(sourceCheckpoint);
+    expect(result.warnings).toEqual([
+      'Existing warning.',
+      'Non-question workflow gates are not represented as native question artifacts: approval.',
+    ]);
     expect(result.setup).toEqual({
       workspaceLayout: 'spaces',
       mode: 'manual-workspace',

--- a/lambda/intents/test/native-export.test.js
+++ b/lambda/intents/test/native-export.test.js
@@ -378,7 +378,10 @@ describe('native workflow export', () => {
 
   it('copies project rules into the selected harness native rules directory', async () => {
     const s3 = {
-      send: vi.fn().mockResolvedValue({ Body: Buffer.from('Always test.\n') }),
+      send: vi.fn(async (command) => {
+        expect(command.input.VersionId).toBe('rule-version-1');
+        return { Body: Buffer.from('Always test.\n') };
+      }),
     };
     const files = await loadCustomRules({
       s3,
@@ -390,7 +393,13 @@ describe('native workflow export', () => {
           Buffer.from(JSON.stringify({ harnessDir: '.codex', rulesSubdir: 'aidlc-rules' })),
         ],
       ]),
-      customRules: [{ filename: 'standards.md', s3Key: 'custom-rules/p1/standards.md' }],
+      customRules: [
+        {
+          filename: 'standards.md',
+          s3Key: 'custom-rules/p1/standards.md',
+          versionId: 'rule-version-1',
+        },
+      ],
     });
     expect(files.get('.codex/aidlc-rules/custom--standards.md').toString()).toBe('Always test.\n');
   });
@@ -410,6 +419,11 @@ describe('native workflow export', () => {
       }),
     };
     const presign = vi.fn().mockResolvedValue('https://download.example/export.zip');
+    const sourceCheckpoint = {
+      checkpointId: 'checkpoint-abc',
+      createdAt: '2026-08-11T11:30:00.000Z',
+      sourceStageInstanceId: 'intent-capture',
+    };
     const result = await createNativeExport({
       s3,
       bucket: 'artifacts',
@@ -417,6 +431,7 @@ describe('native workflow export', () => {
       harness: 'codex',
       now: '2026-08-11T12:00:00.000Z',
       presign,
+      sourceCheckpoint,
       projection: {
         intent: {
           projectId: 'project-1',
@@ -447,6 +462,7 @@ describe('native workflow export', () => {
     });
     expect(result.downloadUrl).toBe('https://download.example/export.zip');
     expect(result.filename).toBe('260811-payment-service-codex.zip');
+    expect(result.checkpoint).toEqual(sourceCheckpoint);
     expect(result.setup).toEqual({
       workspaceLayout: 'spaces',
       mode: 'manual-workspace',
@@ -470,6 +486,43 @@ describe('native workflow export', () => {
     expect(puts).toHaveLength(1);
     expect(puts[0].Key).toMatch(/^workflow-exports\/intent-1\/.+\.zip$/);
     expect(puts[0].Body.subarray(0, 2).toString()).toBe('PK');
+  });
+
+  it('does not upload a legacy live snapshot that changed during ZIP generation', async () => {
+    const { archive, manifest } = await distribution();
+    const s3 = {
+      send: vi.fn(async (command) => {
+        if (command instanceof PutObjectCommand) return {};
+        return {
+          Body: command.input.Key.endsWith('codex.manifest.json') ? manifest : archive,
+        };
+      }),
+    };
+    await expect(
+      createNativeExport({
+        s3,
+        bucket: 'artifacts',
+        upstreamRef: REF,
+        harness: 'codex',
+        validateSnapshot: vi.fn().mockResolvedValue(false),
+        projection: {
+          intent: {
+            projectId: 'project-1',
+            intentId: 'intent-1',
+            title: 'Payment service',
+            scope: 'feature',
+            workflowId: 'aidlc-v2',
+            workflowVersion: 4,
+            createdAt: '2026-08-11T10:00:00.000Z',
+          },
+          stages: [{ stageId: 'intent-capture', phase: 'ideation' }],
+          stageRows: [],
+          artifacts: [],
+          repositories: [],
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'export_snapshot_changed' });
+    expect(s3.send.mock.calls.some(([command]) => command instanceof PutObjectCommand)).toBe(false);
   });
 
   it('returns the next unfinished unit and documents legacy iteration limits', async () => {

--- a/lambda/intents/test/native-export.test.js
+++ b/lambda/intents/test/native-export.test.js
@@ -7,12 +7,14 @@ import {
   alignProjectionToDistribution,
   buildZip,
   createNativeExport,
+  detectConstructionCapabilities,
   detectWorkspaceLayout,
   loadDistribution,
   loadCustomRules,
   registerNativeScope,
   resolveRulesDir,
   safeArchivePath,
+  shouldShowWorkspaceSetup,
 } from '../native-export.js';
 
 vi.mock('../../shared/repo-fetch.js', () => ({
@@ -168,6 +170,54 @@ describe('native workflow export', () => {
         files: new Map([['.codex/tools/data/stage-graph.json', graph]]),
       }),
     ).toBe('flat');
+  });
+
+  it('detects deterministic per-unit iteration from the harness implementation', () => {
+    const metadata = Buffer.from(
+      JSON.stringify({ harnessDir: '.codex', rulesSubdir: 'aidlc-rules' }),
+    );
+    expect(
+      detectConstructionCapabilities({
+        harness: 'codex',
+        distributionFiles: new Map([
+          ['.codex/tools/data/harness.json', metadata],
+          ['.codex/tools/aidlc-orchestrate.ts', Buffer.from('function emitPerUnitRunStage() {}')],
+        ]),
+      }),
+    ).toEqual({ perUnitIteration: true });
+    expect(
+      detectConstructionCapabilities({
+        harness: 'codex',
+        distributionFiles: new Map([
+          ['.codex/tools/data/harness.json', metadata],
+          ['.codex/tools/aidlc-orchestrate.ts', Buffer.from('function emitRunStage() {}')],
+        ]),
+      }),
+    ).toEqual({ perUnitIteration: false });
+  });
+
+  it('identifies the final Inception checkpoint and later workspace setup boundaries', () => {
+    expect(
+      shouldShowWorkspaceSetup([
+        { phase: 'inception', marker: '-' },
+        { phase: 'construction', marker: ' ' },
+      ]),
+    ).toBe(true);
+    expect(
+      shouldShowWorkspaceSetup([
+        { phase: 'inception', marker: '-' },
+        { phase: 'inception', marker: ' ' },
+        { phase: 'construction', marker: ' ' },
+      ]),
+    ).toBe(false);
+    expect(shouldShowWorkspaceSetup([{ phase: 'construction', marker: '-' }])).toBe(true);
+    expect(shouldShowWorkspaceSetup([{ phase: 'operation', marker: '-' }])).toBe(true);
+    expect(
+      shouldShowWorkspaceSetup([
+        { phase: 'construction', marker: 'x' },
+        { phase: 'operation', marker: 'x' },
+      ]),
+    ).toBe(true);
   });
 
   it('downloads and caches a missing harness for the exact commit', async () => {
@@ -345,10 +395,66 @@ describe('native workflow export', () => {
       harnessDir: '.codex',
       launchCommand: 'codex',
       continueCommand: '$aidlc',
+      showWorkspaceSetup: false,
       repositories: [],
     });
     expect(puts).toHaveLength(1);
     expect(puts[0].Key).toMatch(/^workflow-exports\/intent-1\/.+\.zip$/);
     expect(puts[0].Body.subarray(0, 2).toString()).toBe('PK');
+  });
+
+  it('returns the next unfinished unit and documents legacy iteration limits', async () => {
+    const { archive, manifest } = await distribution();
+    const s3 = {
+      send: vi.fn(async (command) => {
+        if (command instanceof PutObjectCommand) return {};
+        return {
+          Body: command.input.Key.endsWith('codex.manifest.json') ? manifest : archive,
+        };
+      }),
+    };
+    const result = await createNativeExport({
+      s3,
+      bucket: 'artifacts',
+      upstreamRef: REF,
+      harness: 'codex',
+      now: '2026-08-11T12:00:00.000Z',
+      presign: vi.fn().mockResolvedValue('https://download.example/export.zip'),
+      projection: {
+        intent: {
+          projectId: 'project-1',
+          intentId: 'intent-1',
+          title: 'Payment service',
+          scope: 'feature',
+          workflowId: 'aidlc-v2',
+          workflowVersion: 4,
+          createdAt: '2026-08-11T10:00:00.000Z',
+        },
+        stages: [{ stageId: 'intent-capture', phase: 'ideation' }],
+        stageRows: [],
+        artifacts: [],
+        repositories: [],
+        unitPlan: {
+          units: [
+            { slug: 'upload-image', dependsOn: [] },
+            { slug: 'identify-plant', dependsOn: ['upload-image'] },
+          ],
+          batches: [['upload-image'], ['identify-plant']],
+        },
+        unitRows: [
+          { slug: 'upload-image', state: 'MERGED' },
+          { slug: 'identify-plant', state: 'PENDING' },
+        ],
+      },
+    });
+    expect(result.setup.construction).toEqual({
+      nextUnit: 'identify-plant',
+      completedUnits: ['upload-image'],
+      readyUnits: ['identify-plant'],
+      perUnitIteration: false,
+    });
+    expect(result.warnings).toContainEqual(
+      expect.stringMatching(/predates deterministic per-unit/),
+    );
   });
 });

--- a/lambda/intents/test/native-export.test.js
+++ b/lambda/intents/test/native-export.test.js
@@ -15,6 +15,7 @@ import {
   resolveRulesDir,
   safeArchivePath,
   shouldShowWorkspaceSetup,
+  workspaceSyncCommand,
 } from '../native-export.js';
 
 vi.mock('../../shared/repo-fetch.js', () => ({
@@ -194,6 +195,21 @@ describe('native workflow export', () => {
         ]),
       }),
     ).toEqual({ perUnitIteration: false });
+  });
+
+  it('detects workspace sync only when the selected harness ships the tool', () => {
+    expect(
+      workspaceSyncCommand({
+        harness: 'codex',
+        distributionFiles: new Map(),
+      }),
+    ).toBeNull();
+    expect(
+      workspaceSyncCommand({
+        harness: 'codex',
+        distributionFiles: new Map([['.codex/tools/aidlc-workspace-sync.ts', Buffer.alloc(0)]]),
+      }),
+    ).toBe('bun .codex/tools/aidlc-workspace-sync.ts');
   });
 
   it('identifies the final Inception checkpoint and later workspace setup boundaries', () => {
@@ -384,19 +400,41 @@ describe('native workflow export', () => {
         stages: [{ stageId: 'intent-capture', phase: 'ideation' }],
         stageRows: [],
         artifacts: [],
-        repositories: [],
+        repositories: [
+          {
+            name: 'api',
+            url: 'git@github.com:example/api.git',
+            branch: 'aidlc/payment-service',
+          },
+          {
+            name: 'web',
+            url: 'git@github.com:example/web.git',
+            branch: 'aidlc/payment-service',
+          },
+        ],
       },
     });
     expect(result.downloadUrl).toBe('https://download.example/export.zip');
     expect(result.filename).toBe('260811-payment-service-codex.zip');
     expect(result.setup).toEqual({
       workspaceLayout: 'spaces',
-      mode: 'extract-only',
+      mode: 'manual-workspace',
       harnessDir: '.codex',
       launchCommand: 'codex',
       continueCommand: '$aidlc',
       showWorkspaceSetup: false,
-      repositories: [],
+      repositories: [
+        {
+          name: 'api',
+          url: 'git@github.com:example/api.git',
+          branch: 'aidlc/payment-service',
+        },
+        {
+          name: 'web',
+          url: 'git@github.com:example/web.git',
+          branch: 'aidlc/payment-service',
+        },
+      ],
     });
     expect(puts).toHaveLength(1);
     expect(puts[0].Key).toMatch(/^workflow-exports\/intent-1\/.+\.zip$/);

--- a/lambda/seed-blocks/index.js
+++ b/lambda/seed-blocks/index.js
@@ -55,6 +55,7 @@ import {
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { SYSTEM_TENANT } from '../shared/tenant.js';
 import { fetchCoreFiles } from '../shared/repo-fetch.js';
+import { resolveAidlcRepoRef } from '../shared/aidlc-ref.js';
 import { buildFromFiles } from '../shared/block-mappers.js';
 import {
   LATEST,
@@ -90,7 +91,7 @@ const runtimeKey = (ref, repoPath) => `${runtimePrefix(ref)}/${repoPath}`;
 
 // Builds the two stored items (V#latest pointer + V#1 snapshot) for a block,
 // with its body (and, for a sensor, its script) externalized to S3.
-const buildItems = (block, bodyRef, scriptRef, now) => {
+const buildItems = (block, bodyRef, scriptRef, now, sourceRef) => {
   const { type, id, name, body, script, ...attrs } = block;
   void body; // externalized into bodyRef
   void script; // externalized into scriptRef
@@ -101,6 +102,7 @@ const buildItems = (block, bodyRef, scriptRef, now) => {
     blockId: id,
     name,
     version: 1,
+    sourceRef,
     bodyRef,
     ...(scriptRef ? { scriptRef } : {}),
     createdAt: now,
@@ -127,7 +129,7 @@ const workflowSnapshotItem = (item, version) => {
 // Builds the items for a baseline workflow partition: the META header (carrying
 // the workflow catalog GSI1 keys), the inline phase tree, stage placements, rule
 // refs, and immutable V#1 workflow snapshot rows.
-const buildWorkflowItems = (wf, now) => {
+const buildWorkflowItems = (wf, now, sourceRef) => {
   const pk = workflowPk(SYSTEM_TENANT, wf.id);
   const meta = {
     pk,
@@ -141,6 +143,7 @@ const buildWorkflowItems = (wf, now) => {
     defaultScope: wf.defaultScope ?? null,
     status: 'PUBLISHED',
     version: 1,
+    sourceRef,
     createdAt: now,
     updatedAt: now,
     GSI1PK: workflowGsi1Pk(SYSTEM_TENANT),
@@ -243,10 +246,11 @@ const putObject = (key, body, contentType) =>
 export const handler = async (event = {}) => {
   const dryRun = event?.dryRun === true;
   const reseed = event?.reseed === true;
-  const ref = event?.ref || defaultRef();
-  if (!ref) {
+  const configuredRef = event?.ref || defaultRef();
+  if (!configuredRef) {
     throw new Error('seed-blocks: no repo ref — set AIDLC_REPO_REF or pass {"ref":"<sha>"}');
   }
+  const ref = await resolveAidlcRepoRef(configuredRef);
   const now = new Date().toISOString();
   const seeded = [];
   const skipped = [];
@@ -279,7 +283,7 @@ export const handler = async (event = {}) => {
       await putObject(scriptRef.s3Key, script, 'text/plain');
     }
 
-    const { latest, snapshot } = buildItems(block, bodyRef, scriptRef, now);
+    const { latest, snapshot } = buildItems(block, bodyRef, scriptRef, now, ref);
     try {
       // Guard on V#latest only — its absence means the block is new. The
       // snapshot write follows unconditionally so a half-seeded block heals.
@@ -307,7 +311,7 @@ export const handler = async (event = {}) => {
   if (dryRun) {
     seeded.push(`WORKFLOW#${wf.id}`);
   } else {
-    const { meta, children } = buildWorkflowItems(wf, now);
+    const { meta, children } = buildWorkflowItems(wf, now, ref);
     try {
       await ddb.send(
         new PutCommand({

--- a/lambda/seed-blocks/index.js
+++ b/lambda/seed-blocks/index.js
@@ -10,6 +10,8 @@
 //   - the INTERNAL RUNTIME files (engine tools, hooks, protocols, conductor) to
 //     a commit-pinned S3 snapshot under aidlc-runtime/<ref>/<repo-path> — NOT
 //     editable blocks, but available for the execution layer to inject.
+//   - a body-free METHODOLOGY CATALOG under aidlc-catalogs/v1/<ref>.json so
+//     historical exports survive replacement of the mutable SYSTEM catalog.
 //
 // The pinned ref comes from the AIDLC_REPO_REF env var (set by Terraform) and
 // can be overridden per-invoke with {"ref":"<sha|tag|branch>"}.
@@ -57,6 +59,11 @@ import { SYSTEM_TENANT } from '../shared/tenant.js';
 import { fetchCoreFiles } from '../shared/repo-fetch.js';
 import { resolveAidlcRepoRef } from '../shared/aidlc-ref.js';
 import { buildFromFiles } from '../shared/block-mappers.js';
+import {
+  buildMethodologyCatalog,
+  methodologyCatalogKey,
+  writeMethodologyCatalog,
+} from '../shared/methodology-catalog.js';
 import {
   LATEST,
   blockPk,
@@ -259,6 +266,23 @@ export const handler = async (event = {}) => {
   // stale seed is worse than a clear failure the operator retries.
   const files = await fetchCoreFiles(ref);
   const { blocks, workflow, sensorScripts, runtimeFiles } = buildFromFiles(files);
+  const methodologyCatalog = buildMethodologyCatalog({
+    ref,
+    blocks,
+    workflow,
+    sensorScripts,
+  });
+
+  // Preserve the structured methodology before a reseed replaces the mutable
+  // SYSTEM catalog. Historical intents can reconstruct their exact plan from
+  // this commit-pinned snapshot without retaining duplicate Markdown bodies.
+  if (!dryRun) {
+    await writeMethodologyCatalog({
+      s3,
+      bucket: artifactsBucket(),
+      catalog: methodologyCatalog,
+    });
+  }
 
   // Reseed: clear the SYSTEM baseline first so the writes below land fresh.
   let cleared = 0;
@@ -374,6 +398,7 @@ export const handler = async (event = {}) => {
     total: blocks.length + 1,
     runtimeFiles: runtimeWritten,
     sensorScripts: sensorScripts.size,
+    methodologyCatalog: methodologyCatalogKey(ref),
     seeded,
     skipped,
   };

--- a/lambda/seed-blocks/test/seed-blocks.test.js
+++ b/lambda/seed-blocks/test/seed-blocks.test.js
@@ -12,7 +12,7 @@ import { buildFromFiles } from '../../shared/block-mappers.js';
 
 const BLOCKS_TABLE = 'blocks-test';
 const ARTIFACTS_BUCKET = 'artifacts-test';
-const REF = 'testsha';
+const REF = 'a'.repeat(40);
 
 // Mock the repo fetch so the seed reads the fixture tree, not the network.
 vi.mock('../../shared/repo-fetch.js', () => ({
@@ -108,6 +108,9 @@ describe('seed-blocks handler', () => {
   it('seeds each block as a SYSTEM V#latest + V#1 pair', async () => {
     const result = await handler({});
     expect(result.seeded).toHaveLength(TOTAL);
+    expect([...tableStore.values()].find((item) => item.blockType === 'STAGE')?.sourceRef).toBe(
+      REF,
+    );
     expect(result.skipped).toHaveLength(0);
     for (const block of FIXTURE_BLOCKS) {
       const pk = `BLOCK#SYSTEM#${block.type}#${block.id}`;
@@ -191,9 +194,10 @@ describe('seed-blocks handler', () => {
   });
 
   it('uses the ref from the event, overriding the env default', async () => {
-    const result = await handler({ ref: 'override-ref' });
-    expect(result.ref).toBe('override-ref');
-    expect(s3Store.has('aidlc-runtime/override-ref/manifest.json')).toBe(true);
+    const overrideRef = 'b'.repeat(40);
+    const result = await handler({ ref: overrideRef });
+    expect(result.ref).toBe(overrideRef);
+    expect(s3Store.has(`aidlc-runtime/${overrideRef}/manifest.json`)).toBe(true);
   });
 
   it('seeds the aidlc-v2 workflow partition (META + phases + placements)', async () => {

--- a/lambda/seed-blocks/test/seed-blocks.test.js
+++ b/lambda/seed-blocks/test/seed-blocks.test.js
@@ -177,6 +177,18 @@ describe('seed-blocks handler', () => {
     expect(manifest.sensorScripts).toContain('core/tools/aidlc-sensor-linter.ts');
   });
 
+  it('writes a body-free methodology catalog for historical exports', async () => {
+    const result = await handler({});
+    const key = `aidlc-catalogs/v1/${REF}.json`;
+    expect(result.methodologyCatalog).toBe(key);
+    const catalog = JSON.parse(s3Store.get(key));
+    expect(catalog.ref).toBe(REF);
+    expect(catalog.workflow.id).toBe('aidlc-v2');
+    expect(catalog.blocks.STAGE.length).toBeGreaterThan(0);
+    expect(catalog.blocks.STAGE[0].body).toBeUndefined();
+    expect(catalog.blocks.STAGE[0].bodyRef.s3Key).toMatch(/^blocks\/bodies\/sha256\//);
+  });
+
   it('does not seed runtime files as editable blocks', async () => {
     await handler({});
     expect(tableStore.has('BLOCK#SYSTEM#TOOL#aidlc-orchestrate|V#latest')).toBe(false);
@@ -198,6 +210,15 @@ describe('seed-blocks handler', () => {
     const result = await handler({ ref: overrideRef });
     expect(result.ref).toBe(overrideRef);
     expect(s3Store.has(`aidlc-runtime/${overrideRef}/manifest.json`)).toBe(true);
+  });
+
+  it('retains the previous commit catalog across a SYSTEM reseed', async () => {
+    const nextRef = 'b'.repeat(40);
+    await handler({ ref: REF });
+    await handler({ ref: nextRef, reseed: true });
+
+    expect(s3Store.has(`aidlc-catalogs/v1/${REF}.json`)).toBe(true);
+    expect(s3Store.has(`aidlc-catalogs/v1/${nextRef}.json`)).toBe(true);
   });
 
   it('seeds the aidlc-v2 workflow partition (META + phases + placements)', async () => {

--- a/lambda/shared/agent-command-registry.js
+++ b/lambda/shared/agent-command-registry.js
@@ -18,6 +18,7 @@ export const COMMANDS = Object.freeze({
   'run-stage-start': command('runStageStart', AGENT_AUTH_MODES.EXECUTION),
   'promote-units': command('promoteUnits'),
   'derive-artifacts': command('deriveArtifacts', AGENT_AUTH_MODES.EXECUTION),
+  'create-workflow-checkpoint': command('createWorkflowCheckpoint'),
   'record-pr': command('recordPr'),
   'record-unit-pr': command('recordUnitPr'),
   'init-lane': command('initLane'),

--- a/lambda/shared/aidlc-ref.js
+++ b/lambda/shared/aidlc-ref.js
@@ -1,0 +1,31 @@
+const COMMIT_SHA_RE = /^[0-9a-f]{40}$/i;
+const REPO = 'awslabs/aidlc-workflows';
+
+const isCommitSha = (ref) => COMMIT_SHA_RE.test(String(ref ?? '').trim());
+
+// Resolve a supported branch, tag, or SHA to the immutable commit used by an intent.
+const resolveAidlcRepoRef = async (ref, { fetchFn = fetch } = {}) => {
+  const value = String(ref ?? '').trim();
+  if (!value) throw new Error('AI-DLC repository ref is not configured');
+  if (isCommitSha(value)) return value.toLowerCase();
+
+  const response = await fetchFn(
+    `https://api.github.com/repos/${REPO}/commits/${encodeURIComponent(value)}`,
+    {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'sample-collaborative-ai-dlc',
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Unable to resolve AI-DLC repository ref "${value}" (${response.status})`);
+  }
+  const body = await response.json();
+  if (!isCommitSha(body?.sha)) {
+    throw new Error(`AI-DLC repository ref "${value}" did not resolve to a commit SHA`);
+  }
+  return body.sha.toLowerCase();
+};
+
+export { isCommitSha, resolveAidlcRepoRef };

--- a/lambda/shared/artifact-versioning.js
+++ b/lambda/shared/artifact-versioning.js
@@ -3,10 +3,11 @@ import gremlin from 'gremlin';
 import { flattenVertexMap } from './graph-rows.js';
 
 const __ = gremlin.process.statics;
-const { cardinality, t: T } = gremlin.process;
+const { cardinality, t: T, P } = gremlin.process;
 
 export const ARTIFACT_VERSION_LABEL = 'ArtifactVersion';
 export const HAS_VERSION_EDGE = 'HAS_VERSION';
+export const HAS_CHECKPOINT_VERSION_EDGE = 'HAS_CHECKPOINT_VERSION';
 export const VERSIONED_RELATIONSHIP_EDGES = [
   'PRODUCES',
   'CONSUMES',
@@ -15,6 +16,16 @@ export const VERSIONED_RELATIONSHIP_EDGES = [
   'DEPENDS_ON',
   'CITES',
 ];
+
+export class CheckpointArtifactUnavailableError extends Error {
+  constructor({ versionId, reason }) {
+    super(`workflow-checkpoint: artifact version ${versionId} is unavailable (${reason})`);
+    this.name = 'CheckpointArtifactUnavailableError';
+    this.code = 'export_checkpoint_unavailable';
+    this.versionId = versionId;
+    this.reason = reason;
+  }
+}
 
 const dimension = (value) => (value === undefined || value === null ? '' : String(value));
 
@@ -192,6 +203,173 @@ const setProperties = async (traversal, properties) => {
   await q.next();
 };
 
+const ARTIFACT_SNAPSHOT_FIELDS = [
+  'id',
+  'artifact_type',
+  'title',
+  'created_by_execution_id',
+  'created_by_stage_instance_id',
+  'section_index',
+  'unit_slug',
+  'repository',
+  'stage_attempt',
+  'generation',
+  'artifact_aliases',
+  'created_at',
+  'updated_at',
+  'stale_since',
+  'stale_reason',
+  'edited_by',
+  'edited_by_name',
+  'edited_at',
+  'edit_origin',
+  'verified_by',
+  'verified_by_name',
+  'verified_at',
+  'summary_gist',
+  'summary_claims',
+  'enrichment_model',
+  'content',
+];
+
+// Keep only artifact properties that affect native projection and provenance;
+// graph bookkeeping must not create a distinct immutable version.
+export const artifactSnapshot = (row) =>
+  Object.fromEntries(
+    ARTIFACT_SNAPSHOT_FIELDS.filter((field) => row[field] !== undefined).map((field) => [
+      field,
+      row[field],
+    ]),
+  );
+
+// Content-address the complete export-relevant artifact snapshot, not only its
+// Markdown body, so attribution or repository changes produce a new version.
+export const artifactSnapshotHash = (row) =>
+  createHash('sha256')
+    .update(JSON.stringify(artifactSnapshot(row)))
+    .digest('hex');
+
+const ensureCheckpointVersion = async ({ g, intentId, canonical, logicalKey, checkpointedAt }) => {
+  const snapshotHash = artifactSnapshotHash(canonical);
+  const versionId = `${canonical.id}:sha256:${snapshotHash}`;
+  let versionVertexId = (
+    await g
+      .V()
+      .has(ARTIFACT_VERSION_LABEL, 'id', versionId)
+      .has('intent_id', intentId)
+      .limit(1)
+      .id()
+      .toList()
+  )[0];
+  if (versionVertexId === undefined) {
+    const content = String(canonical.content ?? '');
+    await setProperties(g.addV(ARTIFACT_VERSION_LABEL), {
+      ...artifactSnapshot(canonical),
+      id: versionId,
+      artifact_id: canonical.id,
+      intent_id: intentId,
+      artifact_logical_key: logicalKey,
+      checkpointed_at: checkpointedAt,
+      content_length: Buffer.byteLength(content, 'utf8'),
+      content_type: 'text/markdown',
+      content_hash: createHash('sha256').update(content).digest('hex'),
+      snapshot_hash: snapshotHash,
+    });
+    versionVertexId = (
+      await g
+        .V()
+        .has(ARTIFACT_VERSION_LABEL, 'id', versionId)
+        .has('intent_id', intentId)
+        .limit(1)
+        .id()
+        .next()
+    ).value;
+  }
+  const linked = await g
+    .V()
+    .has('Intent', 'id', intentId)
+    .outE(HAS_CHECKPOINT_VERSION_EDGE)
+    .where(__.inV().hasId(versionVertexId))
+    .hasNext();
+  if (!linked) {
+    await g
+      .V()
+      .has('Intent', 'id', intentId)
+      .addE(HAS_CHECKPOINT_VERSION_EDGE)
+      .to(__.V(versionVertexId))
+      .next();
+  }
+  return {
+    artifactId: canonical.id,
+    logicalKey,
+    versionId,
+    snapshotHash,
+  };
+};
+
+// Materialize immutable versions for every current logical artifact head.
+// Unchanged heads reuse their existing content-addressed version.
+export const snapshotCurrentArtifactHeads = async ({
+  g,
+  intentId,
+  clock = () => new Date().toISOString(),
+}) => {
+  const heads = selectCurrentArtifactHeads(await readIntentArtifactEntries(g, intentId), intentId);
+  const checkpointedAt = clock();
+  const refs = [];
+  for (const canonical of heads.toSorted((a, b) =>
+    artifactLogicalKeyFromRow(a, intentId).localeCompare(artifactLogicalKeyFromRow(b, intentId)),
+  )) {
+    const logicalKey = artifactLogicalKeyFromRow(canonical, intentId);
+    refs.push(
+      await ensureCheckpointVersion({
+        g,
+        intentId,
+        canonical,
+        logicalKey,
+        checkpointedAt,
+      }),
+    );
+  }
+  return refs;
+};
+
+// Hydrate the exact immutable artifact versions named by a workflow checkpoint
+// and reject missing or mismatched references instead of falling back to heads.
+export const readCheckpointArtifactVersions = async ({ g, intentId, refs = [] }) => {
+  if (refs.length === 0) return [];
+  const ids = refs.map((ref) => ref.versionId);
+  const rows = await g
+    .V()
+    .hasLabel(ARTIFACT_VERSION_LABEL)
+    .has('intent_id', intentId)
+    .has('id', P.within(...ids))
+    .valueMap(true)
+    .toList();
+  const byId = new Map(
+    rows.map((row) => {
+      const flat = flattenVertexMap(row);
+      return [flat.id, flat];
+    }),
+  );
+  return refs.map((ref) => {
+    const row = byId.get(ref.versionId);
+    if (!row) {
+      throw new CheckpointArtifactUnavailableError({
+        versionId: ref.versionId,
+        reason: 'missing',
+      });
+    }
+    if (row.snapshot_hash !== ref.snapshotHash) {
+      throw new CheckpointArtifactUnavailableError({
+        versionId: ref.versionId,
+        reason: 'hash_mismatch',
+      });
+    }
+    return row;
+  });
+};
+
 const archiveOne = async ({
   g,
   intentId,
@@ -333,7 +511,9 @@ export const archiveArtifactsForStages = async ({
 
 export default {
   ARTIFACT_VERSION_LABEL,
+  CheckpointArtifactUnavailableError,
   HAS_VERSION_EDGE,
+  HAS_CHECKPOINT_VERSION_EDGE,
   VERSIONED_RELATIONSHIP_EDGES,
   artifactLogicalKey,
   artifactLogicalKeyFromRow,
@@ -343,5 +523,9 @@ export default {
   selectCurrentArtifactHeads,
   readIntentArtifactEntries,
   legacyVersionId,
+  artifactSnapshot,
+  artifactSnapshotHash,
+  snapshotCurrentArtifactHeads,
+  readCheckpointArtifactVersions,
   archiveArtifactsForStages,
 };

--- a/lambda/shared/custom-rule-versions.js
+++ b/lambda/shared/custom-rule-versions.js
@@ -1,0 +1,28 @@
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+
+// Pin mutable custom-rule keys to exact S3 object versions so later replacement
+// of the same key cannot change a checkpoint or an export already being built.
+const pinCustomRuleVersions = async ({ s3, bucket, rules = [] }) => {
+  if (rules.length === 0) return [];
+  if (!bucket) throw new Error('artifacts bucket is not configured');
+
+  return Promise.all(
+    rules.map(async (rule) => {
+      const s3Key = String(rule?.s3Key ?? '');
+      if (!s3Key) throw new Error('custom rule has no S3 key');
+      const head = await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: s3Key }));
+      if (!head.VersionId) {
+        throw new Error(`custom rule ${s3Key} has no immutable S3 version`);
+      }
+      return {
+        ...rule,
+        filename: rule.filename ?? s3Key.split('/').at(-1),
+        s3Key,
+        versionId: head.VersionId,
+      };
+    }),
+  );
+};
+
+export { pinCustomRuleVersions };
+export default pinCustomRuleVersions;

--- a/lambda/shared/distribution-archive.js
+++ b/lambda/shared/distribution-archive.js
@@ -1,0 +1,120 @@
+import zlib from 'node:zlib';
+import tar from 'tar-stream';
+
+const MAX_DISTRIBUTION_FILES = 1_000;
+const MAX_DISTRIBUTION_BYTES = 20 * 1024 * 1024;
+
+const safeDistributionPath = (value) => {
+  const path = String(value ?? '').replaceAll('\\', '/');
+  if (
+    !path ||
+    path.startsWith('/') ||
+    path.split('/').some((segment) => !segment || segment === '.' || segment === '..')
+  ) {
+    throw new Error(`distribution-archive: unsafe path ${value}`);
+  }
+  return path;
+};
+
+const buildDistributionArchive = async (files) => {
+  const entries = [...files].map(([path, body]) => [
+    safeDistributionPath(path),
+    Buffer.isBuffer(body) ? body : Buffer.from(body),
+  ]);
+  if (entries.length > MAX_DISTRIBUTION_FILES) {
+    throw new Error(`distribution-archive: exceeds ${MAX_DISTRIBUTION_FILES} files`);
+  }
+  const totalBytes = entries.reduce((sum, [, body]) => sum + body.length, 0);
+  if (totalBytes > MAX_DISTRIBUTION_BYTES) {
+    throw new Error(`distribution-archive: exceeds ${MAX_DISTRIBUTION_BYTES} bytes`);
+  }
+
+  const pack = tar.pack();
+  const gzip = zlib.createGzip({ level: 9 });
+  const chunks = [];
+  const completed = new Promise((resolve, reject) => {
+    gzip.on('data', (chunk) => chunks.push(chunk));
+    gzip.on('end', () => resolve(Buffer.concat(chunks)));
+    gzip.on('error', reject);
+    pack.on('error', reject);
+  });
+  pack.pipe(gzip);
+  for (const [path, body] of entries) {
+    await new Promise((resolve, reject) => {
+      pack.entry({ name: path, size: body.length, mode: 0o644 }, body, (error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+  }
+  pack.finalize();
+  return completed;
+};
+
+const extractDistributionArchive = async (archive) =>
+  new Promise((resolve, reject) => {
+    const files = new Map();
+    let totalBytes = 0;
+    let settled = false;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+    const extract = tar.extract();
+    extract.on('entry', (header, stream, next) => {
+      if (header.type !== 'file') {
+        stream.on('end', next);
+        stream.resume();
+        return;
+      }
+      let path;
+      try {
+        path = safeDistributionPath(header.name);
+        if (files.has(path)) throw new Error(`distribution-archive: duplicate path ${path}`);
+        if (files.size >= MAX_DISTRIBUTION_FILES) {
+          throw new Error(`distribution-archive: exceeds ${MAX_DISTRIBUTION_FILES} files`);
+        }
+      } catch (error) {
+        stream.on('end', next);
+        stream.resume();
+        fail(error);
+        return;
+      }
+      const chunks = [];
+      stream.on('data', (chunk) => {
+        totalBytes += chunk.length;
+        if (totalBytes > MAX_DISTRIBUTION_BYTES) {
+          fail(new Error(`distribution-archive: exceeds ${MAX_DISTRIBUTION_BYTES} bytes`));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      stream.on('end', () => {
+        if (!settled) files.set(path, Buffer.concat(chunks));
+        next();
+      });
+      stream.on('error', fail);
+    });
+    extract.on('finish', () => {
+      if (settled) return;
+      settled = true;
+      resolve(files);
+    });
+    extract.on('error', fail);
+
+    const gunzip = zlib.createGunzip();
+    gunzip.on('error', fail);
+    gunzip.pipe(extract);
+    gunzip.end(archive);
+  });
+
+export {
+  MAX_DISTRIBUTION_BYTES,
+  MAX_DISTRIBUTION_FILES,
+  buildDistributionArchive,
+  extractDistributionArchive,
+  safeDistributionPath,
+};
+
+export default { buildDistributionArchive, extractDistributionArchive };

--- a/lambda/shared/intent-deletion.js
+++ b/lambda/shared/intent-deletion.js
@@ -231,6 +231,15 @@ const deleteIntentCascade = async ({
   await g
     .V()
     .has('Intent', 'id', intentId)
+    .out('HAS_CHECKPOINT_VERSION')
+    .hasLabel('ArtifactVersion')
+    .has('intent_id', intentId)
+    .drop()
+    .next();
+
+  await g
+    .V()
+    .has('Intent', 'id', intentId)
     .out('CONTAINS')
     .has('intent_id', intentId)
     .hasLabel('Artifact')

--- a/lambda/shared/intent-deletion.js
+++ b/lambda/shared/intent-deletion.js
@@ -181,6 +181,7 @@ const deleteIntentCascade = async ({
   await Promise.all([
     purgeAttachmentPrefix(artifactsBucket, `intent-attachments/committed/${intentId}/`),
     purgeAttachmentPrefix(artifactsBucket, `intent-attachments/staging/${intentId}/`),
+    purgeAttachmentPrefix(artifactsBucket, `workflow-exports/${intentId}/`),
   ]);
   const discussionIds = await g
     .V()

--- a/lambda/shared/methodology-catalog.js
+++ b/lambda/shared/methodology-catalog.js
@@ -1,0 +1,236 @@
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { buildFromFiles } from './block-mappers.js';
+import { BLOCK_TYPES, buildBodyRef, buildScriptRef } from './blocks.js';
+import { buildExecutionPlan } from './v2-execution-plan.js';
+import { fetchCoreFiles } from './repo-fetch.js';
+import { isCommitSha } from './aidlc-ref.js';
+import { SYSTEM_TENANT } from './tenant.js';
+import { canonicalJson } from './workflow-checkpoint.js';
+
+const METHODOLOGY_CATALOG_SCHEMA_VERSION = 1;
+const methodologyCatalogKey = (ref) =>
+  `aidlc-catalogs/v${METHODOLOGY_CATALOG_SCHEMA_VERSION}/${ref}.json`;
+
+const keyById = (items) => Object.fromEntries(items.map((item) => [item.id, item]));
+
+const blockPin = (block) => ({
+  tenantId: block.tenantId,
+  version: Number(block.version),
+});
+
+const pinsForBlocks = (blocks) =>
+  Object.fromEntries(blocks.map((block) => [block.id, blockPin(block)]));
+
+const catalogBlock = ({ block, ref, sensorScripts }) => {
+  const { body, script: _script, ...metadata } = block;
+  const script = block.type === 'SENSOR' ? (sensorScripts.get(block.id)?.content ?? null) : null;
+  return {
+    ...metadata,
+    tenantId: SYSTEM_TENANT,
+    blockId: block.id,
+    version: 1,
+    sourceRef: ref,
+    ...(body ? { bodyRef: buildBodyRef(body) } : {}),
+    ...(script ? { scriptRef: buildScriptRef(script) } : {}),
+  };
+};
+
+const catalogWorkflow = (workflow, ref) => ({
+  ...workflow,
+  workflowVersion: 1,
+  sourceRef: ref,
+  placements: (workflow.placements ?? []).map((placement) => ({
+    ...placement,
+    stageTenant: placement.stageTenant ?? SYSTEM_TENANT,
+    pinnedVersion: placement.pinnedVersion ?? 1,
+  })),
+  ruleRefs: (workflow.ruleRefs ?? []).map((ruleRef) => ({
+    ...ruleRef,
+    ruleTenant: ruleRef.ruleTenant ?? SYSTEM_TENANT,
+  })),
+  scopeRefs: (workflow.scopeRefs ?? []).map((scopeRef) => ({
+    ...scopeRef,
+    scopeTenant: scopeRef.scopeTenant ?? SYSTEM_TENANT,
+  })),
+});
+
+/**
+ * Captures the structured SYSTEM methodology for one immutable upstream commit.
+ * Markdown bodies and scripts remain in their content-addressed S3 objects.
+ */
+const buildMethodologyCatalog = ({ ref, blocks, workflow, sensorScripts = new Map() }) => {
+  if (!isCommitSha(ref)) throw new Error('methodology-catalog: ref must be a commit SHA');
+  const grouped = Object.fromEntries(BLOCK_TYPES.map((type) => [type, []]));
+  for (const block of blocks) {
+    if (!grouped[block.type]) grouped[block.type] = [];
+    grouped[block.type].push(catalogBlock({ block, ref, sensorScripts }));
+  }
+  for (const items of Object.values(grouped)) {
+    items.sort((left, right) => left.id.localeCompare(right.id));
+  }
+  const catalog = {
+    schemaVersion: METHODOLOGY_CATALOG_SCHEMA_VERSION,
+    ref: ref.toLowerCase(),
+    workflow: catalogWorkflow(workflow, ref.toLowerCase()),
+    blocks: grouped,
+  };
+  // Match the exact JSON representation persisted to S3: omit undefined
+  // mapper fields so immutable-write comparisons are stable across reads.
+  return JSON.parse(JSON.stringify(catalog));
+};
+
+const validateMethodologyCatalog = (catalog, expectedRef) => {
+  if (
+    catalog?.schemaVersion !== METHODOLOGY_CATALOG_SCHEMA_VERSION ||
+    catalog?.ref !== expectedRef ||
+    !catalog.workflow ||
+    !catalog.blocks ||
+    !Array.isArray(catalog.blocks.STAGE)
+  ) {
+    throw new Error(`methodology-catalog: invalid catalog for ${expectedRef}`);
+  }
+  return catalog;
+};
+
+const bodyToString = async (body) => {
+  if (!body) return '';
+  if (typeof body.transformToString === 'function') return body.transformToString();
+  if (Buffer.isBuffer(body) || body instanceof Uint8Array)
+    return Buffer.from(body).toString('utf8');
+  const chunks = [];
+  for await (const chunk of body) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+const isNotFound = (error) =>
+  error?.name === 'NoSuchKey' ||
+  error?.name === 'NotFound' ||
+  error?.$metadata?.httpStatusCode === 404;
+const isPreconditionFailed = (error) =>
+  error?.name === 'PreconditionFailed' || error?.$metadata?.httpStatusCode === 412;
+
+const readMethodologyCatalog = async ({ s3, bucket, ref }) => {
+  try {
+    const result = await s3.send(
+      new GetObjectCommand({
+        Bucket: bucket,
+        Key: methodologyCatalogKey(ref),
+      }),
+    );
+    return validateMethodologyCatalog(JSON.parse(await bodyToString(result.Body)), ref);
+  } catch (error) {
+    if (isNotFound(error)) return null;
+    throw error;
+  }
+};
+
+const writeMethodologyCatalog = async ({ s3, bucket, catalog }) => {
+  try {
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: methodologyCatalogKey(catalog.ref),
+        Body: `${JSON.stringify(catalog, null, 2)}\n`,
+        ContentType: 'application/json',
+        IfNoneMatch: '*',
+      }),
+    );
+    return catalog;
+  } catch (error) {
+    if (!isPreconditionFailed(error)) throw error;
+    const existing = await readMethodologyCatalog({ s3, bucket, ref: catalog.ref });
+    if (!existing || canonicalJson(existing) !== canonicalJson(catalog)) {
+      throw new Error(`methodology-catalog: immutable catalog conflict for ${catalog.ref}`, {
+        cause: error,
+      });
+    }
+    return existing;
+  }
+};
+
+/**
+ * Loads a commit-pinned catalog, rebuilding and caching it from core/** for
+ * intents created before catalog snapshots were introduced.
+ */
+const loadOrCreateMethodologyCatalog = async ({ s3, bucket, ref }) => {
+  if (!isCommitSha(ref)) throw new Error('methodology-catalog: ref must be a commit SHA');
+  const normalizedRef = ref.toLowerCase();
+  const cached = await readMethodologyCatalog({ s3, bucket, ref: normalizedRef });
+  if (cached) return cached;
+  const files = await fetchCoreFiles(normalizedRef);
+  const { blocks, workflow, sensorScripts } = buildFromFiles(files);
+  const catalog = buildMethodologyCatalog({
+    ref: normalizedRef,
+    blocks,
+    workflow,
+    sensorScripts,
+  });
+  return writeMethodologyCatalog({ s3, bucket, catalog });
+};
+
+/**
+ * Reconstructs the same runnable plan normally assembled from SYSTEM DynamoDB
+ * rows, using the immutable catalog for the intent's pinned commit instead.
+ */
+const executionPlanFromMethodologyCatalog = ({
+  catalog,
+  workflowId,
+  workflowVersion,
+  scope,
+  skipStageIds = null,
+  composedGrid = null,
+  strict = false,
+}) => {
+  if (
+    catalog.workflow.id !== workflowId ||
+    Number(catalog.workflow.workflowVersion) !== Number(workflowVersion)
+  ) {
+    return {
+      valid: false,
+      errors: [{ code: 'workflow_not_found', workflowId, workflowVersion }],
+      plan: null,
+    };
+  }
+  const stages = catalog.blocks.STAGE ?? [];
+  const agents = catalog.blocks.AGENT ?? [];
+  const sensors = catalog.blocks.SENSOR ?? [];
+  const rules = catalog.blocks.RULE ?? [];
+  const artifacts = catalog.blocks.ARTIFACT ?? [];
+  const knowledge = catalog.blocks.KNOWLEDGE ?? [];
+  const result = buildExecutionPlan({
+    workflow: catalog.workflow,
+    scope,
+    library: {
+      stagesById: keyById(stages),
+      agentsById: keyById(agents),
+      sensorsById: keyById(sensors),
+      rulesById: keyById(rules),
+      artifactsById: keyById(artifacts),
+    },
+    skipStageIds,
+    composedGrid,
+    strict,
+  });
+  return {
+    ...result,
+    methodologySourceRefs: [catalog.ref],
+    methodologyPins: {
+      STAGE: pinsForBlocks(stages),
+      AGENT: pinsForBlocks(agents),
+      SENSOR: pinsForBlocks(sensors),
+      RULE: pinsForBlocks(rules),
+      ARTIFACT: pinsForBlocks(artifacts),
+      KNOWLEDGE: pinsForBlocks(knowledge),
+    },
+  };
+};
+
+export {
+  METHODOLOGY_CATALOG_SCHEMA_VERSION,
+  buildMethodologyCatalog,
+  executionPlanFromMethodologyCatalog,
+  loadOrCreateMethodologyCatalog,
+  methodologyCatalogKey,
+  readMethodologyCatalog,
+  writeMethodologyCatalog,
+};

--- a/lambda/shared/native-repositories.js
+++ b/lambda/shared/native-repositories.js
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto';
+
+// Reduce supported repository references and clone URLs to their canonical
+// provider identity, such as `owner/repo`.
+const repositoryId = (repository) => {
+  const value = String(repository ?? '').trim();
+  if (!value) return '';
+
+  let path = value;
+  if (value.startsWith('git@')) {
+    path = value.slice(value.indexOf(':') + 1);
+  } else if (/^(?:https?|ssh):\/\//.test(value)) {
+    try {
+      path = new URL(value).pathname;
+    } catch {
+      path = value;
+    }
+  }
+  return path.replace(/^\/+|\/+$/g, '').replace(/\.git$/i, '');
+};
+
+const repositoryBasename = (id) => id.split('/').at(-1) || 'repository';
+const directoryHash = (id) => createHash('sha256').update(id).digest('hex');
+
+// Preserve canonical repository identity while assigning stable local checkout
+// directories. Basenames stay readable unless more than one repository shares one.
+const assignNativeRepositoryDirectories = (repositories) => {
+  const normalized = repositories.map((repository) => {
+    const id = repositoryId(repository.id);
+    if (!id) throw new Error('native-export: repository identity is required');
+    return { ...repository, id, basename: repositoryBasename(id) };
+  });
+
+  const ids = new Set();
+  for (const repository of normalized) {
+    const key = repository.id.toLowerCase();
+    if (ids.has(key)) {
+      throw new Error(`native-export: duplicate repository identity ${repository.id}`);
+    }
+    ids.add(key);
+  }
+
+  const basenameCounts = new Map();
+  for (const repository of normalized) {
+    const key = repository.basename.toLowerCase();
+    basenameCounts.set(key, (basenameCounts.get(key) ?? 0) + 1);
+  }
+
+  const candidates = normalized.map(({ basename, ...repository }) => {
+    const digest = directoryHash(repository.id);
+    const duplicateBasename = basenameCounts.get(basename.toLowerCase()) > 1;
+    const directory = duplicateBasename ? repository.id.replaceAll('/', '_') : basename;
+    return { ...repository, directory, digest };
+  });
+
+  const candidateCounts = new Map();
+  for (const repository of candidates) {
+    const key = repository.directory.toLowerCase();
+    candidateCounts.set(key, (candidateCounts.get(key) ?? 0) + 1);
+  }
+
+  const projected = candidates.map(({ digest, ...repository }) => ({
+    ...repository,
+    directory:
+      candidateCounts.get(repository.directory.toLowerCase()) > 1
+        ? `${repository.directory}-${digest.slice(0, 8)}`
+        : repository.directory,
+  }));
+  if (
+    new Set(projected.map((repository) => repository.directory.toLowerCase())).size !==
+    projected.length
+  ) {
+    throw new Error('native-export: could not derive unique repository directories');
+  }
+  return projected;
+};
+
+export { assignNativeRepositoryDirectories, repositoryId };

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -65,6 +65,11 @@ const parseJsonValue = (value, field) => {
 
 const optionLetter = (index) => String.fromCharCode(65 + index);
 
+const flattenMarkdownField = (value) =>
+  String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
 const renderQuestionAnswer = ({ answer, question, index }) => {
   const parsed = parseJsonValue(answer, 'question answer');
   const entry = Array.isArray(parsed?.answers)
@@ -79,7 +84,7 @@ const renderQuestionAnswer = ({ answer, question, index }) => {
     ? entry.selectedOptions
         .filter((selectedIndex) => Number.isInteger(selectedIndex) && selectedIndex >= 0)
         .map((selectedIndex) => {
-          const label = question.options?.[selectedIndex]?.label;
+          const label = flattenMarkdownField(question.options?.[selectedIndex]?.label);
           return label ? `${optionLetter(selectedIndex)}. ${label}` : optionLetter(selectedIndex);
         })
     : [];
@@ -108,8 +113,9 @@ const renderQuestionFile = ({ stageId, tasks }) => {
           : '';
       const options = Array.isArray(question.options) ? question.options : [];
       const optionLines = options.map((option, optionIndex) => {
-        const description = option?.description ? ` — ${option.description}` : '';
-        return `${optionLetter(optionIndex)}. ${option?.label ?? ''}${description}`;
+        const label = flattenMarkdownField(option?.label);
+        const description = flattenMarkdownField(option?.description);
+        return `${optionLetter(optionIndex)}. ${label}${description ? ` — ${description}` : ''}`;
       });
       if (!options.some((option) => /^other\b/i.test(String(option?.label ?? '').trim()))) {
         optionLines.push('X. Other (please specify)');
@@ -117,7 +123,7 @@ const renderQuestionFile = ({ stageId, tasks }) => {
       const answer = renderQuestionAnswer({ answer: task.answer, question, index });
       sections.push(
         [
-          `## Q${questionNumber}. ${question.text}${multi}`,
+          `## Q${questionNumber}. ${flattenMarkdownField(question.text)}${multi}`,
           '',
           ...optionLines,
           '',
@@ -491,7 +497,7 @@ const renderState = ({
   return `# AI-DLC State Tracking
 
 ## Project Information
-- **Project**: ${intent.prompt || intent.title || intent.intentId}
+- **Project**: ${flattenMarkdownField(intent.prompt || intent.title || intent.intentId)}
 - **Project Type**: ${projectType}
 - **Scope**: ${nativeScope}
 - **Start Date**: ${intent.createdAt || now}

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -296,17 +296,24 @@ const unitStageAggregate = ({ stage, rows, unitPlan, completedUnits, activeUnit 
     unitRows.push(row);
     rowsByUnit.set(row.unitSlug, unitRows);
   }
-  const unitComplete = (unit) => {
-    if (completedUnits.has(unit.name)) return true;
+  const unitResult = (unit) => {
     const skippedStages = unitPlan.skipMatrix?.[unit.name];
-    if (Array.isArray(skippedStages) && skippedStages.includes(stage.stageId)) return true;
-    return (rowsByUnit.get(unit.name) ?? []).some((row) =>
-      ['SUCCEEDED', 'SKIPPED'].includes(row.state),
-    );
+    if (Array.isArray(skippedStages) && skippedStages.includes(stage.stageId)) return 'SKIPPED';
+    const result = stageAggregate(rowsByUnit.get(unit.name) ?? []);
+    if (result !== 'PENDING') return result;
+    return completedUnits.has(unit.name) ? 'SUCCEEDED' : result;
   };
-  if (unitPlan.units.every(unitComplete)) return 'SUCCEEDED';
+  const unitResults = unitPlan.units.map((unit) => [unit.name, unitResult(unit)]);
+  const completedUnitNames = new Set(
+    unitResults
+      .filter(([, result]) => ['SUCCEEDED', 'SKIPPED'].includes(result))
+      .map(([unitName]) => unitName),
+  );
+  if (completedUnitNames.size === unitPlan.units.length) {
+    return unitResults.some(([, result]) => result === 'SUCCEEDED') ? 'SUCCEEDED' : 'SKIPPED';
+  }
   return stageAggregate(
-    rows.filter((row) => !row.unitSlug || !unitComplete({ name: row.unitSlug })),
+    rows.filter((row) => !row.unitSlug || !completedUnitNames.has(row.unitSlug)),
   );
 };
 

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -215,6 +215,65 @@ const completedUnitTimestamp = ({ unitSlug, unitRows = [], fallback }) => {
   return timestamps.at(-1) ?? fallback;
 };
 
+const timestampMs = (value) => {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const stageTimeline = ({ intent, stages, stageRows = [], now }) => {
+  const rowsByStage = new Map();
+  for (const row of stageRows) {
+    if (!row?.stageId) continue;
+    const rows = rowsByStage.get(row.stageId) ?? [];
+    rows.push(row);
+    rowsByStage.set(row.stageId, rows);
+  }
+
+  const workflowStartedMs = timestampMs(intent.createdAt) ?? timestampMs(now) ?? 0;
+  let cursor = workflowStartedMs;
+  const timeline = [];
+
+  for (const stage of stages) {
+    if (!['x', '-'].includes(stage.marker)) continue;
+    const rows = rowsByStage.get(stage.stageId) ?? [];
+    const activeRows =
+      stage.marker === '-'
+        ? rows.filter((row) => !['SUCCEEDED', 'SKIPPED'].includes(row.state))
+        : rows;
+    const startedCandidates = activeRows
+      .flatMap((row) => [row.startedAt])
+      .map(timestampMs)
+      .filter((value) => value !== null);
+    const rawStarted = startedCandidates.length ? Math.min(...startedCandidates) : null;
+    const startedMs = Math.max(rawStarted ?? cursor + 1, cursor + 1);
+
+    let completedAt = null;
+    if (stage.marker === 'x') {
+      const completedCandidates = rows
+        .flatMap((row) => [row.completedAt, row.updatedAt])
+        .map(timestampMs)
+        .filter((value) => value !== null);
+      const rawCompleted = completedCandidates.length ? Math.max(...completedCandidates) : null;
+      const completedMs = Math.max(rawCompleted ?? startedMs + 1, startedMs + 1);
+      completedAt = new Date(completedMs).toISOString();
+      cursor = completedMs;
+    } else {
+      cursor = startedMs;
+    }
+
+    timeline.push({
+      stageId: stage.stageId,
+      phase: stage.phase,
+      agent: stage.leadAgent ?? '',
+      produces: stage.produces ?? [],
+      startedAt: new Date(startedMs).toISOString(),
+      completedAt,
+    });
+  }
+
+  return timeline;
+};
+
 const unitStageAggregate = ({ stage, rows, unitPlan, completedUnits }) => {
   if (stage.forEach !== 'unit-of-work' || stage.forEachDegraded || !unitPlan) {
     return stageAggregate(rows);
@@ -498,31 +557,71 @@ const renderAudit = ({
   intent,
   nativeScope,
   now,
+  stageTimeline: timeline = [],
   unitPlan = null,
   completedUnits = new Set(),
   unitRows = [],
 }) => {
   const startedAt = intent.createdAt || now;
+  let sequence = 0;
   const entries = [
-    renderAuditEntry({
-      heading: 'Workflow Started',
+    {
       timestamp: startedAt,
-      event: 'WORKFLOW_STARTED',
-      fields: {
-        'Workflow ID': intent.intentId,
-        Scope: nativeScope,
-        Request: 'Exported Collaborative AI-DLC checkpoint',
-      },
-    }),
+      sequence: sequence++,
+      body: renderAuditEntry({
+        heading: 'Workflow Started',
+        timestamp: startedAt,
+        event: 'WORKFLOW_STARTED',
+        fields: {
+          'Workflow ID': intent.intentId,
+          Scope: nativeScope,
+          Request: 'Exported Collaborative AI-DLC checkpoint',
+        },
+      }),
+    },
   ];
+  for (const stage of timeline) {
+    entries.push({
+      timestamp: stage.startedAt,
+      sequence: sequence++,
+      body: renderAuditEntry({
+        heading: `Stage Started: ${stage.stageId}`,
+        timestamp: stage.startedAt,
+        event: 'STAGE_STARTED',
+        fields: {
+          Stage: stage.stageId,
+          Agent: stage.agent,
+        },
+      }),
+    });
+    if (stage.completedAt) {
+      entries.push({
+        timestamp: stage.completedAt,
+        sequence: sequence++,
+        body: renderAuditEntry({
+          heading: `Stage Completed: ${stage.stageId}`,
+          timestamp: stage.completedAt,
+          event: 'STAGE_COMPLETED',
+          fields: {
+            Stage: stage.stageId,
+            Details: 'Imported from Collaborative AI-DLC checkpoint',
+            Artifacts: stage.produces.join(', ') || 'none',
+          },
+        }),
+      });
+    }
+  }
   const orderedCompletedUnits =
     unitPlan?.batches.flat().filter((unit) => completedUnits.has(unit)) ?? [];
   for (const unitSlug of orderedCompletedUnits) {
     const batchIndex = unitPlan.batches.findIndex((batch) => batch.includes(unitSlug));
-    entries.push(
-      renderAuditEntry({
+    const timestamp = completedUnitTimestamp({ unitSlug, unitRows, fallback: now });
+    entries.push({
+      timestamp,
+      sequence: sequence++,
+      body: renderAuditEntry({
         heading: 'Bolt Completed',
-        timestamp: completedUnitTimestamp({ unitSlug, unitRows, fallback: now }),
+        timestamp,
         event: 'BOLT_COMPLETED',
         fields: {
           'Bolt names': unitSlug,
@@ -530,30 +629,55 @@ const renderAudit = ({
           'Bolt slug': unitSlug,
         },
       }),
-    );
+    });
     if (
       unitSlug === unitPlan.walkingSkeleton &&
       ['gated', 'autonomous'].includes(unitPlan.autonomyMode)
     ) {
-      entries.push(
-        renderAuditEntry({
+      entries.push({
+        timestamp: completedUnitTimestamp({ unitSlug, unitRows, fallback: now }),
+        sequence: sequence++,
+        body: renderAuditEntry({
           heading: 'Autonomy Mode Set',
-          timestamp: completedUnitTimestamp({ unitSlug, unitRows, fallback: now }),
+          timestamp,
           event: 'AUTONOMY_MODE_SET',
           fields: { Mode: unitPlan.autonomyMode },
         }),
-      );
+      });
     }
   }
 
-  return `# AI-DLC Audit Log\n\n${entries.join('\n')}`;
+  entries.sort(
+    (left, right) =>
+      String(left.timestamp).localeCompare(String(right.timestamp)) ||
+      left.sequence - right.sequence,
+  );
+  return `# AI-DLC Audit Log\n\n${entries.map((entry) => entry.body).join('\n')}`;
 };
 
-const renderRuntimeGraph = ({ intent, nativeScope, unitPlan, now }) => ({
-  workflow_id: intent.intentId,
+const renderRuntimeGraph = ({
+  intent,
+  nativeScope,
+  unitPlan,
+  now,
+  stageTimeline: timeline,
+  recordRoot,
+}) => ({
+  workflow_id: intent.createdAt || now,
   scope: nativeScope,
   started_at: intent.createdAt || now,
-  stages: [],
+  stages: timeline.map((stage) => ({
+    stage_slug: stage.stageId,
+    started_at: stage.startedAt,
+    completed_at: stage.completedAt,
+    agent: stage.agent || null,
+    memory_path: `${recordRoot.path}/${stage.phase}/${stage.stageId}/memory.md`,
+    memory_entries: null,
+    memory_breakdown: null,
+    sensor_firings: [],
+    outcome: stage.completedAt ? 'approved' : 'pending',
+    learnings_captured: stage.completedAt ? { from_orchestrator: 0, from_user_addition: 0 } : null,
+  })),
   ...(unitPlan
     ? {
         bolt_dag: {
@@ -643,6 +767,12 @@ const projectNativeWorkspace = ({
   const readyUnits = dependencyReadyUnitSlugs({ unitPlan, completedUnits });
   const nextUnit = readyUnits[0] ?? remainingUnits[0] ?? null;
   const projectedStages = projectStageState({ stages, stageRows, unitPlan, unitRows });
+  const timeline = stageTimeline({
+    intent,
+    stages: projectedStages,
+    stageRows,
+    now,
+  });
   const projectType = resolveProjectType({
     intent,
     artifacts,
@@ -700,6 +830,7 @@ const projectNativeWorkspace = ({
       intent,
       nativeScope,
       now,
+      stageTimeline: timeline,
       unitPlan,
       completedUnits,
       unitRows,
@@ -737,11 +868,22 @@ const projectNativeWorkspace = ({
   if (unitPlan) {
     const dependencyPath = `${recordRoot.path}/inception/units-generation/unit-of-work-dependency.md`;
     files.set(dependencyPath, upsertUnitDagArtifact(files.get(dependencyPath), unitPlan));
-    files.set(
-      `${recordRoot.path}/runtime-graph.json`,
-      `${JSON.stringify(renderRuntimeGraph({ intent, nativeScope, unitPlan, now }), null, 2)}\n`,
-    );
   }
+  files.set(
+    `${recordRoot.path}/runtime-graph.json`,
+    `${JSON.stringify(
+      renderRuntimeGraph({
+        intent,
+        nativeScope,
+        unitPlan,
+        now,
+        stageTimeline: timeline,
+        recordRoot,
+      }),
+      null,
+      2,
+    )}\n`,
+  );
   const questionGroups = new Map();
   for (const task of humanTasks) {
     if (task?.kind !== 'question' || task.status === 'superseded') continue;

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -1,0 +1,498 @@
+import { createHash } from 'node:crypto';
+
+const PHASES = ['initialization', 'ideation', 'inception', 'construction', 'operation'];
+const PHASE_LABELS = {
+  initialization: 'INITIALIZATION PHASE',
+  ideation: 'IDEATION PHASE',
+  inception: 'INCEPTION PHASE',
+  construction: 'CONSTRUCTION PHASE',
+  operation: 'OPERATION PHASE',
+};
+
+const sha256 = (body) => createHash('sha256').update(body).digest('hex');
+
+const slugify = (value, fallback = 'intent') => {
+  const slug = String(value ?? '')
+    .normalize('NFKD')
+    .replace(/[^\p{ASCII}]/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+    .replace(/-+$/g, '');
+  return slug || fallback;
+};
+
+const recordDate = (value) => {
+  const date = new Date(value);
+  const safe = Number.isNaN(date.getTime()) ? new Date() : date;
+  return [
+    String(safe.getUTCFullYear()).slice(-2),
+    String(safe.getUTCMonth() + 1).padStart(2, '0'),
+    String(safe.getUTCDate()).padStart(2, '0'),
+  ].join('');
+};
+
+const assertSafeSegment = (value, field) => {
+  const segment = String(value ?? '');
+  if (!/^[A-Za-z0-9._-]+$/.test(segment) || segment === '.' || segment === '..') {
+    throw new Error(`native-export: ${field} must be a safe path segment`);
+  }
+  return segment;
+};
+
+const normalizePhase = (phase) => {
+  const value = String(phase ?? '').toLowerCase();
+  return PHASES.includes(value) ? value : null;
+};
+
+const titleCase = (value) =>
+  String(value ?? '')
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part[0].toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+
+const parseJsonValue = (value, field) => {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(`native-export: ${field} contains invalid JSON`);
+  }
+};
+
+const optionLetter = (index) => String.fromCharCode(65 + index);
+
+const renderQuestionAnswer = ({ answer, question, index }) => {
+  const parsed = parseJsonValue(answer, 'question answer');
+  const entry = Array.isArray(parsed?.answers)
+    ? parsed.answers[index]
+    : index === 0
+      ? parsed
+      : null;
+  if (!entry) return '';
+  if (typeof entry === 'string') return entry.trim();
+
+  const selected = Array.isArray(entry.selectedOptions)
+    ? entry.selectedOptions
+        .filter((selectedIndex) => Number.isInteger(selectedIndex) && selectedIndex >= 0)
+        .map((selectedIndex) => {
+          const label = question.options?.[selectedIndex]?.label;
+          return label ? `${optionLetter(selectedIndex)}. ${label}` : optionLetter(selectedIndex);
+        })
+    : [];
+  const freeText = typeof entry.freeText === 'string' ? entry.freeText.trim() : '';
+  if (selected.length === 0) return freeText ? `X. ${freeText}` : '';
+  return freeText ? `${selected.join(', ')}; ${freeText}` : selected.join(', ');
+};
+
+const renderQuestionFile = ({ stageId, tasks }) => {
+  const sections = [];
+  let questionNumber = 0;
+  for (const task of tasks) {
+    const questions = parseJsonValue(task.questions, `question gate ${task.humanTaskId}`);
+    if (!Array.isArray(questions) || questions.length === 0) {
+      throw new Error(`native-export: question gate ${task.humanTaskId} has no questions`);
+    }
+    for (let index = 0; index < questions.length; index += 1) {
+      const question = questions[index];
+      if (!question?.text) {
+        throw new Error(`native-export: question gate ${task.humanTaskId} has an invalid question`);
+      }
+      questionNumber += 1;
+      const multi =
+        question.type === 'multi' && !String(question.text).includes('select all that apply')
+          ? ' (select all that apply)'
+          : '';
+      const options = Array.isArray(question.options) ? question.options : [];
+      const optionLines = options.map((option, optionIndex) => {
+        const description = option?.description ? ` — ${option.description}` : '';
+        return `${optionLetter(optionIndex)}. ${option?.label ?? ''}${description}`;
+      });
+      if (!options.some((option) => /^other\b/i.test(String(option?.label ?? '').trim()))) {
+        optionLines.push('X. Other (please specify)');
+      }
+      const answer = renderQuestionAnswer({ answer: task.answer, question, index });
+      sections.push(
+        [
+          `## Q${questionNumber}. ${question.text}${multi}`,
+          '',
+          ...optionLines,
+          '',
+          answer ? `[Answer]: ${answer}` : '[Answer]:',
+        ].join('\n'),
+      );
+    }
+  }
+  return `# ${titleCase(stageId)} Questions\n\n${sections.join('\n\n')}\n`;
+};
+
+const stageAggregate = (rows) => {
+  if (rows.length === 0) return 'PENDING';
+  if (rows.every((row) => row.state === 'SUCCEEDED')) return 'SUCCEEDED';
+  if (rows.every((row) => row.state === 'SKIPPED')) return 'SKIPPED';
+  if (rows.some((row) => row.state === 'WAITING_FOR_HUMAN')) return 'WAITING_FOR_HUMAN';
+  if (rows.some((row) => row.state === 'RUNNING')) return 'RUNNING';
+  if (rows.some((row) => row.state === 'FAILED')) return 'FAILED';
+  return 'PENDING';
+};
+
+const projectStageState = ({ stages, stageRows }) => {
+  const rowsByStage = new Map();
+  for (const row of stageRows ?? []) {
+    if (!row?.stageId) continue;
+    const list = rowsByStage.get(row.stageId) ?? [];
+    list.push(row);
+    rowsByStage.set(row.stageId, list);
+  }
+
+  const projected = stages.map((stage) => ({
+    ...stage,
+    phase: normalizePhase(stage.phase),
+    cloudState: stage.excluded ? 'SKIPPED' : stageAggregate(rowsByStage.get(stage.stageId) ?? []),
+  }));
+  const firstUnfinished = projected.findIndex(
+    (stage) => !['SUCCEEDED', 'SKIPPED'].includes(stage.cloudState),
+  );
+  return projected.map((stage, index) => ({
+    ...stage,
+    marker:
+      stage.cloudState === 'SUCCEEDED'
+        ? 'x'
+        : stage.cloudState === 'SKIPPED'
+          ? 'S'
+          : index === firstUnfinished
+            ? '-'
+            : ' ',
+  }));
+};
+
+const phaseStatus = (phase, stages) => {
+  const phaseStages = stages.filter((stage) => stage.phase === phase);
+  if (phaseStages.every((stage) => stage.marker === 'S')) {
+    return 'Skipped';
+  }
+  if (phaseStages.every((stage) => ['x', 'S'].includes(stage.marker))) return 'Verified';
+  if (phaseStages.some((stage) => ['-', '?', 'R'].includes(stage.marker))) return 'Active';
+  return 'Pending';
+};
+
+const renderState = ({ intent, stages, now, repositories, nativeScope }) => {
+  const activeIndex = stages.findIndex((stage) => stage.marker === '-');
+  const current = activeIndex >= 0 ? stages[activeIndex] : null;
+  const next =
+    activeIndex >= 0
+      ? stages.slice(activeIndex + 1).find((stage) => !['x', 'S'].includes(stage.marker))
+      : null;
+  const lastCompleted = stages.toReversed().find((stage) => stage.marker === 'x');
+  const completed = stages.filter((stage) => stage.marker === 'x').length;
+  const execute = stages.filter((stage) => stage.marker !== 'S');
+  const skipped = stages.filter((stage) => stage.marker === 'S');
+  const phaseLines = PHASES.map(
+    (phase) => `- **${phase[0].toUpperCase()}${phase.slice(1)}**: ${phaseStatus(phase, stages)}`,
+  ).join('\n');
+  const stageLines = PHASES.map((phase) => {
+    const phaseStages = stages.filter((stage) => stage.phase === phase);
+    if (phaseStages.length === 0) return '';
+    const lines = [`### ${PHASE_LABELS[phase]}`];
+    if (phase === 'construction') lines.push('Per unit: exported cloud units');
+    for (const stage of phaseStages) {
+      lines.push(
+        `- [${stage.marker}] ${stage.stageId} — ${stage.marker === 'S' ? 'SKIP' : 'EXECUTE'}`,
+      );
+    }
+    return lines.join('\n');
+  })
+    .filter(Boolean)
+    .join('\n\n');
+  const status = current ? 'Running' : 'Completed';
+  const lifecycle = current?.phase?.toUpperCase() ?? 'COMPLETED';
+  const pendingArtifacts = current?.produces?.length ? current.produces.join(', ') : 'none';
+
+  return `# AI-DLC State Tracking
+
+## Project Information
+- **Project**: ${intent.prompt || intent.title || intent.intentId}
+- **Project Type**: ${repositories.length > 0 ? 'Brownfield' : 'Greenfield'}
+- **Scope**: ${nativeScope}
+- **Start Date**: ${intent.createdAt || now}
+- **State Version**: 7
+- **Active Agent**: ${current?.leadAgent || ''}
+- **Worktree Path**:
+- **Bolt Refs**:
+- **Practices Affirmed Timestamp**:
+
+## Scope Configuration
+- **Stages to Execute**: ${execute.map((stage) => stage.number || stage.stageId).join(', ') || 'none'}
+- **Stages to Skip**: ${skipped.map((stage) => stage.number || stage.stageId).join(', ') || 'none'}
+- **Depth**: Standard
+- **Test Strategy**: Standard
+- **Review Override**:
+
+## Workspace State
+- **Project Root**: .
+- **Languages**:
+- **Frameworks**:
+- **Build System**:
+
+## Execution Plan Summary
+- **Total Stages**: ${execute.length}
+- **Completed**: ${completed}
+- **In Progress**: ${current?.stageId || 'none'}
+
+## Runtime State
+- **Revision Count**: 0
+
+## Phase Progress
+<!-- Status values: Pending, Active, Verified, Skipped -->
+
+${phaseLines}
+
+## Stage Progress
+<!-- Checkbox states: [ ] not started, [-] in progress, [?] awaiting approval (gate open), [R] revising (user rejected gate), [x] completed, [S] skipped via --stage/--phase jump -->
+
+${stageLines}
+
+## Current Status
+- **Lifecycle Phase**: ${lifecycle}
+- **Current Stage**: ${current?.stageId || 'none'}
+- **Next Stage**: ${next?.stageId || 'none'}
+- **Status**: ${status}
+- **Last Updated**: ${now}
+
+## Session Resume Point
+- **Last Completed Stage**: ${lastCompleted?.stageId || 'none'}
+- **Next Action**: ${current ? `Execute ${current.stageId}` : 'Workflow complete'}
+- **Pending Artifacts**: ${pendingArtifacts}
+`;
+};
+
+const artifactPath = ({
+  artifact,
+  recordRoot,
+  stageById,
+  repositories,
+  workspaceLayout = 'spaces',
+}) => {
+  const type = assertSafeSegment(slugify(artifact.artifactType || artifact.type), 'artifact type');
+  const stage = stageById.get(artifact.stageId);
+  const phase = normalizePhase(artifact.phase || stage?.phase);
+  if (!phase || !artifact.stageId) {
+    throw new Error(`native-export: artifact ${artifact.id ?? type} has no native producer stage`);
+  }
+  const stageId = assertSafeSegment(artifact.stageId, 'artifact stage');
+  if (stageId === 'reverse-engineering') {
+    if (workspaceLayout === 'flat') {
+      return `${recordRoot.path}/inception/reverse-engineering/${type}.md`;
+    }
+    const repo = artifact.repository || (repositories.length === 1 ? repositories[0].name : null);
+    if (!repo) {
+      throw new Error(`native-export: reverse-engineering artifact ${type} has no repository`);
+    }
+    return `aidlc/spaces/${recordRoot.space}/codekb/${assertSafeSegment(repo, 'repository')}/${type}.md`;
+  }
+  if (phase === 'construction' && artifact.unitSlug) {
+    return `${recordRoot.path}/construction/${assertSafeSegment(artifact.unitSlug, 'unit')}/${stageId}/${type}.md`;
+  }
+  return `${recordRoot.path}/${phase}/${stageId}/${type}.md`;
+};
+
+const projectNativeWorkspace = ({
+  intent,
+  stages,
+  stageRows = [],
+  artifacts = [],
+  humanTasks = [],
+  repositories = [],
+  space = 'default',
+  now = new Date().toISOString(),
+  upstreamRef,
+  harness,
+  workspaceLayout = 'spaces',
+  nativeScope = intent?.scope,
+}) => {
+  if (!intent?.intentId) throw new Error('native-export: intentId is required');
+  if (!nativeScope) throw new Error('native-export: native scope is required');
+  if (!Array.isArray(stages) || stages.length === 0) {
+    throw new Error('native-export: at least one workflow stage is required');
+  }
+  const safeSpace = assertSafeSegment(slugify(space, 'default'), 'space');
+  if (!['flat', 'spaces'].includes(workspaceLayout)) {
+    throw new Error(`native-export: unsupported workspace layout ${workspaceLayout}`);
+  }
+  const label = slugify(intent.title || intent.prompt || intent.intentId);
+  const recordDir = `${recordDate(intent.createdAt || now)}-${label}`;
+  const recordRoot =
+    workspaceLayout === 'flat'
+      ? { space: null, path: 'aidlc-docs' }
+      : {
+          space: safeSpace,
+          path: `aidlc/spaces/${safeSpace}/intents/${recordDir}`,
+        };
+  const normalizedRepos = repositories.map((repo) => ({
+    name: assertSafeSegment(repo.name, 'repository'),
+    url: String(repo.url || ''),
+    branch: String(repo.branch || intent.branch || ''),
+  }));
+  if (workspaceLayout === 'flat' && normalizedRepos.length > 1) {
+    throw new Error('native-export: legacy flat workspaces do not support multiple repositories');
+  }
+  const projectedStages = projectStageState({ stages, stageRows });
+  const stageById = new Map(projectedStages.map((stage) => [stage.stageId, stage]));
+  const stageByInstance = new Map(
+    stageRows
+      .filter((stage) => stage?.stageInstanceId)
+      .map((stage) => [stage.stageInstanceId, stage]),
+  );
+  const files = new Map();
+  if (workspaceLayout === 'spaces') {
+    files.set('aidlc/active-space', `${safeSpace}\n`);
+    files.set(`aidlc/spaces/${safeSpace}/intents/active-intent`, `${recordDir}\n`);
+    files.set(
+      `aidlc/spaces/${safeSpace}/intents/intents.json`,
+      `${JSON.stringify(
+        [
+          {
+            uuid: intent.intentId,
+            slug: label,
+            dirName: recordDir,
+            scope: nativeScope,
+            ...(normalizedRepos.length ? { repos: normalizedRepos.map((repo) => repo.name) } : {}),
+            status: projectedStages.some((stage) => stage.marker === '-')
+              ? 'in-flight'
+              : 'complete',
+          },
+        ],
+        null,
+        2,
+      )}\n`,
+    );
+  }
+  files.set(
+    `${recordRoot.path}/aidlc-state.md`,
+    renderState({
+      intent,
+      stages: projectedStages,
+      now,
+      repositories: normalizedRepos,
+      nativeScope,
+    }),
+  );
+  if (workspaceLayout === 'spaces' && normalizedRepos.length > 0) {
+    const org = normalizedRepos[0].url.match(/[:/]([^/:]+)\/[^/]+(?:\.git)?$/)?.[1] || 'workspace';
+    files.set(
+      'repos.json',
+      `${JSON.stringify(
+        {
+          org,
+          repos: normalizedRepos.map((repo) => ({
+            name: repo.name,
+            ...(repo.branch ? { branch: repo.branch } : {}),
+            ...(repo.url ? { url: repo.url } : {}),
+          })),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+  for (const artifact of artifacts) {
+    const path = artifactPath({
+      artifact,
+      recordRoot,
+      stageById,
+      repositories: normalizedRepos,
+      workspaceLayout,
+    });
+    if (files.has(path)) throw new Error(`native-export: duplicate output path ${path}`);
+    files.set(path, String(artifact.content ?? ''));
+  }
+  const questionGroups = new Map();
+  for (const task of humanTasks) {
+    if (task?.kind !== 'question' || task.status === 'superseded') continue;
+    const producer = stageByInstance.get(task.stageInstanceId);
+    const stageId = task.stageId ?? producer?.stageId;
+    const stage = stageById.get(stageId);
+    const phase = normalizePhase(task.phase ?? producer?.phase ?? stage?.phase);
+    if (!stageId || !phase) {
+      throw new Error(
+        `native-export: question gate ${task.humanTaskId ?? 'unknown'} has no native producer stage`,
+      );
+    }
+    const syntheticArtifact = {
+      id: task.humanTaskId,
+      artifactType: `${stageId}-questions`,
+      stageId,
+      phase,
+      unitSlug: task.unitSlug ?? producer?.unitSlug ?? null,
+    };
+    const path = artifactPath({
+      artifact: syntheticArtifact,
+      recordRoot,
+      stageById,
+      repositories: normalizedRepos,
+      workspaceLayout,
+    });
+    if (files.has(path)) continue;
+    const tasks = questionGroups.get(path) ?? [];
+    tasks.push(task);
+    questionGroups.set(path, tasks);
+  }
+  for (const [path, tasks] of questionGroups) {
+    tasks.sort(
+      (left, right) =>
+        String(left.createdAt ?? '').localeCompare(String(right.createdAt ?? '')) ||
+        String(left.humanTaskId ?? '').localeCompare(String(right.humanTaskId ?? '')),
+    );
+    const producer = stageByInstance.get(tasks[0].stageInstanceId);
+    files.set(
+      path,
+      renderQuestionFile({
+        stageId: tasks[0].stageId ?? producer?.stageId,
+        tasks,
+      }),
+    );
+  }
+  const manifest = {
+    schemaVersion: 1,
+    mode: 'workflow-continuation',
+    exportedAt: now,
+    source: {
+      projectId: intent.projectId,
+      intentId: intent.intentId,
+      workflowId: intent.workflowId,
+      workflowVersion: intent.workflowVersion,
+      scope: intent.scope,
+    },
+    native: {
+      upstreamRef,
+      harness,
+      workspaceLayout,
+      scope: nativeScope,
+      ...(workspaceLayout === 'spaces' ? { space: safeSpace, recordDir } : {}),
+    },
+    repositories: normalizedRepos,
+    files: [...files]
+      .map(([path, body]) => ({
+        path,
+        bytes: Buffer.byteLength(body),
+        sha256: sha256(body),
+      }))
+      .toSorted((a, b) => a.path.localeCompare(b.path)),
+  };
+  files.set('export-manifest.json', `${JSON.stringify(manifest, null, 2)}\n`);
+  return { files, manifest, recordDir, stages: projectedStages };
+};
+
+export {
+  PHASES,
+  artifactPath,
+  projectNativeWorkspace,
+  projectStageState,
+  recordDate,
+  renderQuestionFile,
+  slugify,
+};
+
+export default { projectNativeWorkspace };

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -274,9 +274,20 @@ const stageTimeline = ({ intent, stages, stageRows = [], now }) => {
   return timeline;
 };
 
-const unitStageAggregate = ({ stage, rows, unitPlan, completedUnits }) => {
+const unitStageAggregate = ({ stage, rows, unitPlan, completedUnits, activeUnit }) => {
   if (stage.forEach !== 'unit-of-work' || stage.forEachDegraded || !unitPlan) {
     return stageAggregate(rows);
+  }
+  if (activeUnit) {
+    const activeUnitPlan = unitPlan.units.find((unit) => unit.name === activeUnit);
+    if (
+      completedUnits.has(activeUnit) ||
+      activeUnitPlan == null ||
+      unitPlan.skipMatrix?.[activeUnit]?.includes(stage.stageId)
+    ) {
+      return 'SKIPPED';
+    }
+    return stageAggregate(rows.filter((row) => row.unitSlug === activeUnit));
   }
   const rowsByUnit = new Map();
   for (const row of rows) {
@@ -299,7 +310,13 @@ const unitStageAggregate = ({ stage, rows, unitPlan, completedUnits }) => {
   );
 };
 
-const projectStageState = ({ stages, stageRows, unitPlan = null, unitRows = [] }) => {
+const projectStageState = ({
+  stages,
+  stageRows,
+  unitPlan = null,
+  unitRows = [],
+  activeUnit = null,
+}) => {
   const rowsByStage = new Map();
   for (const row of stageRows ?? []) {
     if (!row?.stageId) continue;
@@ -319,6 +336,7 @@ const projectStageState = ({ stages, stageRows, unitPlan = null, unitRows = [] }
           rows: rowsByStage.get(stage.stageId) ?? [],
           unitPlan,
           completedUnits,
+          activeUnit,
         }),
   }));
   const firstUnfinished = projected.findIndex(
@@ -438,11 +456,25 @@ const renderState = ({
         stage.phase === 'construction' && stage.forEach === 'unit-of-work' && stage.marker !== 'S',
     )
     .at(-1);
+  const activeUnitLastCompletedStage =
+    activeIndex >= 0
+      ? stages
+          .slice(0, activeIndex)
+          .toReversed()
+          .find(
+            (stage) =>
+              stage.phase === 'construction' &&
+              stage.forEach === 'unit-of-work' &&
+              stage.marker === 'x',
+          )
+      : null;
   const constructionResume = current?.phase === 'construction' && nextUnit;
   const resumeLastCompleted =
-    constructionResume && lastCompletedUnit && lastCompletedUnitStage
-      ? `${lastCompletedUnitStage.stageId} for unit ${lastCompletedUnit}`
-      : lastCompleted?.stageId || 'none';
+    constructionResume && activeUnitLastCompletedStage
+      ? `${activeUnitLastCompletedStage.stageId} for unit ${nextUnit}`
+      : constructionResume && lastCompletedUnit && lastCompletedUnitStage
+        ? `${lastCompletedUnitStage.stageId} for unit ${lastCompletedUnit}`
+        : lastCompleted?.stageId || 'none';
   const resumeNextAction = current
     ? constructionResume
       ? `Execute ${current.stageId} for unit ${nextUnit}`
@@ -766,7 +798,13 @@ const projectNativeWorkspace = ({
   const remainingUnits = unitOrder.filter((unit) => !completedUnits.has(unit));
   const readyUnits = dependencyReadyUnitSlugs({ unitPlan, completedUnits });
   const nextUnit = readyUnits[0] ?? remainingUnits[0] ?? null;
-  const projectedStages = projectStageState({ stages, stageRows, unitPlan, unitRows });
+  const projectedStages = projectStageState({
+    stages,
+    stageRows,
+    unitPlan,
+    unitRows,
+    activeUnit: nextUnit,
+  });
   const timeline = stageTimeline({
     intent,
     stages: projectedStages,

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -695,7 +695,7 @@ const renderRuntimeGraph = ({
   stageTimeline: timeline,
   recordRoot,
 }) => ({
-  workflow_id: intent.createdAt || now,
+  workflow_id: intent.intentId,
   scope: nativeScope,
   started_at: intent.createdAt || now,
   stages: timeline.map((stage) => ({

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -738,11 +738,23 @@ const artifactPath = ({
     if (workspaceLayout === 'flat') {
       return `${recordRoot.path}/inception/reverse-engineering/${type}.md`;
     }
-    const repo = artifact.repository || (repositories.length === 1 ? repositories[0].name : null);
-    if (!repo) {
+    const repositoryRef =
+      artifact.repository || (repositories.length === 1 ? repositories[0].id : null);
+    const matches = repositories.filter(
+      (repository) =>
+        repository.id === repositoryRef ||
+        repository.directory === repositoryRef ||
+        repository.id.split('/').at(-1) === repositoryRef,
+    );
+    if (matches.length === 0) {
       throw new Error(`native-export: reverse-engineering artifact ${type} has no repository`);
     }
-    return `aidlc/spaces/${recordRoot.space}/codekb/${assertSafeSegment(repo, 'repository')}/${type}.md`;
+    if (matches.length > 1) {
+      throw new Error(
+        `native-export: reverse-engineering artifact ${type} has an ambiguous repository`,
+      );
+    }
+    return `aidlc/spaces/${recordRoot.space}/codekb/${matches[0].directory}/${type}.md`;
   }
   if (phase === 'construction' && artifact.unitSlug) {
     return `${recordRoot.path}/construction/${assertSafeSegment(artifact.unitSlug, 'unit')}/${stageId}/${type}.md`;
@@ -785,7 +797,8 @@ const projectNativeWorkspace = ({
           path: `aidlc/spaces/${safeSpace}/intents/${recordDir}`,
         };
   const normalizedRepos = repositories.map((repo) => ({
-    name: assertSafeSegment(repo.name, 'repository'),
+    id: String(repo.id || ''),
+    directory: assertSafeSegment(repo.directory, 'repository directory'),
     url: String(repo.url || ''),
     branch: String(repo.branch || intent.branch || ''),
   }));
@@ -834,7 +847,9 @@ const projectNativeWorkspace = ({
             slug: label,
             dirName: recordDir,
             scope: nativeScope,
-            ...(normalizedRepos.length ? { repos: normalizedRepos.map((repo) => repo.name) } : {}),
+            ...(normalizedRepos.length
+              ? { repos: normalizedRepos.map((repo) => repo.directory) }
+              : {}),
             status: projectedStages.some((stage) => stage.marker === '-')
               ? 'in-flight'
               : 'complete',
@@ -882,7 +897,7 @@ const projectNativeWorkspace = ({
         {
           org,
           repos: normalizedRepos.map((repo) => ({
-            name: repo.name,
+            name: repo.directory,
             ...(repo.branch ? { branch: repo.branch } : {}),
             ...(repo.url ? { url: repo.url } : {}),
           })),

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { parseBoltDag } from './v2-sensor-contract.js';
 
 const PHASES = ['initialization', 'ideation', 'inception', 'construction', 'operation'];
+const ACTIVE_STAGE_MARKERS = new Set(['-', '?', 'R']);
 const PHASE_LABELS = {
   initialization: 'INITIALIZATION PHASE',
   ideation: 'IDEATION PHASE',
@@ -172,6 +173,40 @@ const normalizedUnitPlan = (unitPlan) => {
   };
 };
 
+const projectionWarnings = ({ unitPlan, humanTasks = [] }) => {
+  const warnings = [];
+  const unitsWithKinds = (unitPlan?.units ?? [])
+    .filter((unit) => unit?.kind)
+    .map((unit) => unit.slug ?? unit.name)
+    .filter(Boolean);
+  if (unitsWithKinds.length > 0) {
+    warnings.push(
+      `Unit kinds are not represented in the native Bolt DAG for: ${unitsWithKinds.join(', ')}.`,
+    );
+  }
+  const skippedUnits = Object.entries(unitPlan?.skipMatrix ?? {})
+    .filter(([, stages]) => Array.isArray(stages) && stages.length > 0)
+    .map(([unit]) => unit);
+  if (skippedUnits.length > 0) {
+    warnings.push(
+      `Per-unit stage skips affect exported progress but are not preserved as native continuation rules for: ${skippedUnits.join(', ')}.`,
+    );
+  }
+  const omittedGateKinds = [
+    ...new Set(
+      humanTasks
+        .filter((task) => task?.kind && task.kind !== 'question' && task.status !== 'superseded')
+        .map((task) => task.kind),
+    ),
+  ].toSorted();
+  if (omittedGateKinds.length > 0) {
+    warnings.push(
+      `Non-question workflow gates are not represented as native question artifacts: ${omittedGateKinds.join(', ')}.`,
+    );
+  }
+  return warnings;
+};
+
 const normalizedUnitRows = (unitRows = []) => {
   const rowsByUnit = new Map();
   for (const row of unitRows) {
@@ -240,12 +275,11 @@ const stageTimeline = ({ intent, stages, stageRows = [], now }) => {
   const timeline = [];
 
   for (const stage of stages) {
-    if (!['x', '-'].includes(stage.marker)) continue;
+    if (stage.marker !== 'x' && !ACTIVE_STAGE_MARKERS.has(stage.marker)) continue;
     const rows = rowsByStage.get(stage.stageId) ?? [];
-    const activeRows =
-      stage.marker === '-'
-        ? rows.filter((row) => !['SUCCEEDED', 'SKIPPED'].includes(row.state))
-        : rows;
+    const activeRows = ACTIVE_STAGE_MARKERS.has(stage.marker)
+      ? rows.filter((row) => !['SUCCEEDED', 'SKIPPED'].includes(row.state))
+      : rows;
     const startedCandidates = activeRows
       .flatMap((row) => [row.startedAt])
       .map(timestampMs)
@@ -329,6 +363,7 @@ const projectStageState = ({
   unitPlan = null,
   unitRows = [],
   activeUnit = null,
+  awaitingGateStageIds = new Set(),
 }) => {
   const rowsByStage = new Map();
   for (const row of stageRows ?? []) {
@@ -339,32 +374,41 @@ const projectStageState = ({
   }
   const completedUnits = completedUnitSlugs({ unitPlan, unitRows });
 
-  const projected = stages.map((stage) => ({
-    ...stage,
-    phase: normalizePhase(stage.phase),
-    cloudState: stage.excluded
-      ? 'SKIPPED'
-      : unitStageAggregate({
-          stage,
-          rows: rowsByStage.get(stage.stageId) ?? [],
-          unitPlan,
-          completedUnits,
-          activeUnit,
-        }),
-  }));
+  const projected = stages.map((stage) => {
+    const phase = normalizePhase(stage.phase);
+    if (!phase) {
+      throw new Error(
+        `native-export: stage ${stage.stageId ?? 'unknown'} has unsupported phase ${stage.phase ?? '<missing>'}`,
+      );
+    }
+    return {
+      ...stage,
+      phase,
+      cloudState: stage.excluded
+        ? 'SKIPPED'
+        : unitStageAggregate({
+            stage,
+            rows: rowsByStage.get(stage.stageId) ?? [],
+            unitPlan,
+            completedUnits,
+            activeUnit,
+          }),
+    };
+  });
   const firstUnfinished = projected.findIndex(
     (stage) => !['SUCCEEDED', 'SKIPPED'].includes(stage.cloudState),
   );
+  const markerFor = (stage, index) => {
+    if (stage.cloudState === 'SUCCEEDED') return 'x';
+    if (stage.cloudState === 'SKIPPED') return 'S';
+    if (stage.cloudState === 'WAITING_FOR_HUMAN' && awaitingGateStageIds.has(stage.stageId)) {
+      return '?';
+    }
+    return index === firstUnfinished ? '-' : ' ';
+  };
   return projected.map((stage, index) => ({
     ...stage,
-    marker:
-      stage.cloudState === 'SUCCEEDED'
-        ? 'x'
-        : stage.cloudState === 'SKIPPED'
-          ? 'S'
-          : index === firstUnfinished
-            ? '-'
-            : ' ',
+    marker: markerFor(stage, index),
   }));
 };
 
@@ -430,7 +474,7 @@ const renderState = ({
   completedUnits,
   nextUnit,
 }) => {
-  const activeIndex = stages.findIndex((stage) => stage.marker === '-');
+  const activeIndex = stages.findIndex((stage) => ACTIVE_STAGE_MARKERS.has(stage.marker));
   const current = activeIndex >= 0 ? stages[activeIndex] : null;
   const next =
     activeIndex >= 0
@@ -489,9 +533,13 @@ const renderState = ({
         ? `${lastCompletedUnitStage.stageId} for unit ${lastCompletedUnit}`
         : lastCompleted?.stageId || 'none';
   const resumeNextAction = current
-    ? constructionResume
-      ? `Execute ${current.stageId} for unit ${nextUnit}`
-      : `Execute ${current.stageId}`
+    ? current.marker === '?'
+      ? `Await approval for ${current.stageId}`
+      : current.marker === 'R'
+        ? `Revise ${current.stageId}`
+        : constructionResume
+          ? `Execute ${current.stageId} for unit ${nextUnit}`
+          : `Execute ${current.stageId}`
     : 'Workflow complete';
 
   return `# AI-DLC State Tracking
@@ -740,7 +788,11 @@ const artifactPath = ({
   repositories,
   workspaceLayout = 'spaces',
 }) => {
-  const type = assertSafeSegment(slugify(artifact.artifactType || artifact.type), 'artifact type');
+  const rawType = artifact.artifactType || artifact.type;
+  if (!rawType) {
+    throw new Error(`native-export: artifact ${artifact.id ?? 'unknown'} has no artifact type`);
+  }
+  const type = assertSafeSegment(slugify(rawType), 'artifact type');
   const stage = stageById.get(artifact.stageId);
   const phase = normalizePhase(artifact.phase || stage?.phase);
   if (!phase || !artifact.stageId) {
@@ -819,17 +871,30 @@ const projectNativeWorkspace = ({
     throw new Error('native-export: legacy flat workspaces do not support multiple repositories');
   }
   const unitPlan = normalizedUnitPlan(rawUnitPlan);
+  const warnings = projectionWarnings({ unitPlan: rawUnitPlan, humanTasks });
   const completedUnits = completedUnitSlugs({ unitPlan, unitRows });
   const unitOrder = unitPlan?.batches.flat() ?? [];
   const remainingUnits = unitOrder.filter((unit) => !completedUnits.has(unit));
   const readyUnits = dependencyReadyUnitSlugs({ unitPlan, completedUnits });
   const nextUnit = readyUnits[0] ?? remainingUnits[0] ?? null;
+  const stageIdByInstance = new Map(
+    stageRows
+      .filter((stage) => stage?.stageInstanceId)
+      .map((stage) => [stage.stageInstanceId, stage.stageId]),
+  );
+  const awaitingGateStageIds = new Set(
+    humanTasks
+      .filter((task) => task?.status === 'pending')
+      .map((task) => task.stageId ?? stageIdByInstance.get(task.stageInstanceId))
+      .filter(Boolean),
+  );
   const projectedStages = projectStageState({
     stages,
     stageRows,
     unitPlan,
     unitRows,
     activeUnit: nextUnit,
+    awaitingGateStageIds,
   });
   const timeline = stageTimeline({
     intent,
@@ -863,7 +928,7 @@ const projectNativeWorkspace = ({
             ...(normalizedRepos.length
               ? { repos: normalizedRepos.map((repo) => repo.directory) }
               : {}),
-            status: projectedStages.some((stage) => stage.marker === '-')
+            status: projectedStages.some((stage) => ACTIVE_STAGE_MARKERS.has(stage.marker))
               ? 'in-flight'
               : 'complete',
           },
@@ -1016,6 +1081,7 @@ const projectNativeWorkspace = ({
       ...(workspaceLayout === 'spaces' ? { space: safeSpace, recordDir } : {}),
     },
     repositories: normalizedRepos,
+    warnings,
     ...(unitPlan
       ? {
           construction: {
@@ -1040,7 +1106,7 @@ const projectNativeWorkspace = ({
       .toSorted((a, b) => a.path.localeCompare(b.path)),
   };
   files.set('export-manifest.json', `${JSON.stringify(manifest, null, 2)}\n`);
-  return { files, manifest, recordDir, stages: projectedStages };
+  return { files, manifest, recordDir, stages: projectedStages, warnings };
 };
 
 export {

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { parseBoltDag } from './v2-sensor-contract.js';
 
 const PHASES = ['initialization', 'ideation', 'inception', 'construction', 'operation'];
 const PHASE_LABELS = {
@@ -138,7 +139,108 @@ const stageAggregate = (rows) => {
   return 'PENDING';
 };
 
-const projectStageState = ({ stages, stageRows }) => {
+const normalizedUnitPlan = (unitPlan) => {
+  if (!unitPlan || !Array.isArray(unitPlan.units) || unitPlan.units.length === 0) return null;
+  const hasRecordedAutonomyMode = ['gated', 'autonomous'].includes(unitPlan.autonomyMode);
+  const units = unitPlan.units.map((unit) => ({
+    name: assertSafeSegment(unit.slug ?? unit.name, 'unit'),
+    depends_on: (unit.dependsOn ?? unit.depends_on ?? []).map((dependency) =>
+      assertSafeSegment(dependency, 'unit dependency'),
+    ),
+  }));
+  const dagBody = renderUnitDagBlock(units);
+  const parsed = parseBoltDag(`\`\`\`yaml\n${dagBody}\n\`\`\`\n`);
+  if (!parsed.ok) {
+    throw new Error(`native-export: unit plan is invalid: ${parsed.detail}`);
+  }
+  return {
+    units: parsed.units.map((unit) => ({
+      name: unit.name,
+      depends_on: unit.depends_on,
+    })),
+    batches: parsed.batches,
+    skipMatrix: unitPlan.skipMatrix ?? {},
+    walkingSkeleton: unitPlan.walkingSkeleton ?? null,
+    autonomyMode: hasRecordedAutonomyMode ? unitPlan.autonomyMode : 'gated',
+    autonomyModeSource: hasRecordedAutonomyMode ? 'cloud' : 'export-default',
+  };
+};
+
+const normalizedUnitRows = (unitRows = []) => {
+  const rowsByUnit = new Map();
+  for (const row of unitRows) {
+    if (!row?.slug) continue;
+    const rows = rowsByUnit.get(row.slug) ?? [];
+    rows.push(row);
+    rowsByUnit.set(row.slug, rows);
+  }
+  for (const [slug, rows] of rowsByUnit) {
+    if (rows.some((row) => row.sectionIndex != null)) {
+      rowsByUnit.set(
+        slug,
+        rows.filter((row) => row.sectionIndex != null),
+      );
+    }
+  }
+  return rowsByUnit;
+};
+
+const completedUnitSlugs = ({ unitPlan, unitRows = [] }) => {
+  if (!unitPlan) return new Set();
+  const rowsByUnit = normalizedUnitRows(unitRows);
+  return new Set(
+    unitPlan.units
+      .filter((unit) => {
+        const rows = rowsByUnit.get(unit.name) ?? [];
+        return rows.length > 0 && rows.every((row) => row.state === 'MERGED');
+      })
+      .map((unit) => unit.name),
+  );
+};
+
+const dependencyReadyUnitSlugs = ({ unitPlan, completedUnits }) => {
+  if (!unitPlan) return [];
+  return unitPlan.units
+    .filter((unit) => !completedUnits.has(unit.name))
+    .filter((unit) => unit.depends_on.every((dependency) => completedUnits.has(dependency)))
+    .map((unit) => unit.name);
+};
+
+const completedUnitTimestamp = ({ unitSlug, unitRows = [], fallback }) => {
+  const timestamps = unitRows
+    .filter((row) => row?.slug === unitSlug && row.state === 'MERGED')
+    .flatMap((row) => [row.mergedAt, row.completedAt, row.updatedAt])
+    .filter(Boolean)
+    .toSorted();
+  return timestamps.at(-1) ?? fallback;
+};
+
+const unitStageAggregate = ({ stage, rows, unitPlan, completedUnits }) => {
+  if (stage.forEach !== 'unit-of-work' || stage.forEachDegraded || !unitPlan) {
+    return stageAggregate(rows);
+  }
+  const rowsByUnit = new Map();
+  for (const row of rows) {
+    if (!row.unitSlug) continue;
+    const unitRows = rowsByUnit.get(row.unitSlug) ?? [];
+    unitRows.push(row);
+    rowsByUnit.set(row.unitSlug, unitRows);
+  }
+  const unitComplete = (unit) => {
+    if (completedUnits.has(unit.name)) return true;
+    const skippedStages = unitPlan.skipMatrix?.[unit.name];
+    if (Array.isArray(skippedStages) && skippedStages.includes(stage.stageId)) return true;
+    return (rowsByUnit.get(unit.name) ?? []).some((row) =>
+      ['SUCCEEDED', 'SKIPPED'].includes(row.state),
+    );
+  };
+  if (unitPlan.units.every(unitComplete)) return 'SUCCEEDED';
+  return stageAggregate(
+    rows.filter((row) => !row.unitSlug || !unitComplete({ name: row.unitSlug })),
+  );
+};
+
+const projectStageState = ({ stages, stageRows, unitPlan = null, unitRows = [] }) => {
   const rowsByStage = new Map();
   for (const row of stageRows ?? []) {
     if (!row?.stageId) continue;
@@ -146,11 +248,19 @@ const projectStageState = ({ stages, stageRows }) => {
     list.push(row);
     rowsByStage.set(row.stageId, list);
   }
+  const completedUnits = completedUnitSlugs({ unitPlan, unitRows });
 
   const projected = stages.map((stage) => ({
     ...stage,
     phase: normalizePhase(stage.phase),
-    cloudState: stage.excluded ? 'SKIPPED' : stageAggregate(rowsByStage.get(stage.stageId) ?? []),
+    cloudState: stage.excluded
+      ? 'SKIPPED'
+      : unitStageAggregate({
+          stage,
+          rows: rowsByStage.get(stage.stageId) ?? [],
+          unitPlan,
+          completedUnits,
+        }),
   }));
   const firstUnfinished = projected.findIndex(
     (stage) => !['SUCCEEDED', 'SKIPPED'].includes(stage.cloudState),
@@ -178,7 +288,58 @@ const phaseStatus = (phase, stages) => {
   return 'Pending';
 };
 
-const renderState = ({ intent, stages, now, repositories, nativeScope }) => {
+const normalizeProjectType = (value) => {
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase();
+  if (normalized === 'greenfield') return 'Greenfield';
+  if (normalized === 'brownfield') return 'Brownfield';
+  return null;
+};
+
+const projectTypeFromArtifacts = (artifacts = []) => {
+  const detected = new Set();
+  for (const artifact of artifacts) {
+    const content = String(artifact?.content ?? '').replaceAll('*', '');
+    for (const match of content.matchAll(
+      /\b(?:project|request)\s+type\s*(?:\||:)\s*[^|\n]{0,80}\b(greenfield|brownfield)\b/gi,
+    )) {
+      detected.add(normalizeProjectType(match[1]));
+    }
+  }
+  return detected.size === 1 ? [...detected][0] : null;
+};
+
+const projectTypeFromDescription = (intent) => {
+  const content = [intent?.title, intent?.prompt].filter(Boolean).join('\n');
+  const detected = new Set(
+    [...content.matchAll(/\b(greenfield|brownfield)\b/gi)].map((match) =>
+      normalizeProjectType(match[1]),
+    ),
+  );
+  return detected.size === 1 ? [...detected][0] : null;
+};
+
+const resolveProjectType = ({ intent, artifacts = [] }) => {
+  const recorded = normalizeProjectType(intent?.projectType);
+  if (recorded) return recorded;
+
+  const artifactType = projectTypeFromArtifacts(artifacts);
+  if (artifactType) return artifactType;
+
+  return projectTypeFromDescription(intent) ?? 'Unknown';
+};
+
+const renderState = ({
+  intent,
+  stages,
+  now,
+  projectType,
+  nativeScope,
+  unitPlan,
+  completedUnits,
+  nextUnit,
+}) => {
   const activeIndex = stages.findIndex((stage) => stage.marker === '-');
   const current = activeIndex >= 0 ? stages[activeIndex] : null;
   const next =
@@ -209,12 +370,31 @@ const renderState = ({ intent, stages, now, repositories, nativeScope }) => {
   const status = current ? 'Running' : 'Completed';
   const lifecycle = current?.phase?.toUpperCase() ?? 'COMPLETED';
   const pendingArtifacts = current?.produces?.length ? current.produces.join(', ') : 'none';
+  const orderedCompletedUnits =
+    unitPlan?.batches.flat().filter((unit) => completedUnits?.has(unit)) ?? [];
+  const lastCompletedUnit = orderedCompletedUnits.at(-1) ?? null;
+  const lastCompletedUnitStage = stages
+    .filter(
+      (stage) =>
+        stage.phase === 'construction' && stage.forEach === 'unit-of-work' && stage.marker !== 'S',
+    )
+    .at(-1);
+  const constructionResume = current?.phase === 'construction' && nextUnit;
+  const resumeLastCompleted =
+    constructionResume && lastCompletedUnit && lastCompletedUnitStage
+      ? `${lastCompletedUnitStage.stageId} for unit ${lastCompletedUnit}`
+      : lastCompleted?.stageId || 'none';
+  const resumeNextAction = current
+    ? constructionResume
+      ? `Execute ${current.stageId} for unit ${nextUnit}`
+      : `Execute ${current.stageId}`
+    : 'Workflow complete';
 
   return `# AI-DLC State Tracking
 
 ## Project Information
 - **Project**: ${intent.prompt || intent.title || intent.intentId}
-- **Project Type**: ${repositories.length > 0 ? 'Brownfield' : 'Greenfield'}
+- **Project Type**: ${projectType}
 - **Scope**: ${nativeScope}
 - **Start Date**: ${intent.createdAt || now}
 - **State Version**: 7
@@ -222,6 +402,7 @@ const renderState = ({ intent, stages, now, repositories, nativeScope }) => {
 - **Worktree Path**:
 - **Bolt Refs**:
 - **Practices Affirmed Timestamp**:
+- **Construction Autonomy Mode**: ${unitPlan?.autonomyMode ?? 'unset'}
 
 ## Scope Configuration
 - **Stages to Execute**: ${execute.map((stage) => stage.number || stage.stageId).join(', ') || 'none'}
@@ -243,6 +424,7 @@ const renderState = ({ intent, stages, now, repositories, nativeScope }) => {
 
 ## Runtime State
 - **Revision Count**: 0
+${unitPlan?.walkingSkeleton ? '- **Skeleton Stance**: on' : ''}
 
 ## Phase Progress
 <!-- Status values: Pending, Active, Verified, Skipped -->
@@ -262,11 +444,125 @@ ${stageLines}
 - **Last Updated**: ${now}
 
 ## Session Resume Point
-- **Last Completed Stage**: ${lastCompleted?.stageId || 'none'}
-- **Next Action**: ${current ? `Execute ${current.stageId}` : 'Workflow complete'}
+- **Last Completed Stage**: ${resumeLastCompleted}
+- **Next Action**: ${resumeNextAction}
 - **Pending Artifacts**: ${pendingArtifacts}
 `;
 };
+
+const renderUnitDagBlock = (units) =>
+  [
+    'units:',
+    ...units.flatMap((unit) => [
+      `  - name: ${unit.name}`,
+      `    depends_on: [${unit.depends_on.join(', ')}]`,
+    ]),
+  ].join('\n');
+
+const upsertUnitDagArtifact = (content, unitPlan) => {
+  const block = `\`\`\`yaml\n${renderUnitDagBlock(unitPlan.units)}\n\`\`\``;
+  const source = String(content ?? '');
+  let replaced = false;
+  const updated = source.replace(/```ya?ml[^\n]*\n([\s\S]*?)```/g, (match, inner) => {
+    if (replaced || !/^\s*units\s*:/m.test(inner)) return match;
+    replaced = true;
+    return block;
+  });
+  if (replaced) return updated.endsWith('\n') ? updated : `${updated}\n`;
+  if (updated.trim()) {
+    return `${updated.trimEnd()}\n\n## Exported Unit DAG\n\n${block}\n`;
+  }
+  return `# Unit of Work Dependency
+
+## Unit DAG
+
+${block}
+
+## Export Context
+
+This dependency graph was reconstructed from the approved Collaborative AI-DLC unit plan.
+`;
+};
+
+const renderAuditEntry = ({ heading, timestamp, event, fields = {} }) => `## ${heading}
+**Timestamp**: ${timestamp}
+**Event**: ${event}
+${Object.entries(fields)
+  .map(([key, value]) => `**${key}**: ${value}`)
+  .join('\n')}
+
+---
+`;
+
+const renderAudit = ({
+  intent,
+  nativeScope,
+  now,
+  unitPlan = null,
+  completedUnits = new Set(),
+  unitRows = [],
+}) => {
+  const startedAt = intent.createdAt || now;
+  const entries = [
+    renderAuditEntry({
+      heading: 'Workflow Started',
+      timestamp: startedAt,
+      event: 'WORKFLOW_STARTED',
+      fields: {
+        'Workflow ID': intent.intentId,
+        Scope: nativeScope,
+        Request: 'Exported Collaborative AI-DLC checkpoint',
+      },
+    }),
+  ];
+  const orderedCompletedUnits =
+    unitPlan?.batches.flat().filter((unit) => completedUnits.has(unit)) ?? [];
+  for (const unitSlug of orderedCompletedUnits) {
+    const batchIndex = unitPlan.batches.findIndex((batch) => batch.includes(unitSlug));
+    entries.push(
+      renderAuditEntry({
+        heading: 'Bolt Completed',
+        timestamp: completedUnitTimestamp({ unitSlug, unitRows, fallback: now }),
+        event: 'BOLT_COMPLETED',
+        fields: {
+          'Bolt names': unitSlug,
+          'Batch number': batchIndex + 1,
+          'Bolt slug': unitSlug,
+        },
+      }),
+    );
+    if (
+      unitSlug === unitPlan.walkingSkeleton &&
+      ['gated', 'autonomous'].includes(unitPlan.autonomyMode)
+    ) {
+      entries.push(
+        renderAuditEntry({
+          heading: 'Autonomy Mode Set',
+          timestamp: completedUnitTimestamp({ unitSlug, unitRows, fallback: now }),
+          event: 'AUTONOMY_MODE_SET',
+          fields: { Mode: unitPlan.autonomyMode },
+        }),
+      );
+    }
+  }
+
+  return `# AI-DLC Audit Log\n\n${entries.join('\n')}`;
+};
+
+const renderRuntimeGraph = ({ intent, nativeScope, unitPlan, now }) => ({
+  workflow_id: intent.intentId,
+  scope: nativeScope,
+  started_at: intent.createdAt || now,
+  stages: [],
+  ...(unitPlan
+    ? {
+        bolt_dag: {
+          units: unitPlan.units,
+          batches: unitPlan.batches,
+        },
+      }
+    : {}),
+});
 
 const artifactPath = ({
   artifact,
@@ -305,6 +601,8 @@ const projectNativeWorkspace = ({
   artifacts = [],
   humanTasks = [],
   repositories = [],
+  unitPlan: rawUnitPlan = null,
+  unitRows = [],
   space = 'default',
   now = new Date().toISOString(),
   upstreamRef,
@@ -338,7 +636,17 @@ const projectNativeWorkspace = ({
   if (workspaceLayout === 'flat' && normalizedRepos.length > 1) {
     throw new Error('native-export: legacy flat workspaces do not support multiple repositories');
   }
-  const projectedStages = projectStageState({ stages, stageRows });
+  const unitPlan = normalizedUnitPlan(rawUnitPlan);
+  const completedUnits = completedUnitSlugs({ unitPlan, unitRows });
+  const unitOrder = unitPlan?.batches.flat() ?? [];
+  const remainingUnits = unitOrder.filter((unit) => !completedUnits.has(unit));
+  const readyUnits = dependencyReadyUnitSlugs({ unitPlan, completedUnits });
+  const nextUnit = readyUnits[0] ?? remainingUnits[0] ?? null;
+  const projectedStages = projectStageState({ stages, stageRows, unitPlan, unitRows });
+  const projectType = resolveProjectType({
+    intent,
+    artifacts,
+  });
   const stageById = new Map(projectedStages.map((stage) => [stage.stageId, stage]));
   const stageByInstance = new Map(
     stageRows
@@ -375,8 +683,26 @@ const projectNativeWorkspace = ({
       intent,
       stages: projectedStages,
       now,
-      repositories: normalizedRepos,
+      projectType,
       nativeScope,
+      unitPlan,
+      completedUnits,
+      nextUnit,
+    }),
+  );
+  const auditPath =
+    workspaceLayout === 'flat'
+      ? `${recordRoot.path}/audit.md`
+      : `${recordRoot.path}/audit/export.md`;
+  files.set(
+    auditPath,
+    renderAudit({
+      intent,
+      nativeScope,
+      now,
+      unitPlan,
+      completedUnits,
+      unitRows,
     }),
   );
   if (workspaceLayout === 'spaces' && normalizedRepos.length > 0) {
@@ -407,6 +733,14 @@ const projectNativeWorkspace = ({
     });
     if (files.has(path)) throw new Error(`native-export: duplicate output path ${path}`);
     files.set(path, String(artifact.content ?? ''));
+  }
+  if (unitPlan) {
+    const dependencyPath = `${recordRoot.path}/inception/units-generation/unit-of-work-dependency.md`;
+    files.set(dependencyPath, upsertUnitDagArtifact(files.get(dependencyPath), unitPlan));
+    files.set(
+      `${recordRoot.path}/runtime-graph.json`,
+      `${JSON.stringify(renderRuntimeGraph({ intent, nativeScope, unitPlan, now }), null, 2)}\n`,
+    );
   }
   const questionGroups = new Map();
   for (const task of humanTasks) {
@@ -464,6 +798,7 @@ const projectNativeWorkspace = ({
       workflowId: intent.workflowId,
       workflowVersion: intent.workflowVersion,
       scope: intent.scope,
+      projectType,
     },
     native: {
       upstreamRef,
@@ -473,6 +808,21 @@ const projectNativeWorkspace = ({
       ...(workspaceLayout === 'spaces' ? { space: safeSpace, recordDir } : {}),
     },
     repositories: normalizedRepos,
+    ...(unitPlan
+      ? {
+          construction: {
+            unitCount: unitPlan.units.length,
+            batches: unitPlan.batches,
+            completedUnits: unitOrder.filter((unit) => completedUnits.has(unit)),
+            remainingUnits,
+            readyUnits,
+            nextUnit,
+            walkingSkeleton: unitPlan.walkingSkeleton,
+            autonomyMode: unitPlan.autonomyMode,
+            autonomyModeSource: unitPlan.autonomyModeSource,
+          },
+        }
+      : {}),
     files: [...files]
       .map(([path, body]) => ({
         path,
@@ -491,8 +841,11 @@ export {
   projectNativeWorkspace,
   projectStageState,
   recordDate,
+  resolveProjectType,
+  renderUnitDagBlock,
   renderQuestionFile,
   slugify,
+  upsertUnitDagArtifact,
 };
 
 export default { projectNativeWorkspace };

--- a/lambda/shared/native-workspace-projector.js
+++ b/lambda/shared/native-workspace-projector.js
@@ -161,8 +161,8 @@ const normalizedUnitPlan = (unitPlan) => {
     batches: parsed.batches,
     skipMatrix: unitPlan.skipMatrix ?? {},
     walkingSkeleton: unitPlan.walkingSkeleton ?? null,
-    autonomyMode: hasRecordedAutonomyMode ? unitPlan.autonomyMode : 'gated',
-    autonomyModeSource: hasRecordedAutonomyMode ? 'cloud' : 'export-default',
+    autonomyMode: hasRecordedAutonomyMode ? unitPlan.autonomyMode : null,
+    autonomyModeSource: hasRecordedAutonomyMode ? 'cloud' : 'unset',
   };
 };
 

--- a/lambda/shared/repo-fetch.js
+++ b/lambda/shared/repo-fetch.js
@@ -29,15 +29,16 @@ const stripTopLevel = (name) => {
 };
 
 // Streams the gzipped tarball through the extractor, collecting file entries
-// whose repo-relative path starts with `core/`. Returns a Map<path, string>.
-const extractCoreFiles = (gzBuffer) =>
+// whose repo-relative path starts with one of `prefixes`. Returns Map<path, Buffer>.
+const extractFiles = (gzBuffer, prefixes) =>
   new Promise((resolve, reject) => {
     const files = new Map();
     const extract = tar.extract();
 
     extract.on('entry', (header, stream, next) => {
       const rel = stripTopLevel(header.name);
-      const keep = header.type === 'file' && rel && rel.startsWith('core/');
+      const keep =
+        header.type === 'file' && rel && prefixes.some((prefix) => rel.startsWith(prefix));
       if (!keep) {
         stream.on('end', next);
         stream.resume();
@@ -46,7 +47,7 @@ const extractCoreFiles = (gzBuffer) =>
       const chunks = [];
       stream.on('data', (c) => chunks.push(c));
       stream.on('end', () => {
-        files.set(rel, Buffer.concat(chunks).toString('utf8'));
+        files.set(rel, Buffer.concat(chunks));
         next();
       });
       stream.on('error', reject);
@@ -61,26 +62,36 @@ const extractCoreFiles = (gzBuffer) =>
     gunzip.end(gzBuffer);
   });
 
-// Downloads + extracts the repo's core/ files at `ref`. Throws on any failure.
-const fetchCoreFiles = async (ref) => {
+const fetchRepoFiles = async (ref, { prefixes }) => {
   if (!ref || typeof ref !== 'string') {
     throw new Error('repo-fetch: a ref (commit SHA, tag, or branch) is required');
   }
+  if (!Array.isArray(prefixes) || prefixes.length === 0) {
+    throw new Error('repo-fetch: at least one path prefix is required');
+  }
   const url = tarballUrl(ref);
   const res = await fetch(url, {
-    headers: { 'User-Agent': 'aidlc-seed-blocks', Accept: 'application/x-gzip' },
+    headers: { 'User-Agent': 'collaborative-ai-dlc', Accept: 'application/x-gzip' },
     redirect: 'follow',
   });
   if (!res.ok) {
     throw new Error(`repo-fetch: ${url} returned ${res.status} ${res.statusText}`);
   }
   const gzBuffer = Buffer.from(await res.arrayBuffer());
-  const files = await extractCoreFiles(gzBuffer);
+  const files = await extractFiles(gzBuffer, prefixes);
   if (files.size === 0) {
-    throw new Error(`repo-fetch: no core/ files found in tarball for ref ${ref}`);
+    throw new Error(
+      `repo-fetch: no files found for prefixes ${prefixes.join(', ')} in tarball for ref ${ref}`,
+    );
   }
   return files;
 };
 
-export { fetchCoreFiles, tarballUrl, REPO_OWNER, REPO_NAME };
-export default { fetchCoreFiles, tarballUrl, REPO_OWNER, REPO_NAME };
+// Downloads + extracts the repo's core/ files at `ref`. Throws on any failure.
+const fetchCoreFiles = async (ref) => {
+  const files = await fetchRepoFiles(ref, { prefixes: ['core/'] });
+  return new Map([...files].map(([path, body]) => [path, body.toString('utf8')]));
+};
+
+export { fetchCoreFiles, fetchRepoFiles, extractFiles, tarballUrl, REPO_OWNER, REPO_NAME };
+export default { fetchCoreFiles, fetchRepoFiles, extractFiles, tarballUrl, REPO_OWNER, REPO_NAME };

--- a/lambda/shared/repo-fetch.js
+++ b/lambda/shared/repo-fetch.js
@@ -15,6 +15,10 @@ import tar from 'tar-stream';
 
 const REPO_OWNER = 'awslabs';
 const REPO_NAME = 'aidlc-workflows';
+const MAX_REPO_TARBALL_BYTES = 50 * 1024 * 1024;
+const MAX_REPO_UNCOMPRESSED_BYTES = 250 * 1024 * 1024;
+const MAX_REPO_FILES = 5_000;
+const MAX_REPO_RETAINED_BYTES = 50 * 1024 * 1024;
 
 // codeload serves a gzipped tarball for any ref (branch, tag, or full/short
 // SHA). The archive's top-level dir is `<repo>-<ref>/`, which we strip so keys
@@ -30,9 +34,25 @@ const stripTopLevel = (name) => {
 
 // Streams the gzipped tarball through the extractor, collecting file entries
 // whose repo-relative path starts with one of `prefixes`. Returns Map<path, Buffer>.
-const extractFiles = (gzBuffer, prefixes) =>
+const extractFiles = (
+  gzBuffer,
+  prefixes,
+  {
+    maxFiles = MAX_REPO_FILES,
+    maxRetainedBytes = MAX_REPO_RETAINED_BYTES,
+    maxUncompressedBytes = MAX_REPO_UNCOMPRESSED_BYTES,
+  } = {},
+) =>
   new Promise((resolve, reject) => {
     const files = new Map();
+    let fileBytes = 0;
+    let uncompressedBytes = 0;
+    let settled = false;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
     const extract = tar.extract();
 
     extract.on('entry', (header, stream, next) => {
@@ -44,25 +64,81 @@ const extractFiles = (gzBuffer, prefixes) =>
         stream.resume();
         return;
       }
+      if (files.size >= maxFiles) {
+        stream.on('end', next);
+        stream.resume();
+        fail(new Error(`repo-fetch: exceeds ${maxFiles} matching files`));
+        return;
+      }
       const chunks = [];
-      stream.on('data', (c) => chunks.push(c));
+      stream.on('data', (chunk) => {
+        if (settled) return;
+        fileBytes += chunk.length;
+        if (fileBytes > maxRetainedBytes) {
+          fail(new Error(`repo-fetch: matching files exceed ${maxRetainedBytes} bytes`));
+          return;
+        }
+        chunks.push(chunk);
+      });
       stream.on('end', () => {
-        files.set(rel, Buffer.concat(chunks));
+        if (!settled) files.set(rel, Buffer.concat(chunks));
         next();
       });
-      stream.on('error', reject);
+      stream.on('error', fail);
     });
 
-    extract.on('finish', () => resolve(files));
-    extract.on('error', reject);
+    extract.on('finish', () => {
+      if (settled) return;
+      settled = true;
+      resolve(files);
+    });
+    extract.on('error', fail);
 
     const gunzip = zlib.createGunzip();
-    gunzip.on('error', reject);
+    gunzip.on('data', (chunk) => {
+      uncompressedBytes += chunk.length;
+      if (uncompressedBytes > maxUncompressedBytes) {
+        fail(new Error(`repo-fetch: tarball expands beyond ${maxUncompressedBytes} bytes`));
+        gunzip.destroy();
+      }
+    });
+    gunzip.on('error', fail);
     gunzip.pipe(extract);
     gunzip.end(gzBuffer);
   });
 
-const fetchRepoFiles = async (ref, { prefixes }) => {
+const responseToBuffer = async (res, maxBytes) => {
+  const declaredBytes = Number(res.headers?.get?.('content-length'));
+  if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
+    throw new Error(`repo-fetch: tarball exceeds ${maxBytes} bytes`);
+  }
+
+  const chunks = [];
+  let bytes = 0;
+  if (res.body?.[Symbol.asyncIterator]) {
+    for await (const chunk of res.body) {
+      bytes += chunk.length;
+      if (bytes > maxBytes) throw new Error(`repo-fetch: tarball exceeds ${maxBytes} bytes`);
+      chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  }
+
+  const buffer = Buffer.from(await res.arrayBuffer());
+  if (buffer.length > maxBytes) throw new Error(`repo-fetch: tarball exceeds ${maxBytes} bytes`);
+  return buffer;
+};
+
+const fetchRepoFiles = async (
+  ref,
+  {
+    prefixes,
+    maxTarballBytes = MAX_REPO_TARBALL_BYTES,
+    maxFiles = MAX_REPO_FILES,
+    maxRetainedBytes = MAX_REPO_RETAINED_BYTES,
+    maxUncompressedBytes = MAX_REPO_UNCOMPRESSED_BYTES,
+  },
+) => {
   if (!ref || typeof ref !== 'string') {
     throw new Error('repo-fetch: a ref (commit SHA, tag, or branch) is required');
   }
@@ -77,8 +153,12 @@ const fetchRepoFiles = async (ref, { prefixes }) => {
   if (!res.ok) {
     throw new Error(`repo-fetch: ${url} returned ${res.status} ${res.statusText}`);
   }
-  const gzBuffer = Buffer.from(await res.arrayBuffer());
-  const files = await extractFiles(gzBuffer, prefixes);
+  const gzBuffer = await responseToBuffer(res, maxTarballBytes);
+  const files = await extractFiles(gzBuffer, prefixes, {
+    maxFiles,
+    maxRetainedBytes,
+    maxUncompressedBytes,
+  });
   if (files.size === 0) {
     throw new Error(
       `repo-fetch: no files found for prefixes ${prefixes.join(', ')} in tarball for ref ${ref}`,
@@ -93,5 +173,17 @@ const fetchCoreFiles = async (ref) => {
   return new Map([...files].map(([path, body]) => [path, body.toString('utf8')]));
 };
 
-export { fetchCoreFiles, fetchRepoFiles, extractFiles, tarballUrl, REPO_OWNER, REPO_NAME };
+export {
+  MAX_REPO_FILES,
+  MAX_REPO_RETAINED_BYTES,
+  MAX_REPO_TARBALL_BYTES,
+  MAX_REPO_UNCOMPRESSED_BYTES,
+  fetchCoreFiles,
+  fetchRepoFiles,
+  extractFiles,
+  responseToBuffer,
+  tarballUrl,
+  REPO_OWNER,
+  REPO_NAME,
+};
 export default { fetchCoreFiles, fetchRepoFiles, extractFiles, tarballUrl, REPO_OWNER, REPO_NAME };

--- a/lambda/shared/test/aidlc-ref.test.js
+++ b/lambda/shared/test/aidlc-ref.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isCommitSha, resolveAidlcRepoRef } from '../aidlc-ref.js';
+
+const SHA = 'ABCDEF0123456789ABCDEF0123456789ABCDEF01';
+
+describe('AI-DLC repository refs', () => {
+  it('accepts and normalizes an existing commit SHA without a network call', async () => {
+    const fetchFn = vi.fn();
+    await expect(resolveAidlcRepoRef(SHA, { fetchFn })).resolves.toBe(SHA.toLowerCase());
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(isCommitSha(SHA)).toBe(true);
+  });
+
+  it('resolves a branch or tag through the GitHub commits API', async () => {
+    const fetchFn = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ sha: SHA }),
+    }));
+    await expect(resolveAidlcRepoRef('release/v2', { fetchFn })).resolves.toBe(SHA.toLowerCase());
+    expect(fetchFn.mock.calls[0][0]).toContain('/commits/release%2Fv2');
+  });
+
+  it('rejects refs that cannot be resolved to a commit', async () => {
+    const fetchFn = vi.fn(async () => ({ ok: false, status: 404 }));
+    await expect(resolveAidlcRepoRef('missing', { fetchFn })).rejects.toThrow(/404/);
+  });
+});

--- a/lambda/shared/test/artifact-checkpoint.test.js
+++ b/lambda/shared/test/artifact-checkpoint.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  artifactSnapshot,
+  artifactSnapshotHash,
+  readCheckpointArtifactVersions,
+} from '../artifact-versioning.js';
+
+const graphReturning = (rows) => {
+  const traversal = {
+    V: () => traversal,
+    hasLabel: () => traversal,
+    has: () => traversal,
+    valueMap: () => traversal,
+    toList: async () => rows,
+  };
+  return traversal;
+};
+
+describe('artifact checkpoint identity', () => {
+  const artifact = {
+    id: 'requirements',
+    artifact_type: 'requirements',
+    created_by_stage_instance_id: 'requirements-analysis',
+    content: '# Requirements\n',
+    updated_at: '2026-08-14T10:00:00.000Z',
+    vertexId: 'internal-neptune-id',
+    version_count: 7,
+  };
+
+  it('hashes every field that affects native projection', () => {
+    expect(artifactSnapshotHash(artifact)).not.toBe(
+      artifactSnapshotHash({ ...artifact, content: '# Changed\n' }),
+    );
+    expect(artifactSnapshotHash(artifact)).not.toBe(
+      artifactSnapshotHash({ ...artifact, repository: 'org/api' }),
+    );
+  });
+
+  it('ignores graph bookkeeping that does not affect the exported artifact', () => {
+    expect(artifactSnapshot(artifact)).not.toHaveProperty('vertexId');
+    expect(artifactSnapshotHash(artifact)).toBe(
+      artifactSnapshotHash({ ...artifact, vertexId: 'different', version_count: 99 }),
+    );
+  });
+
+  it('reports a missing checkpoint artifact version', async () => {
+    await expect(
+      readCheckpointArtifactVersions({
+        g: graphReturning([]),
+        intentId: 'i1',
+        refs: [{ versionId: 'a1:sha256:expected', snapshotHash: 'expected' }],
+      }),
+    ).rejects.toMatchObject({
+      code: 'export_checkpoint_unavailable',
+      versionId: 'a1:sha256:expected',
+      reason: 'missing',
+    });
+  });
+
+  it('reports a checkpoint artifact version hash mismatch', async () => {
+    await expect(
+      readCheckpointArtifactVersions({
+        g: graphReturning([
+          {
+            id: ['a1:sha256:expected'],
+            snapshot_hash: ['different'],
+          },
+        ]),
+        intentId: 'i1',
+        refs: [{ versionId: 'a1:sha256:expected', snapshotHash: 'expected' }],
+      }),
+    ).rejects.toMatchObject({
+      code: 'export_checkpoint_unavailable',
+      versionId: 'a1:sha256:expected',
+      reason: 'hash_mismatch',
+    });
+  });
+});

--- a/lambda/shared/test/custom-rule-versions.test.js
+++ b/lambda/shared/test/custom-rule-versions.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import { pinCustomRuleVersions } from '../custom-rule-versions.js';
+
+describe('pinCustomRuleVersions', () => {
+  it('preserves rule metadata and pins the exact object version', async () => {
+    const s3 = {
+      send: vi.fn(async (command) => {
+        expect(command).toBeInstanceOf(HeadObjectCommand);
+        expect(command.input).toEqual({
+          Bucket: 'artifacts',
+          Key: 'custom-rules/p1/security.md',
+        });
+        return { VersionId: 'version-1' };
+      }),
+    };
+
+    await expect(
+      pinCustomRuleVersions({
+        s3,
+        bucket: 'artifacts',
+        rules: [{ s3Key: 'custom-rules/p1/security.md', source: 'project' }],
+      }),
+    ).resolves.toEqual([
+      {
+        filename: 'security.md',
+        s3Key: 'custom-rules/p1/security.md',
+        source: 'project',
+        versionId: 'version-1',
+      },
+    ]);
+  });
+
+  it('rejects an object without an immutable version', async () => {
+    await expect(
+      pinCustomRuleVersions({
+        s3: { send: vi.fn(async () => ({})) },
+        bucket: 'artifacts',
+        rules: [{ filename: 'rules.md', s3Key: 'custom-rules/p1/rules.md' }],
+      }),
+    ).rejects.toThrow('has no immutable S3 version');
+  });
+});

--- a/lambda/shared/test/distribution-archive.test.js
+++ b/lambda/shared/test/distribution-archive.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDistributionArchive,
+  extractDistributionArchive,
+  safeDistributionPath,
+} from '../distribution-archive.js';
+
+describe('distribution archive', () => {
+  it('round-trips binary and text files', async () => {
+    const source = new Map([
+      ['AGENTS.md', Buffer.from('# Harness\n')],
+      ['assets/icon.bin', Buffer.from([0, 1, 2, 255])],
+    ]);
+    const archive = await buildDistributionArchive(source);
+    const extracted = await extractDistributionArchive(archive);
+    expect(extracted).toEqual(source);
+  });
+
+  it('rejects unsafe paths', () => {
+    expect(() => safeDistributionPath('../secret')).toThrow(/unsafe path/);
+    expect(() => safeDistributionPath('/absolute')).toThrow(/unsafe path/);
+  });
+});

--- a/lambda/shared/test/methodology-catalog.test.js
+++ b/lambda/shared/test/methodology-catalog.test.js
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { mockClient } from 'aws-sdk-client-mock';
+import { buildFromFiles } from '../block-mappers.js';
+import {
+  buildMethodologyCatalog,
+  executionPlanFromMethodologyCatalog,
+  loadOrCreateMethodologyCatalog,
+  methodologyCatalogKey,
+  writeMethodologyCatalog,
+} from '../methodology-catalog.js';
+import { CORE_FILES } from './fixtures/repo-files.js';
+
+const REF = 'a'.repeat(40);
+const fetchCoreFilesSpy = vi.hoisted(() => vi.fn());
+vi.mock('../repo-fetch.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchCoreFiles: fetchCoreFilesSpy,
+}));
+const s3Mock = mockClient(S3Client);
+
+beforeEach(() => {
+  s3Mock.reset();
+  fetchCoreFilesSpy.mockReset().mockResolvedValue(CORE_FILES);
+});
+
+describe('methodology catalog', () => {
+  it('captures structured methodology without embedding Markdown bodies', () => {
+    const parsed = buildFromFiles(CORE_FILES);
+    const catalog = buildMethodologyCatalog({ ref: REF, ...parsed });
+
+    expect(methodologyCatalogKey(REF)).toBe(`aidlc-catalogs/v1/${REF}.json`);
+    expect(catalog.workflow.sourceRef).toBe(REF);
+    expect(catalog.blocks.STAGE.length).toBeGreaterThan(0);
+    expect(catalog.blocks.STAGE[0]).not.toHaveProperty('body');
+    expect(catalog.blocks.STAGE[0].bodyRef).toMatchObject({
+      s3Key: expect.stringMatching(/^blocks\/bodies\/sha256\//),
+      sha256: expect.any(String),
+    });
+    expect(catalog.blocks.SENSOR.find((block) => block.id === 'linter').scriptRef).toMatchObject({
+      s3Key: expect.stringMatching(/^blocks\/scripts\/sha256\//),
+      sha256: expect.any(String),
+    });
+  });
+
+  it('reconstructs a runnable plan for the pinned workflow and scope', () => {
+    const parsed = buildFromFiles(CORE_FILES);
+    const catalog = buildMethodologyCatalog({ ref: REF, ...parsed });
+    const result = executionPlanFromMethodologyCatalog({
+      catalog,
+      workflowId: 'aidlc-v2',
+      workflowVersion: 1,
+      scope: 'mvp',
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.plan.stages.length).toBeGreaterThan(0);
+    expect(result.methodologySourceRefs).toEqual([REF]);
+    expect(result.methodologyPins.STAGE).toBeTruthy();
+  });
+
+  it('rebuilds and caches a missing historical catalog from the pinned commit', async () => {
+    s3Mock.on(GetObjectCommand).rejects(Object.assign(new Error('missing'), { name: 'NoSuchKey' }));
+    s3Mock.on(PutObjectCommand).resolves({});
+
+    const catalog = await loadOrCreateMethodologyCatalog({
+      s3: s3Mock,
+      bucket: 'artifacts-test',
+      ref: REF,
+    });
+
+    expect(catalog.ref).toBe(REF);
+    expect(fetchCoreFilesSpy).toHaveBeenCalledWith(REF);
+    expect(s3Mock.commandCalls(PutObjectCommand)[0].args[0].input).toMatchObject({
+      Bucket: 'artifacts-test',
+      Key: methodologyCatalogKey(REF),
+      ContentType: 'application/json',
+    });
+  });
+
+  it('reuses an identical immutable catalog when another writer wins', async () => {
+    const catalog = buildMethodologyCatalog({ ref: REF, ...buildFromFiles(CORE_FILES) });
+    s3Mock
+      .on(PutObjectCommand)
+      .rejects(Object.assign(new Error('exists'), { name: 'PreconditionFailed' }));
+    s3Mock.on(GetObjectCommand).resolves({ Body: Buffer.from(JSON.stringify(catalog)) });
+
+    await expect(
+      writeMethodologyCatalog({
+        s3: s3Mock,
+        bucket: 'artifacts-test',
+        catalog,
+      }),
+    ).resolves.toEqual(catalog);
+  });
+});

--- a/lambda/shared/test/native-repositories.test.js
+++ b/lambda/shared/test/native-repositories.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { assignNativeRepositoryDirectories, repositoryId } from '../native-repositories.js';
+
+describe('native repository projection', () => {
+  it('preserves unique basenames as local directories', () => {
+    expect(
+      assignNativeRepositoryDirectories([
+        { id: 'org/api', url: 'git@github.com:org/api.git' },
+        { id: 'org/web', url: 'git@github.com:org/web.git' },
+      ]),
+    ).toEqual([
+      { id: 'org/api', directory: 'api', url: 'git@github.com:org/api.git' },
+      { id: 'org/web', directory: 'web', url: 'git@github.com:org/web.git' },
+    ]);
+  });
+
+  it('assigns different stable directories to repositories with the same basename', () => {
+    const repositories = assignNativeRepositoryDirectories([
+      { id: 'org-a/api' },
+      { id: 'org-b/api' },
+    ]);
+
+    expect(repositories.map((repository) => repository.id)).toEqual(['org-a/api', 'org-b/api']);
+    expect(repositories.map((repository) => repository.directory)).toEqual([
+      'org-a_api',
+      'org-b_api',
+    ]);
+  });
+
+  it('derives canonical identities from supported clone URL forms', () => {
+    expect(repositoryId('owner/repo')).toBe('owner/repo');
+    expect(repositoryId('git@github.com:owner/repo.git')).toBe('owner/repo');
+    expect(repositoryId('https://github.com/owner/repo.git')).toBe('owner/repo');
+  });
+});

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -174,6 +174,59 @@ describe('projectNativeWorkspace', () => {
     );
   });
 
+  it('projects a stage skipped for every unit as SKIPPED without synthetic timeline entries', () => {
+    const value = input();
+    value.stageRows[1].state = 'SUCCEEDED';
+    value.stages[2].forEach = 'unit-of-work';
+    value.unitPlan = {
+      units: [
+        { slug: 'a', dependsOn: [] },
+        { slug: 'b', dependsOn: [] },
+      ],
+      skipMatrix: {
+        a: ['code-generation'],
+        b: ['code-generation'],
+      },
+    };
+
+    const result = projectNativeWorkspace(value);
+    const root = 'aidlc/spaces/default/intents/260811-payment-service';
+    expect(result.files.get(`${root}/aidlc-state.md`)).toContain('- [S] code-generation — SKIP');
+    expect(
+      JSON.parse(result.files.get(`${root}/runtime-graph.json`)).stages.some(
+        (stage) => stage.stage_slug === 'code-generation',
+      ),
+    ).toBe(false);
+    expect(result.files.get(`${root}/audit/export.md`)).not.toContain('**Stage**: code-generation');
+  });
+
+  it('projects a per-unit stage as SUCCEEDED when at least one unit succeeded', () => {
+    const value = input();
+    value.stageRows = [
+      { stageId: 'intent-capture', state: 'SUCCEEDED' },
+      { stageId: 'requirements-analysis', state: 'SUCCEEDED' },
+      { stageId: 'code-generation', state: 'SUCCEEDED', unitSlug: 'a' },
+      { stageId: 'code-generation', state: 'SKIPPED', unitSlug: 'b' },
+    ];
+    value.stages[2].forEach = 'unit-of-work';
+    value.unitPlan = {
+      units: [
+        { slug: 'a', dependsOn: [] },
+        { slug: 'b', dependsOn: [] },
+      ],
+      skipMatrix: { b: ['code-generation'] },
+    };
+
+    const result = projectNativeWorkspace(value);
+    const root = 'aidlc/spaces/default/intents/260811-payment-service';
+    expect(result.files.get(`${root}/aidlc-state.md`)).toContain('- [x] code-generation — EXECUTE');
+    expect(
+      JSON.parse(result.files.get(`${root}/runtime-graph.json`)).stages.some(
+        (stage) => stage.stage_slug === 'code-generation',
+      ),
+    ).toBe(true);
+  });
+
   it('projects a partial Construction checkpoint with the complete Bolt DAG', () => {
     const value = input();
     value.stages[2].forEach = 'unit-of-work';

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+import { projectNativeWorkspace } from '../native-workspace-projector.js';
+
+const input = () => ({
+  intent: {
+    projectId: 'project-1',
+    intentId: 'intent-1',
+    title: 'Payment service',
+    prompt: 'Add payments',
+    scope: 'feature',
+    branch: 'aidlc/intent-1',
+    workflowId: 'aidlc-v2',
+    workflowVersion: 4,
+    createdAt: '2026-08-11T10:00:00.000Z',
+  },
+  upstreamRef: 'abc123',
+  harness: 'codex',
+  now: '2026-08-11T12:00:00.000Z',
+  stages: [
+    {
+      stageId: 'intent-capture',
+      phase: 'ideation',
+      number: '1.1',
+      leadAgent: 'aidlc-product-agent',
+      produces: ['intent'],
+    },
+    {
+      stageId: 'requirements-analysis',
+      phase: 'inception',
+      number: '2.2',
+      leadAgent: 'aidlc-product-agent',
+      produces: ['requirements'],
+    },
+    {
+      stageId: 'code-generation',
+      phase: 'construction',
+      number: '3.5',
+      leadAgent: 'aidlc-developer-agent',
+      produces: ['code-generation-plan', 'code-summary'],
+    },
+  ],
+  stageRows: [
+    { stageInstanceId: 'si-intent', stageId: 'intent-capture', state: 'SUCCEEDED' },
+    {
+      stageInstanceId: 'si-requirements',
+      stageId: 'requirements-analysis',
+      phase: 'inception',
+      state: 'FAILED',
+    },
+  ],
+  repositories: [
+    {
+      name: 'checkout-api',
+      url: 'git@github.com:example/checkout-api.git',
+      branch: 'aidlc/intent-1',
+    },
+    {
+      name: 'checkout-web',
+      url: 'git@github.com:example/checkout-web.git',
+      branch: 'aidlc/intent-1',
+    },
+  ],
+  artifacts: [
+    {
+      id: 'artifact-1',
+      artifactType: 'requirements',
+      stageId: 'requirements-analysis',
+      phase: 'inception',
+      content: '# Requirements\n',
+    },
+    {
+      id: 'artifact-2',
+      artifactType: 'code-summary',
+      stageId: 'code-generation',
+      phase: 'construction',
+      unitSlug: 'payment-api',
+      content: '# Summary\n',
+    },
+  ],
+});
+
+describe('projectNativeWorkspace', () => {
+  it('builds a resumable native multi-repository workspace', () => {
+    const result = projectNativeWorkspace(input());
+    expect(result.recordDir).toBe('260811-payment-service');
+    expect(result.files.get('aidlc/active-space')).toBe('default\n');
+    expect(result.files.get('repos.json')).toContain('"checkout-api"');
+    expect(
+      result.files.get(
+        'aidlc/spaces/default/intents/260811-payment-service/inception/requirements-analysis/requirements.md',
+      ),
+    ).toBe('# Requirements\n');
+    expect(
+      result.files.get(
+        'aidlc/spaces/default/intents/260811-payment-service/construction/payment-api/code-generation/code-summary.md',
+      ),
+    ).toBe('# Summary\n');
+    const state = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md',
+    );
+    expect(state).toContain('- **State Version**: 7');
+    expect(state).toContain('- [x] intent-capture — EXECUTE');
+    expect(state).toContain('- [-] requirements-analysis — EXECUTE');
+    expect(state).toContain('- [ ] code-generation — EXECUTE');
+    expect(state).toContain('- **Current Stage**: requirements-analysis');
+  });
+
+  it('aggregates per-unit rows and reruns a partially successful stage', () => {
+    const value = input();
+    value.stageRows = [
+      { stageId: 'intent-capture', state: 'SUCCEEDED' },
+      { stageId: 'requirements-analysis', state: 'SUCCEEDED', unitSlug: 'a' },
+      { stageId: 'requirements-analysis', state: 'FAILED', unitSlug: 'b' },
+    ];
+    const result = projectNativeWorkspace(value);
+    expect(result.stages.find((stage) => stage.stageId === 'requirements-analysis').marker).toBe(
+      '-',
+    );
+  });
+
+  it('projects legacy distributions into aidlc-docs', () => {
+    const value = input();
+    value.workspaceLayout = 'flat';
+    value.intent.scope = 'feature-custom';
+    value.nativeScope = 'feature-custom';
+    value.repositories = [value.repositories[0]];
+    const result = projectNativeWorkspace(value);
+    expect(result.files.has('aidlc/active-space')).toBe(false);
+    expect(result.files.has('repos.json')).toBe(false);
+    expect(result.files.get('aidlc-docs/aidlc-state.md')).toContain(
+      '- **Current Stage**: requirements-analysis',
+    );
+    expect(result.files.get('aidlc-docs/aidlc-state.md')).toContain('- **Scope**: feature-custom');
+    expect(result.files.get('aidlc-docs/inception/requirements-analysis/requirements.md')).toBe(
+      '# Requirements\n',
+    );
+    expect(
+      result.files.get('aidlc-docs/construction/payment-api/code-generation/code-summary.md'),
+    ).toBe('# Summary\n');
+    expect(result.manifest.native.workspaceLayout).toBe('flat');
+    expect(result.manifest.native.scope).toBe('feature-custom');
+    expect(result.manifest.source.scope).toBe('feature-custom');
+  });
+
+  it('reconstructs a pending native question file from a human gate', () => {
+    const value = input();
+    value.stages.splice(2, 0, {
+      stageId: 'units-generation',
+      phase: 'inception',
+      number: '2.7',
+      leadAgent: 'aidlc-architect-agent',
+      produces: ['unit-of-work'],
+    });
+    value.stageRows.push({
+      stageInstanceId: 'si-units',
+      stageId: 'units-generation',
+      phase: 'inception',
+      state: 'WAITING_FOR_HUMAN',
+    });
+    value.humanTasks = [
+      {
+        humanTaskId: 'q-units',
+        stageInstanceId: 'si-units',
+        kind: 'question',
+        status: 'pending',
+        createdAt: '2026-08-11T11:00:00.000Z',
+        questions: JSON.stringify([
+          {
+            text: 'How should units be divided?',
+            type: 'single',
+            options: [
+              { label: 'By service', description: 'One unit per service' },
+              { label: 'By feature' },
+            ],
+          },
+        ]),
+      },
+    ];
+
+    const result = projectNativeWorkspace(value);
+    expect(
+      result.files.get(
+        'aidlc/spaces/default/intents/260811-payment-service/inception/units-generation/units-generation-questions.md',
+      ),
+    ).toBe(`# Units Generation Questions
+
+## Q1. How should units be divided?
+
+A. By service — One unit per service
+B. By feature
+X. Other (please specify)
+
+[Answer]:
+`);
+  });
+
+  it('writes selected labels and free text into reconstructed answers', () => {
+    const value = input();
+    value.humanTasks = [
+      {
+        humanTaskId: 'q-requirements',
+        stageInstanceId: 'si-requirements',
+        kind: 'question',
+        status: 'answered',
+        questions: [
+          {
+            text: 'Which interfaces are required?',
+            type: 'multi',
+            options: [{ label: 'REST' }, { label: 'Events' }],
+          },
+        ],
+        answer: {
+          answers: [{ selectedOptions: [0, 1], freeText: 'Webhooks later' }],
+        },
+      },
+    ];
+
+    const result = projectNativeWorkspace(value);
+    const questions = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/inception/requirements-analysis/requirements-analysis-questions.md',
+    );
+    expect(questions).toContain('## Q1. Which interfaces are required? (select all that apply)');
+    expect(questions).toContain('[Answer]: A. REST, B. Events; Webhooks later');
+  });
+
+  it('keeps an existing question artifact authoritative', () => {
+    const value = input();
+    value.artifacts.push({
+      id: 'requirements-questions',
+      artifactType: 'requirements-analysis-questions',
+      stageId: 'requirements-analysis',
+      phase: 'inception',
+      content: '# Existing Questions\n',
+    });
+    value.humanTasks = [
+      {
+        humanTaskId: 'q-requirements',
+        stageInstanceId: 'si-requirements',
+        kind: 'question',
+        status: 'pending',
+        questions: [{ text: 'A newer gate?', type: 'single', options: [] }],
+      },
+    ];
+
+    const result = projectNativeWorkspace(value);
+    expect(
+      result.files.get(
+        'aidlc/spaces/default/intents/260811-payment-service/inception/requirements-analysis/requirements-analysis-questions.md',
+      ),
+    ).toBe('# Existing Questions\n');
+  });
+
+  it('rejects multi-repository projection for legacy flat distributions', () => {
+    const value = input();
+    value.workspaceLayout = 'flat';
+    expect(() => projectNativeWorkspace(value)).toThrow(/do not support multiple repositories/);
+  });
+
+  it('fails instead of inventing a path for an unmappable artifact', () => {
+    const value = input();
+    value.artifacts.push({
+      id: 'broken',
+      artifactType: 'mystery',
+      stageId: null,
+      content: 'x',
+    });
+    expect(() => projectNativeWorkspace(value)).toThrow(/no native producer stage/);
+  });
+
+  it('requires repository attribution for multi-repo reverse engineering', () => {
+    const value = input();
+    value.artifacts.push({
+      id: 'architecture',
+      artifactType: 'architecture',
+      stageId: 'reverse-engineering',
+      phase: 'inception',
+      content: '# Architecture',
+    });
+    expect(() => projectNativeWorkspace(value)).toThrow(/has no repository/);
+  });
+});

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -105,6 +105,32 @@ describe('projectNativeWorkspace', () => {
     expect(state).toContain('- **Current Stage**: requirements-analysis');
     expect(state).toContain('- **Project Type**: Unknown');
     expect(result.manifest.source.projectType).toBe('Unknown');
+    const root = 'aidlc/spaces/default/intents/260811-payment-service';
+    expect(JSON.parse(result.files.get(`${root}/runtime-graph.json`)).stages).toEqual([
+      expect.objectContaining({
+        stage_slug: 'intent-capture',
+        completed_at: expect.any(String),
+        agent: 'aidlc-product-agent',
+        outcome: 'approved',
+      }),
+      expect.objectContaining({
+        stage_slug: 'requirements-analysis',
+        completed_at: null,
+        agent: 'aidlc-product-agent',
+        outcome: 'pending',
+      }),
+    ]);
+    const audit = result.files.get(`${root}/audit/export.md`);
+    expect(audit).toContain(`**Event**: STAGE_STARTED
+**Stage**: intent-capture
+**Agent**: aidlc-product-agent`);
+    expect(audit).toContain(`**Event**: STAGE_COMPLETED
+**Stage**: intent-capture
+**Details**: Imported from Collaborative AI-DLC checkpoint`);
+    expect(audit).toContain(`**Event**: STAGE_STARTED
+**Stage**: requirements-analysis
+**Agent**: aidlc-product-agent`);
+    expect(audit).not.toContain('**Stage**: code-generation');
   });
 
   it('reads an explicit project type from canonical work products', () => {

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -138,6 +138,20 @@ describe('projectNativeWorkspace', () => {
     expect(audit).not.toContain('**Stage**: code-generation');
   });
 
+  it('flattens the project prompt before writing state fields', () => {
+    const value = input();
+    value.intent.prompt = 'Add payments\n- **State Version**: 1';
+
+    const result = projectNativeWorkspace(value);
+    const state = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md',
+    );
+
+    expect(state).toContain('- **Project**: Add payments - **State Version**: 1');
+    expect(state.match(/^- \*\*State Version\*\*:/gm)).toEqual(['- **State Version**:']);
+    expect(state).toContain('- **State Version**: 7');
+  });
+
   it('reads an explicit project type from canonical work products', () => {
     const value = input();
     value.artifacts[0].content =
@@ -565,6 +579,45 @@ X. Other (please specify)
     );
     expect(questions).toContain('## Q1. Which interfaces are required? (select all that apply)');
     expect(questions).toContain('[Answer]: A. REST, B. Events; Webhooks later');
+  });
+
+  it('flattens question headings and option fields', () => {
+    const value = input();
+    value.humanTasks = [
+      {
+        humanTaskId: 'q-requirements',
+        stageInstanceId: 'si-requirements',
+        kind: 'question',
+        status: 'answered',
+        questions: [
+          {
+            text: 'Which interfaces\n## Injected heading',
+            type: 'single',
+            options: [
+              {
+                label: 'REST\n[Answer]: injected',
+                description: 'Public API\nX. Injected option',
+              },
+            ],
+          },
+        ],
+        answer: {
+          answers: [{ selectedOptions: [0] }],
+        },
+      },
+    ];
+
+    const result = projectNativeWorkspace(value);
+    const questions = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/inception/requirements-analysis/requirements-analysis-questions.md',
+    );
+
+    expect(questions).toContain('## Q1. Which interfaces ## Injected heading');
+    expect(questions).toContain('A. REST [Answer]: injected — Public API X. Injected option');
+    expect(questions).toContain('[Answer]: A. REST [Answer]: injected');
+    expect(questions).not.toMatch(/^## Injected heading$/m);
+    expect(questions).not.toMatch(/^\[Answer\]: injected$/m);
+    expect(questions).not.toMatch(/^X\. Injected option$/m);
   });
 
   it('keeps an existing question artifact authoritative', () => {

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -108,7 +108,10 @@ describe('projectNativeWorkspace', () => {
     expect(state).toContain('- **Project Type**: Unknown');
     expect(result.manifest.source.projectType).toBe('Unknown');
     const root = 'aidlc/spaces/default/intents/260811-payment-service';
-    expect(JSON.parse(result.files.get(`${root}/runtime-graph.json`)).stages).toEqual([
+    const runtimeGraph = JSON.parse(result.files.get(`${root}/runtime-graph.json`));
+    expect(runtimeGraph.workflow_id).toBe('intent-1');
+    expect(runtimeGraph.started_at).toBe('2026-08-11T10:00:00.000Z');
+    expect(runtimeGraph.stages).toEqual([
       expect.objectContaining({
         stage_slug: 'intent-capture',
         completed_at: expect.any(String),

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -103,6 +103,31 @@ describe('projectNativeWorkspace', () => {
     expect(state).toContain('- [-] requirements-analysis — EXECUTE');
     expect(state).toContain('- [ ] code-generation — EXECUTE');
     expect(state).toContain('- **Current Stage**: requirements-analysis');
+    expect(state).toContain('- **Project Type**: Unknown');
+    expect(result.manifest.source.projectType).toBe('Unknown');
+  });
+
+  it('reads an explicit project type from canonical work products', () => {
+    const value = input();
+    value.artifacts[0].content =
+      '# Requirements\n\n| Field | Value |\n| --- | --- |\n| **Request Type** | New Project (Greenfield) |\n';
+    const result = projectNativeWorkspace(value);
+    const state = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md',
+    );
+    expect(state).toContain('- **Project Type**: Greenfield');
+  });
+
+  it('uses the recorded workspace classification ahead of fallback evidence', () => {
+    const value = input();
+    value.intent.projectType = 'brownfield';
+    value.artifacts[0].content = '- **Project Type**: Greenfield\n';
+    const result = projectNativeWorkspace(value);
+    const state = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md',
+    );
+    expect(state).toContain('- **Project Type**: Brownfield');
+    expect(result.manifest.source.projectType).toBe('Brownfield');
   });
 
   it('aggregates per-unit rows and reruns a partially successful stage', () => {
@@ -116,6 +141,125 @@ describe('projectNativeWorkspace', () => {
     expect(result.stages.find((stage) => stage.stageId === 'requirements-analysis').marker).toBe(
       '-',
     );
+  });
+
+  it('projects a partial Construction checkpoint with the complete Bolt DAG', () => {
+    const value = input();
+    value.stages[2].forEach = 'unit-of-work';
+    value.stageRows = [
+      { stageId: 'intent-capture', state: 'SUCCEEDED' },
+      { stageId: 'requirements-analysis', state: 'SUCCEEDED' },
+      {
+        stageId: 'code-generation',
+        unitSlug: 'upload-image',
+        state: 'SUCCEEDED',
+      },
+    ];
+    value.unitPlan = {
+      units: [
+        { slug: 'upload-image', dependsOn: [] },
+        { slug: 'identify-plant', dependsOn: ['upload-image'] },
+        { slug: 'display-result', dependsOn: ['identify-plant'] },
+      ],
+      batches: [['upload-image'], ['identify-plant'], ['display-result']],
+      walkingSkeleton: 'upload-image',
+      autonomyMode: 'gated',
+    };
+    value.unitRows = [
+      {
+        slug: 'upload-image',
+        sectionIndex: 1,
+        state: 'MERGED',
+        updatedAt: '2026-08-11T10:00:00.000Z',
+      },
+      { slug: 'identify-plant', sectionIndex: 1, state: 'PENDING' },
+      { slug: 'display-result', sectionIndex: 1, state: 'PENDING' },
+    ];
+
+    const result = projectNativeWorkspace(value);
+    const root = 'aidlc/spaces/default/intents/260811-payment-service';
+    expect(result.files.get(`${root}/aidlc-state.md`)).toContain(
+      '- **Construction Autonomy Mode**: gated',
+    );
+    expect(result.files.get(`${root}/aidlc-state.md`)).toContain('- **Skeleton Stance**: on');
+    expect(result.files.get(`${root}/aidlc-state.md`)).toContain('- [-] code-generation — EXECUTE');
+    expect(result.files.get(`${root}/aidlc-state.md`)).toContain(
+      '- **Last Completed Stage**: code-generation for unit upload-image',
+    );
+    expect(result.files.get(`${root}/aidlc-state.md`)).toContain(
+      '- **Next Action**: Execute code-generation for unit identify-plant',
+    );
+    expect(result.files.get(`${root}/inception/units-generation/unit-of-work-dependency.md`))
+      .toContain(`units:
+  - name: upload-image
+    depends_on: []
+  - name: identify-plant
+    depends_on: [upload-image]
+  - name: display-result
+    depends_on: [identify-plant]`);
+    expect(JSON.parse(result.files.get(`${root}/runtime-graph.json`)).bolt_dag).toEqual({
+      units: [
+        { name: 'upload-image', depends_on: [] },
+        { name: 'identify-plant', depends_on: ['upload-image'] },
+        { name: 'display-result', depends_on: ['identify-plant'] },
+      ],
+      batches: [['upload-image'], ['identify-plant'], ['display-result']],
+    });
+    const audit = result.files.get(`${root}/audit/export.md`);
+    expect(audit).toContain('**Event**: WORKFLOW_STARTED');
+    expect(audit).toContain(`## Bolt Completed
+**Timestamp**: 2026-08-11T10:00:00.000Z
+**Event**: BOLT_COMPLETED
+**Bolt names**: upload-image
+**Batch number**: 1
+**Bolt slug**: upload-image`);
+    expect(audit).toContain(`## Autonomy Mode Set
+**Timestamp**: 2026-08-11T10:00:00.000Z
+**Event**: AUTONOMY_MODE_SET
+**Mode**: gated`);
+    expect(result.manifest.construction).toMatchObject({
+      completedUnits: ['upload-image'],
+      remainingUnits: ['identify-plant', 'display-result'],
+      readyUnits: ['identify-plant'],
+      nextUnit: 'identify-plant',
+      autonomyMode: 'gated',
+      autonomyModeSource: 'cloud',
+    });
+  });
+
+  it('selects the next dependency-ready unit after multiple merged units', () => {
+    const value = input();
+    value.unitPlan = {
+      units: [
+        { slug: 'upload-image', dependsOn: [] },
+        { slug: 'identify-plant', dependsOn: ['upload-image'] },
+        { slug: 'display-result', dependsOn: ['identify-plant'] },
+      ],
+      walkingSkeleton: 'upload-image',
+    };
+    value.unitRows = [
+      { slug: 'upload-image', state: 'MERGED' },
+      { slug: 'identify-plant', state: 'MERGED' },
+      { slug: 'display-result', state: 'PENDING' },
+    ];
+
+    const result = projectNativeWorkspace(value);
+    expect(result.manifest.construction).toMatchObject({
+      completedUnits: ['upload-image', 'identify-plant'],
+      readyUnits: ['display-result'],
+      nextUnit: 'display-result',
+      autonomyMode: 'gated',
+      autonomyModeSource: 'export-default',
+    });
+    const audit = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/audit/export.md',
+    );
+    expect(audit.match(/\*\*Event\*\*: BOLT_COMPLETED/g)).toHaveLength(2);
+    expect(audit).toContain(`**Event**: AUTONOMY_MODE_SET
+**Mode**: gated`);
+    expect(
+      result.files.get('aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md'),
+    ).toContain('- **Construction Autonomy Mode**: gated');
   });
 
   it('projects legacy distributions into aidlc-docs', () => {
@@ -140,6 +284,33 @@ describe('projectNativeWorkspace', () => {
     expect(result.manifest.native.workspaceLayout).toBe('flat');
     expect(result.manifest.native.scope).toBe('feature-custom');
     expect(result.manifest.source.scope).toBe('feature-custom');
+  });
+
+  it('writes the Bolt DAG and audit to legacy flat paths', () => {
+    const value = input();
+    value.workspaceLayout = 'flat';
+    value.repositories = [value.repositories[0]];
+    value.unitPlan = {
+      units: [
+        { slug: 'upload-image', dependsOn: [] },
+        { slug: 'identify-plant', dependsOn: ['upload-image'] },
+      ],
+      batches: [['upload-image'], ['identify-plant']],
+    };
+    value.unitRows = [
+      { slug: 'upload-image', state: 'MERGED' },
+      { slug: 'identify-plant', state: 'PENDING' },
+    ];
+
+    const result = projectNativeWorkspace(value);
+    expect(result.files.get('aidlc-docs/audit.md')).toContain('WORKFLOW_STARTED');
+    expect(JSON.parse(result.files.get('aidlc-docs/runtime-graph.json')).bolt_dag.batches).toEqual([
+      ['upload-image'],
+      ['identify-plant'],
+    ]);
+    expect(
+      result.files.get('aidlc-docs/inception/units-generation/unit-of-work-dependency.md'),
+    ).toContain('depends_on: [upload-image]');
   });
 
   it('reconstructs a pending native question file from a human gate', () => {

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -253,6 +253,93 @@ describe('projectNativeWorkspace', () => {
     });
   });
 
+  it('resumes the active unit at its current Construction stage', () => {
+    const value = input();
+    value.stages.splice(
+      2,
+      0,
+      {
+        stageId: 'functional-design',
+        phase: 'construction',
+        number: '3.1',
+        leadAgent: 'aidlc-architect-agent',
+        produces: ['functional-design'],
+        forEach: 'unit-of-work',
+      },
+      {
+        stageId: 'infrastructure-design',
+        phase: 'construction',
+        number: '3.4',
+        leadAgent: 'aidlc-architect-agent',
+        produces: ['infrastructure-design'],
+        forEach: 'unit-of-work',
+      },
+    );
+    value.stages.find((stage) => stage.stageId === 'code-generation').forEach = 'unit-of-work';
+    value.stageRows = [
+      { stageId: 'intent-capture', state: 'SUCCEEDED' },
+      { stageId: 'requirements-analysis', state: 'SUCCEEDED' },
+      {
+        stageId: 'functional-design',
+        unitSlug: 'upload-image',
+        state: 'SUCCEEDED',
+      },
+      {
+        stageId: 'infrastructure-design',
+        unitSlug: 'upload-image',
+        state: 'SUCCEEDED',
+      },
+      {
+        stageId: 'code-generation',
+        unitSlug: 'upload-image',
+        state: 'SUCCEEDED',
+      },
+      {
+        stageId: 'functional-design',
+        unitSlug: 'identify-plant',
+        state: 'SUCCEEDED',
+      },
+      {
+        stageId: 'infrastructure-design',
+        unitSlug: 'identify-plant',
+        state: 'SUCCEEDED',
+      },
+      {
+        stageId: 'code-generation',
+        unitSlug: 'identify-plant',
+        state: 'WAITING_FOR_HUMAN',
+      },
+    ];
+    value.unitPlan = {
+      units: [
+        { slug: 'upload-image', dependsOn: [] },
+        { slug: 'identify-plant', dependsOn: ['upload-image'] },
+        { slug: 'display-result', dependsOn: ['identify-plant'] },
+      ],
+      batches: [['upload-image'], ['identify-plant'], ['display-result']],
+      walkingSkeleton: 'upload-image',
+      autonomyMode: 'gated',
+    };
+    value.unitRows = [
+      { slug: 'upload-image', sectionIndex: 1, state: 'MERGED' },
+      { slug: 'identify-plant', sectionIndex: 1, state: 'RUNNING' },
+      { slug: 'display-result', sectionIndex: 1, state: 'PENDING' },
+    ];
+
+    const result = projectNativeWorkspace(value);
+    const state = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md',
+    );
+    expect(state).toContain('- [x] functional-design — EXECUTE');
+    expect(state).toContain('- [x] infrastructure-design — EXECUTE');
+    expect(state).toContain('- [-] code-generation — EXECUTE');
+    expect(state).toContain('- **Current Stage**: code-generation');
+    expect(state).toContain(
+      '- **Last Completed Stage**: infrastructure-design for unit identify-plant',
+    );
+    expect(state).toContain('- **Next Action**: Execute code-generation for unit identify-plant');
+  });
+
   it('selects the next dependency-ready unit after multiple merged units', () => {
     const value = input();
     value.unitPlan = {

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -50,12 +50,14 @@ const input = () => ({
   ],
   repositories: [
     {
-      name: 'checkout-api',
+      id: 'example/checkout-api',
+      directory: 'checkout-api',
       url: 'git@github.com:example/checkout-api.git',
       branch: 'aidlc/intent-1',
     },
     {
-      name: 'checkout-web',
+      id: 'example/checkout-web',
+      directory: 'checkout-web',
       url: 'git@github.com:example/checkout-web.git',
       branch: 'aidlc/intent-1',
     },
@@ -561,5 +563,50 @@ X. Other (please specify)
       content: '# Architecture',
     });
     expect(() => projectNativeWorkspace(value)).toThrow(/has no repository/);
+  });
+
+  it('maps canonical repository identities to collision-safe CodeKB directories', () => {
+    const value = input();
+    value.repositories = [
+      {
+        id: 'org-a/api',
+        directory: 'org-a_api',
+        url: 'git@github.com:org-a/api.git',
+        branch: 'aidlc/intent-1',
+      },
+      {
+        id: 'org-b/api',
+        directory: 'org-b_api',
+        url: 'git@github.com:org-b/api.git',
+        branch: 'aidlc/intent-1',
+      },
+    ];
+    value.artifacts.push({
+      id: 'architecture',
+      artifactType: 'architecture',
+      stageId: 'reverse-engineering',
+      phase: 'inception',
+      repository: 'org-b/api',
+      content: '# Architecture',
+    });
+
+    const result = projectNativeWorkspace(value);
+
+    expect(result.files.get('aidlc/spaces/default/codekb/org-b_api/architecture.md')).toBe(
+      '# Architecture',
+    );
+    expect(result.manifest.repositories).toEqual(value.repositories);
+    expect(JSON.parse(result.files.get('repos.json')).repos).toEqual([
+      {
+        name: 'org-a_api',
+        url: 'git@github.com:org-a/api.git',
+        branch: 'aidlc/intent-1',
+      },
+      {
+        name: 'org-b_api',
+        url: 'git@github.com:org-b/api.git',
+        branch: 'aidlc/intent-1',
+      },
+    ]);
   });
 });

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -344,6 +344,8 @@ describe('projectNativeWorkspace', () => {
 
   it('selects the next dependency-ready unit after multiple merged units', () => {
     const value = input();
+    value.stageRows[1].state = 'SUCCEEDED';
+    value.stages[2].forEach = 'unit-of-work';
     value.unitPlan = {
       units: [
         { slug: 'upload-image', dependsOn: [] },
@@ -363,18 +365,18 @@ describe('projectNativeWorkspace', () => {
       completedUnits: ['upload-image', 'identify-plant'],
       readyUnits: ['display-result'],
       nextUnit: 'display-result',
-      autonomyMode: 'gated',
-      autonomyModeSource: 'export-default',
+      autonomyMode: null,
+      autonomyModeSource: 'unset',
     });
     const audit = result.files.get(
       'aidlc/spaces/default/intents/260811-payment-service/audit/export.md',
     );
     expect(audit.match(/\*\*Event\*\*: BOLT_COMPLETED/g)).toHaveLength(2);
-    expect(audit).toContain(`**Event**: AUTONOMY_MODE_SET
-**Mode**: gated`);
-    expect(
-      result.files.get('aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md'),
-    ).toContain('- **Construction Autonomy Mode**: gated');
+    expect(audit).not.toContain('**Event**: AUTONOMY_MODE_SET');
+    const state = result.files.get(
+      'aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md',
+    );
+    expect(state).toContain('- **Construction Autonomy Mode**: unset');
   });
 
   it('projects legacy distributions into aidlc-docs', () => {

--- a/lambda/shared/test/native-workspace-projector.test.js
+++ b/lambda/shared/test/native-workspace-projector.test.js
@@ -188,6 +188,82 @@ describe('projectNativeWorkspace', () => {
     );
   });
 
+  it('renders a waiting stage as an awaiting-approval marker', () => {
+    const value = input();
+    value.stageRows[1].state = 'WAITING_FOR_HUMAN';
+    value.humanTasks = [
+      {
+        humanTaskId: 'approval-1',
+        stageInstanceId: 'si-requirements',
+        kind: 'approval',
+        status: 'pending',
+      },
+    ];
+
+    const result = projectNativeWorkspace(value);
+
+    expect(result.stages.find((stage) => stage.stageId === 'requirements-analysis').marker).toBe(
+      '?',
+    );
+    expect(
+      result.files.get('aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md'),
+    ).toContain('- [?] requirements-analysis — EXECUTE');
+    expect(
+      result.files.get('aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md'),
+    ).toContain('- **Current Stage**: requirements-analysis');
+    expect(
+      result.files.get('aidlc/spaces/default/intents/260811-payment-service/aidlc-state.md'),
+    ).toContain('- **Next Action**: Await approval for requirements-analysis');
+  });
+
+  it('rejects stages with phases the native workspace cannot represent', () => {
+    const value = input();
+    value.stages[1].phase = 'delivery';
+
+    expect(() => projectNativeWorkspace(value)).toThrow(
+      /stage requirements-analysis has unsupported phase delivery/,
+    );
+  });
+
+  it('rejects artifacts without a type instead of inventing intent.md', () => {
+    const value = input();
+    value.artifacts[0].artifactType = null;
+
+    expect(() => projectNativeWorkspace(value)).toThrow(/artifact artifact-1 has no artifact type/);
+  });
+
+  it('warns when native continuation cannot preserve cloud-only unit and gate semantics', () => {
+    const value = input();
+    value.unitPlan = {
+      units: [
+        { slug: 'api', kind: 'service', dependsOn: [] },
+        { slug: 'web', dependsOn: ['api'] },
+      ],
+      skipMatrix: { web: ['code-generation'] },
+    };
+    value.humanTasks = [
+      {
+        humanTaskId: 'approval-1',
+        kind: 'approval',
+        status: 'answered',
+      },
+      {
+        humanTaskId: 'validation-1',
+        kind: 'validation',
+        status: 'pending',
+      },
+    ];
+
+    const result = projectNativeWorkspace(value);
+
+    expect(result.warnings).toEqual([
+      'Unit kinds are not represented in the native Bolt DAG for: api.',
+      'Per-unit stage skips affect exported progress but are not preserved as native continuation rules for: web.',
+      'Non-question workflow gates are not represented as native question artifacts: approval, validation.',
+    ]);
+    expect(result.manifest.warnings).toEqual(result.warnings);
+  });
+
   it('projects a stage skipped for every unit as SKIPPED without synthetic timeline entries', () => {
     const value = input();
     value.stageRows[1].state = 'SUCCEEDED';

--- a/lambda/shared/test/repo-fetch.test.js
+++ b/lambda/shared/test/repo-fetch.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import zlib from 'node:zlib';
 import tar from 'tar-stream';
-import { fetchCoreFiles, tarballUrl } from '../repo-fetch.js';
+import { fetchCoreFiles, fetchRepoFiles, tarballUrl } from '../repo-fetch.js';
 
 // Builds a gzipped tarball whose entries are nested under a top-level
 // `<repo>-<ref>/` dir, mirroring GitHub's codeload archive layout.
@@ -67,10 +67,24 @@ describe('fetchCoreFiles', () => {
   it('hard-fails when the tarball has no core/ files', async () => {
     const tarball = await makeTarball({ 'README.md': 'only readme' });
     mockFetchReturning(tarball);
-    await expect(fetchCoreFiles('abc123')).rejects.toThrow(/no core\/ files/);
+    await expect(fetchCoreFiles('abc123')).rejects.toThrow(/no files found for prefixes core\//);
   });
 
   it('requires a ref', async () => {
     await expect(fetchCoreFiles('')).rejects.toThrow(/ref/);
+  });
+});
+
+describe('fetchRepoFiles', () => {
+  it('returns binary-safe files from all requested prefixes', async () => {
+    const tarball = await makeTarball({
+      'core/stages/a.md': '# Stage A',
+      'dist/codex/AGENTS.md': '# Codex',
+      'README.md': 'ignored',
+    });
+    mockFetchReturning(tarball);
+    const files = await fetchRepoFiles('abc123', { prefixes: ['core/', 'dist/codex/'] });
+    expect(Buffer.isBuffer(files.get('core/stages/a.md'))).toBe(true);
+    expect(files.get('dist/codex/AGENTS.md').toString('utf8')).toContain('Codex');
   });
 });

--- a/lambda/shared/test/repo-fetch.test.js
+++ b/lambda/shared/test/repo-fetch.test.js
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import zlib from 'node:zlib';
 import tar from 'tar-stream';
-import { fetchCoreFiles, fetchRepoFiles, tarballUrl } from '../repo-fetch.js';
+import {
+  extractFiles,
+  fetchCoreFiles,
+  fetchRepoFiles,
+  responseToBuffer,
+  tarballUrl,
+} from '../repo-fetch.js';
 
 // Builds a gzipped tarball whose entries are nested under a top-level
 // `<repo>-<ref>/` dir, mirroring GitHub's codeload archive layout.
@@ -86,5 +92,51 @@ describe('fetchRepoFiles', () => {
     const files = await fetchRepoFiles('abc123', { prefixes: ['core/', 'dist/codex/'] });
     expect(Buffer.isBuffer(files.get('core/stages/a.md'))).toBe(true);
     expect(files.get('dist/codex/AGENTS.md').toString('utf8')).toContain('Codex');
+  });
+
+  it('rejects a response whose declared size exceeds the download limit', async () => {
+    await expect(
+      responseToBuffer(
+        {
+          headers: { get: () => '11' },
+          arrayBuffer: async () => Buffer.alloc(0),
+        },
+        10,
+      ),
+    ).rejects.toThrow(/tarball exceeds 10 bytes/);
+  });
+
+  it('rejects a streamed response that exceeds the download limit', async () => {
+    await expect(
+      responseToBuffer(
+        {
+          headers: { get: () => null },
+          body: {
+            async *[Symbol.asyncIterator]() {
+              yield Buffer.alloc(6);
+              yield Buffer.alloc(5);
+            },
+          },
+        },
+        10,
+      ),
+    ).rejects.toThrow(/tarball exceeds 10 bytes/);
+  });
+
+  it('bounds matching files while extracting the tarball', async () => {
+    const tarball = await makeTarball({
+      'dist/codex/a.txt': '123456',
+      'dist/codex/b.txt': '123456',
+    });
+    await expect(extractFiles(tarball, ['dist/codex/'], { maxRetainedBytes: 10 })).rejects.toThrow(
+      /matching files exceed 10 bytes/,
+    );
+  });
+
+  it('bounds the total expanded tarball size', async () => {
+    const tarball = await makeTarball({ 'README.md': 'x'.repeat(10_000) });
+    await expect(extractFiles(tarball, ['core/'], { maxUncompressedBytes: 1_000 })).rejects.toThrow(
+      /tarball expands beyond 1000 bytes/,
+    );
   });
 });

--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -11,6 +11,7 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 import {
   executionMetaKey,
+  workflowCheckpointKey,
   stageKey,
   humanTaskKey,
   steeringKey,
@@ -49,6 +50,7 @@ import { createProcessStore } from '../v2-process-store.js';
 describe('v2-process-keys', () => {
   it('namespaces every record under EXEC#<id>', () => {
     expect(executionMetaKey('e1')).toEqual({ pk: 'EXEC#e1', sk: 'META' });
+    expect(workflowCheckpointKey('e1')).toEqual({ pk: 'EXEC#e1', sk: 'CHECKPOINT' });
     expect(stageKey('e1', 'si-1')).toEqual({ pk: 'EXEC#e1', sk: 'STAGE#si-1' });
     expect(humanTaskKey('e1', 'h1')).toEqual({ pk: 'EXEC#e1', sk: 'HUMAN#h1' });
     expect(trackerSyncKey('e1')).toEqual({ pk: 'EXEC#e1', sk: 'TRACKERSYNC' });
@@ -180,6 +182,23 @@ describe('createProcessStore', () => {
     expect(consistent).toMatchObject({
       Key: executionMetaKey('e1'),
       ConsistentRead: true,
+    });
+  });
+
+  it('stores and retrieves the latest workflow checkpoint', async () => {
+    ddb.on(PutCommand).resolves({});
+    ddb.on(GetCommand).resolves({
+      Item: { pk: 'EXEC#e1', sk: 'CHECKPOINT', executionId: 'e1', checkpointId: 'cp1' },
+    });
+    await store.putWorkflowCheckpoint({ executionId: 'e1', checkpointId: 'cp1' });
+    expect(ddb.commandCalls(PutCommand)[0].args[0].input.Item).toMatchObject({
+      pk: 'EXEC#e1',
+      sk: 'CHECKPOINT',
+      checkpointId: 'cp1',
+      updatedAt: 'T',
+    });
+    await expect(store.getWorkflowCheckpoint('e1')).resolves.toMatchObject({
+      checkpointId: 'cp1',
     });
   });
 

--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -223,6 +223,14 @@ describe('createProcessStore', () => {
     ).rejects.toThrow('failure must be {code, message} or null');
   });
 
+  it('persists a validated workspace classification', async () => {
+    ddb.on(UpdateCommand).resolves({ Attributes: { projectType: 'greenfield' } });
+    await store.updateExecution({ executionId: 'e1', projectType: 'greenfield' });
+    const input = ddb.commandCalls(UpdateCommand)[0].args[0].input;
+    expect(input.ExpressionAttributeValues[':pt']).toBe('greenfield');
+    expect(input.UpdateExpression).toContain('projectType = :pt');
+  });
+
   it('removes the sparse active projection on a terminal execution state', async () => {
     ddb.on(UpdateCommand).resolves({ Attributes: { status: 'FAILED' } });
     await store.updateExecution({

--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -378,6 +378,7 @@ describe('createProcessStore', () => {
       cli: 'claude',
       cliSessionId: 'sess-1',
       stageCallbackId: 'cb-2',
+      aidlcRepoRef: 'a'.repeat(40),
     });
     const input = ddb.commandCalls(UpdateCommand)[0].args[0].input;
     expect(input.ExpressionAttributeValues[':state']).toBe('RUNNING');
@@ -389,6 +390,8 @@ describe('createProcessStore', () => {
     expect(input.UpdateExpression).not.toContain('attempt');
     expect(input.ExpressionAttributeValues[':csid']).toBe('sess-1');
     expect(input.ExpressionAttributeValues[':scb']).toBe('cb-2');
+    expect(input.UpdateExpression).toContain('aidlcRepoRef = :aidlcRepoRef');
+    expect(input.ExpressionAttributeValues[':aidlcRepoRef']).toBe('a'.repeat(40));
   });
 
   it('resumeStageRow tolerates a missing/unparsable park stamp (waitMs unchanged, no NaN)', async () => {

--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
 import {
   BatchWriteCommand,
+  DeleteCommand,
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
@@ -186,19 +187,39 @@ describe('createProcessStore', () => {
   });
 
   it('stores and retrieves the latest workflow checkpoint', async () => {
-    ddb.on(PutCommand).resolves({});
+    ddb.on(TransactWriteCommand).resolves({});
     ddb.on(GetCommand).resolves({
       Item: { pk: 'EXEC#e1', sk: 'CHECKPOINT', executionId: 'e1', checkpointId: 'cp1' },
     });
-    await store.putWorkflowCheckpoint({ executionId: 'e1', checkpointId: 'cp1' });
-    expect(ddb.commandCalls(PutCommand)[0].args[0].input.Item).toMatchObject({
+    await store.putWorkflowCheckpoint({
+      executionId: 'e1',
+      checkpointId: 'cp1',
+      orchestratorRunId: 'run-1',
+    });
+    const transaction = ddb.commandCalls(TransactWriteCommand)[0].args[0].input.TransactItems;
+    expect(transaction[0].ConditionCheck).toMatchObject({
+      Key: { pk: 'EXEC#e1', sk: 'META' },
+      ConditionExpression: 'orchestratorRunId = :orchestratorRunId',
+      ExpressionAttributeValues: { ':orchestratorRunId': 'run-1' },
+    });
+    expect(transaction[1].Put.Item).toMatchObject({
       pk: 'EXEC#e1',
       sk: 'CHECKPOINT',
       checkpointId: 'cp1',
+      orchestratorRunId: 'run-1',
       updatedAt: 'T',
     });
     await expect(store.getWorkflowCheckpoint('e1')).resolves.toMatchObject({
       checkpointId: 'cp1',
+    });
+  });
+
+  it('deletes the latest workflow checkpoint', async () => {
+    ddb.on(DeleteCommand).resolves({ Attributes: { checkpointId: 'cp1' } });
+    await expect(store.deleteWorkflowCheckpoint('e1')).resolves.toEqual({ checkpointId: 'cp1' });
+    expect(ddb.commandCalls(DeleteCommand)[0].args[0].input).toMatchObject({
+      Key: { pk: 'EXEC#e1', sk: 'CHECKPOINT' },
+      ReturnValues: 'ALL_OLD',
     });
   });
 

--- a/lambda/shared/test/v2-workflow-plan.test.js
+++ b/lambda/shared/test/v2-workflow-plan.test.js
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { mockClient } from 'aws-sdk-client-mock';
-import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { loadExecutionPlan, loadWorkflowScopes } from '../v2-workflow-plan.js';
+import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  __test,
+  assembleWorkflow,
+  loadExecutionPlan,
+  loadWorkflowScopes,
+} from '../v2-workflow-plan.js';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const TABLE = 'blocks-test';
@@ -14,6 +19,8 @@ const wfItems = [
     pk: 'WF#SYSTEM#aidlc-v2',
     sk: 'V#1#PLACEMENT#stage-a',
     stageId: 'stage-a',
+    stageTenant: 'SYSTEM',
+    pinnedVersion: 1,
     order: 0,
     scopeMembership: { feature: 'EXECUTE' },
   },
@@ -21,6 +28,8 @@ const wfItems = [
     pk: 'WF#SYSTEM#aidlc-v2',
     sk: 'V#1#PLACEMENT#stage-b',
     stageId: 'stage-b',
+    stageTenant: 'SYSTEM',
+    pinnedVersion: 1,
     order: 1,
     scopeMembership: { feature: 'EXECUTE' },
   },
@@ -53,6 +62,13 @@ const agentBlocks = [{ GSI1PK: 'TENANT#SYSTEM#AGENT', id: 'agent-x', blockId: 'a
 
 beforeEach(() => {
   ddbMock.reset();
+  ddbMock.on(GetCommand).callsFake((input) => ({
+    Item: stageBlocks.find(
+      (stage) =>
+        input.Key.pk === `BLOCK#SYSTEM#STAGE#${stage.blockId}` &&
+        input.Key.sk === `V#${stage.version}`,
+    ),
+  }));
   ddbMock.on(QueryCommand).callsFake((input) => {
     const values = input.ExpressionAttributeValues || {};
     if (input.IndexName === 'GSI1') {
@@ -68,6 +84,45 @@ beforeEach(() => {
 });
 
 describe('loadExecutionPlan', () => {
+  it('resolves legacy placements without ownership metadata through the merged catalog', async () => {
+    const legacyStage = {
+      GSI1PK: 'TENANT#default#STAGE',
+      id: 'legacy-stage',
+      blockId: 'legacy-stage',
+      version: 3,
+    };
+    ddbMock.reset();
+    ddbMock.on(QueryCommand).callsFake((input) => {
+      const pk = input.ExpressionAttributeValues?.[':pk'];
+      return { Items: pk === 'TENANT#default#STAGE' ? [legacyStage] : [] };
+    });
+
+    await expect(
+      __test.loadPlacedStages(ddbMock, TABLE, [{ stageId: 'legacy-stage' }]),
+    ).resolves.toEqual([legacyStage]);
+    expect(ddbMock.commandCalls(GetCommand)).toHaveLength(0);
+  });
+
+  it('preserves missing ownership metadata when assembling a legacy workflow snapshot', () => {
+    const workflow = assembleWorkflow(
+      [
+        { sk: 'V#1#META' },
+        {
+          sk: 'V#1#PLACEMENT#legacy-stage',
+          stageId: 'legacy-stage',
+          scopeMembership: { feature: 'EXECUTE' },
+        },
+      ],
+      { workflowId: 'legacy', workflowVersion: 1 },
+    );
+
+    expect(workflow.placements[0]).toMatchObject({
+      stageId: 'legacy-stage',
+      stageTenant: null,
+      pinnedVersion: null,
+    });
+  });
+
   it('returns the ordered in-scope stage list for a pinned workflow', async () => {
     const result = await loadExecutionPlan({
       ddb: ddbMock,
@@ -90,6 +145,26 @@ describe('loadExecutionPlan', () => {
     });
     expect(result.valid).toBe(true);
     expect((result.errors ?? []).map((e) => e.code)).not.toContain('unresolved_agent');
+  });
+
+  it('loads the immutable stage version pinned by the workflow snapshot', async () => {
+    const result = await loadExecutionPlan({
+      ddb: ddbMock,
+      tableName: TABLE,
+      workflowId: 'aidlc-v2',
+      workflowVersion: 1,
+      scope: 'feature',
+    });
+    expect(result.valid).toBe(true);
+    const gets = ddbMock.commandCalls(GetCommand).map((call) => call.args[0].input.Key);
+    expect(gets).toContainEqual({
+      pk: 'BLOCK#SYSTEM#STAGE#stage-a',
+      sk: 'V#1',
+    });
+    expect(gets).toContainEqual({
+      pk: 'BLOCK#SYSTEM#STAGE#stage-b',
+      sk: 'V#1',
+    });
   });
 
   it('fails closed when the workflow version is not found', async () => {
@@ -146,12 +221,21 @@ describe('loadExecutionPlan', () => {
         pk: 'WF#default#aidlc-v2',
         sk: 'V#1#PLACEMENT#stage-a',
         stageId: 'stage-a',
+        stageTenant: 'SYSTEM',
+        pinnedVersion: 1,
         order: 0,
         scopeMembership: { feature: 'EXECUTE' },
       },
       { pk: 'WF#default#aidlc-v2', sk: 'V#1#SCOPEREF#feature', scopeId: 'feature' },
     ];
     ddbMock.reset();
+    ddbMock.on(GetCommand).callsFake((input) => ({
+      Item: stageBlocks.find(
+        (stage) =>
+          input.Key.pk === `BLOCK#SYSTEM#STAGE#${stage.blockId}` &&
+          input.Key.sk === `V#${stage.version}`,
+      ),
+    }));
     ddbMock.on(QueryCommand).callsFake((input) => {
       const values = input.ExpressionAttributeValues || {};
       if (input.IndexName === 'GSI1') {
@@ -180,6 +264,13 @@ describe('loadExecutionPlan', () => {
     // 1MB pages: a dropped second page loses PLACEMENT#stage-b (stage silently
     // skipped) or its STAGE block (plan fails unresolved_stage).
     ddbMock.reset();
+    ddbMock.on(GetCommand).callsFake((input) => ({
+      Item: stageBlocks.find(
+        (stage) =>
+          input.Key.pk === `BLOCK#SYSTEM#STAGE#${stage.blockId}` &&
+          input.Key.sk === `V#${stage.version}`,
+      ),
+    }));
     ddbMock.on(QueryCommand).callsFake((input) => {
       const values = input.ExpressionAttributeValues || {};
       if (input.IndexName === 'GSI1') {

--- a/lambda/shared/test/v2-workflow-plan.test.js
+++ b/lambda/shared/test/v2-workflow-plan.test.js
@@ -10,11 +10,12 @@ import {
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const TABLE = 'blocks-test';
+const SOURCE_REF = 'a'.repeat(40);
 
 // Minimal fixture: a workflow with two placed stages (a→b via produces/consumes)
 // in scope "feature", plus the two STAGE blocks.
 const wfItems = [
-  { pk: 'WF#SYSTEM#aidlc-v2', sk: 'V#1#META', version: 1 },
+  { pk: 'WF#SYSTEM#aidlc-v2', sk: 'V#1#META', version: 1, sourceRef: SOURCE_REF },
   {
     pk: 'WF#SYSTEM#aidlc-v2',
     sk: 'V#1#PLACEMENT#stage-a',
@@ -44,6 +45,7 @@ const stageBlocks = [
     version: 1,
     phase: 'inception',
     leadAgent: 'agent-x',
+    sourceRef: SOURCE_REF,
   },
   {
     GSI1PK: 'TENANT#SYSTEM#STAGE',
@@ -53,21 +55,37 @@ const stageBlocks = [
     phase: 'construction',
     leadAgent: 'agent-x',
     reviewer: 'agent-x',
+    sourceRef: SOURCE_REF,
   },
 ];
 
 // The AGENT blocks the stages above reference. loadExecutionPlan must load these
 // into agentsById or every agent-bearing stage fails `unresolved_agent`.
-const agentBlocks = [{ GSI1PK: 'TENANT#SYSTEM#AGENT', id: 'agent-x', blockId: 'agent-x' }];
+const agentBlocks = [
+  {
+    GSI1PK: 'TENANT#SYSTEM#AGENT',
+    tenantId: 'SYSTEM',
+    id: 'agent-x',
+    blockId: 'agent-x',
+    version: 4,
+    sourceRef: SOURCE_REF,
+  },
+];
 
 beforeEach(() => {
   ddbMock.reset();
   ddbMock.on(GetCommand).callsFake((input) => ({
-    Item: stageBlocks.find(
-      (stage) =>
-        input.Key.pk === `BLOCK#SYSTEM#STAGE#${stage.blockId}` &&
-        input.Key.sk === `V#${stage.version}`,
-    ),
+    Item:
+      stageBlocks.find(
+        (stage) =>
+          input.Key.pk === `BLOCK#SYSTEM#STAGE#${stage.blockId}` &&
+          input.Key.sk === `V#${stage.version}`,
+      ) ??
+      agentBlocks.find(
+        (agent) =>
+          input.Key.pk === `BLOCK#SYSTEM#AGENT#${agent.blockId}` &&
+          input.Key.sk === `V#${agent.version}`,
+      ),
   }));
   ddbMock.on(QueryCommand).callsFake((input) => {
     const values = input.ExpressionAttributeValues || {};
@@ -145,6 +163,32 @@ describe('loadExecutionPlan', () => {
     });
     expect(result.valid).toBe(true);
     expect((result.errors ?? []).map((e) => e.code)).not.toContain('unresolved_agent');
+    expect(result.methodologyPins.AGENT).toEqual({
+      'agent-x': { tenantId: 'SYSTEM', version: 4 },
+    });
+    expect(result.methodologySourceRefs).toEqual([SOURCE_REF]);
+  });
+
+  it('reloads supporting methodology from exact create-time version pins', async () => {
+    const result = await loadExecutionPlan({
+      ddb: ddbMock,
+      tableName: TABLE,
+      workflowId: 'aidlc-v2',
+      workflowVersion: 1,
+      scope: 'feature',
+      methodologyPins: {
+        AGENT: { 'agent-x': { tenantId: 'SYSTEM', version: 4 } },
+        SENSOR: {},
+        RULE: {},
+        ARTIFACT: {},
+        KNOWLEDGE: {},
+      },
+    });
+    expect(result.valid).toBe(true);
+    expect(ddbMock.commandCalls(GetCommand).map((call) => call.args[0].input.Key)).toContainEqual({
+      pk: 'BLOCK#SYSTEM#AGENT#agent-x',
+      sk: 'V#4',
+    });
   });
 
   it('loads the immutable stage version pinned by the workflow snapshot', async () => {

--- a/lambda/shared/test/workflow-checkpoint.test.js
+++ b/lambda/shared/test/workflow-checkpoint.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_WORKFLOW_CHECKPOINT_BYTES,
+  buildWorkflowCheckpoint,
+  canonicalJson,
+  checkpointProjection,
+} from '../workflow-checkpoint.js';
+
+describe('workflow checkpoint', () => {
+  const records = {
+    meta: { pk: 'EXEC#i1', sk: 'META', executionId: 'i1', projectId: 'p1' },
+    stages: [{ pk: 'EXEC#i1', sk: 'STAGE#s1', stageInstanceId: 's1', state: 'SUCCEEDED' }],
+    humanTasks: [],
+    unitPlan: null,
+    units: [],
+  };
+
+  it('creates a deterministic projector snapshot without infrastructure keys', () => {
+    const input = {
+      executionId: 'i1',
+      createdAt: '2026-08-14T10:00:00.000Z',
+      sourceStageInstanceId: 's1',
+      records,
+      artifactRefs: [{ artifactId: 'a1', versionId: 'a1:sha256:1', snapshotHash: '1' }],
+    };
+    const first = buildWorkflowCheckpoint(input);
+    const second = buildWorkflowCheckpoint({ ...input, createdAt: 'later' });
+    expect(first.checkpointId).toBe(second.checkpointId);
+    expect(first.process.meta).not.toHaveProperty('pk');
+    expect(checkpointProjection(first)).toEqual({
+      meta: { executionId: 'i1', projectId: 'p1' },
+      stages: [{ stageInstanceId: 's1', state: 'SUCCEEDED' }],
+      humanTasks: [],
+      unitPlan: null,
+      units: [],
+    });
+  });
+
+  it('canonicalizes nested object properties independently of insertion order', () => {
+    const first = {
+      stageRows: [
+        {
+          stageInstanceId: 's1',
+          state: 'WAITING',
+          metadata: { phase: 'inception', stageId: 'requirements-analysis' },
+        },
+      ],
+    };
+    const second = {
+      stageRows: [
+        {
+          metadata: { stageId: 'requirements-analysis', phase: 'inception' },
+          state: 'WAITING',
+          stageInstanceId: 's1',
+        },
+      ],
+    };
+
+    expect(canonicalJson(first)).toBe(canonicalJson(second));
+  });
+
+  it('refuses a checkpoint that could exceed the DynamoDB item limit', () => {
+    expect(() =>
+      buildWorkflowCheckpoint({
+        executionId: 'i1',
+        createdAt: 'T',
+        records: {
+          ...records,
+          humanTasks: [{ humanTaskId: 'h1', answer: 'x'.repeat(MAX_WORKFLOW_CHECKPOINT_BYTES) }],
+        },
+      }),
+    ).toThrow(/exceeds/);
+  });
+});

--- a/lambda/shared/v2-execution-plan.js
+++ b/lambda/shared/v2-execution-plan.js
@@ -603,6 +603,8 @@ const buildExecutionPlan = ({
         stageInstanceId: stageInstanceId(namespace, stageId),
         stageId,
         stageVersion,
+        stageTenant: placement.stageTenant ?? null,
+        pinnedVersion: placement.pinnedVersion ?? null,
         phase: stage.phase ?? null,
         order: placement.order ?? 0,
         mode: stage.mode ?? 'inline',

--- a/lambda/shared/v2-process-keys.js
+++ b/lambda/shared/v2-process-keys.js
@@ -291,6 +291,9 @@ const buildExecutionMeta = ({
   status = 'CREATED',
   workflowId,
   workflowVersion,
+  // Commit-pinned native AI-DLC distribution used by this intent. Export
+  // prefers this snapshot over the deployment's current baseline ref.
+  aidlcRepoRef = null,
   scope = null,
   currentPhase = null,
   currentStage = null,
@@ -434,6 +437,7 @@ const buildExecutionMeta = ({
   status,
   workflowId,
   workflowVersion,
+  aidlcRepoRef,
   scope,
   currentPhase,
   currentStage,

--- a/lambda/shared/v2-process-keys.js
+++ b/lambda/shared/v2-process-keys.js
@@ -376,6 +376,10 @@ const buildExecutionMeta = ({
   // 'gated' (one approval gate per parallel batch). null until the ladder
   // prompt after the walking-skeleton gate is answered.
   constructionAutonomyMode = null,
+  // Structured result of the always-run workspace-detection stage. Persisted
+  // through a stage-scoped MCP tool so downstream consumers never need to
+  // infer methodology context from repository presence or agent prose.
+  projectType = null,
   // Optional tracker reference the intent was kicked off from (GitHub issue,
   // Jira artifact, …). The imported text lives in `prompt`; this is just the
   // provenance link surfaced in the UI. null when typed by hand. Mirrors the v1
@@ -467,6 +471,7 @@ const buildExecutionMeta = ({
   maxParallelUnits,
   prStrategy,
   constructionAutonomyMode,
+  projectType,
   source,
   planWarnings,
   orchestratorRunId,

--- a/lambda/shared/v2-process-keys.js
+++ b/lambda/shared/v2-process-keys.js
@@ -299,6 +299,9 @@ const buildExecutionMeta = ({
   // Commit-pinned native AI-DLC distribution used by this intent. Export
   // prefers this snapshot over the deployment's current baseline ref.
   aidlcRepoRef = null,
+  // Exact supporting block versions resolved when the intent was created.
+  // Stage versions remain pinned by workflow placements.
+  methodologyPins = null,
   scope = null,
   currentPhase = null,
   currentStage = null,
@@ -447,6 +450,7 @@ const buildExecutionMeta = ({
   workflowId,
   workflowVersion,
   aidlcRepoRef,
+  methodologyPins,
   scope,
   currentPhase,
   currentStage,
@@ -532,6 +536,7 @@ const buildStageRow = ({
   // instances so every stage row is attributable to its lane.
   unitSlug = null,
   sectionIndex = null,
+  aidlcRepoRef = null,
   now,
 }) => ({
   ...stageKey(executionId, stageInstanceId),
@@ -542,6 +547,7 @@ const buildStageRow = ({
   stageId: stageId ?? null,
   unitSlug,
   sectionIndex,
+  aidlcRepoRef,
   phase,
   state,
   attempt,

--- a/lambda/shared/v2-process-keys.js
+++ b/lambda/shared/v2-process-keys.js
@@ -38,6 +38,7 @@
 //     (sparse maintenance index for live execution and integration work)
 
 const META = 'META';
+const WORKFLOW_CHECKPOINT = 'CHECKPOINT';
 
 // ── Partition keys ──
 const executionPk = (executionId) => `EXEC#${executionId}`;
@@ -48,6 +49,10 @@ const TRACKER_SYNCS_INDEX_PK = 'TRACKER_SYNCS';
 
 // ── Item keys ──
 const executionMetaKey = (executionId) => ({ pk: executionPk(executionId), sk: META });
+const workflowCheckpointKey = (executionId) => ({
+  pk: executionPk(executionId),
+  sk: WORKFLOW_CHECKPOINT,
+});
 const stageKey = (executionId, stageInstanceId) => ({
   pk: executionPk(executionId),
   sk: `STAGE#${stageInstanceId}`,
@@ -1130,9 +1135,11 @@ const buildTrackerSyncRow = ({
 
 export {
   META,
+  WORKFLOW_CHECKPOINT,
   executionPk,
   projectPk,
   executionMetaKey,
+  workflowCheckpointKey,
   stageKey,
   eventKey,
   humanTaskKey,
@@ -1196,9 +1203,11 @@ export {
 };
 export default {
   META,
+  WORKFLOW_CHECKPOINT,
   executionPk,
   projectPk,
   executionMetaKey,
+  workflowCheckpointKey,
   stageKey,
   eventKey,
   humanTaskKey,

--- a/lambda/shared/v2-process-store.js
+++ b/lambda/shared/v2-process-store.js
@@ -20,6 +20,7 @@ import {
 import {
   META,
   executionMetaKey,
+  workflowCheckpointKey,
   stageKey,
   humanTaskKey,
   steeringKey,
@@ -115,6 +116,29 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
         Key: executionMetaKey(executionId),
         ...(consistentRead ? { ConsistentRead: true } : {}),
       }),
+    );
+    return Item ?? null;
+  };
+
+  // One atomic item is the latest-checkpoint pointer and its bounded process
+  // snapshot; overwriting it cannot expose a partially published checkpoint.
+  const putWorkflowCheckpoint = async (checkpoint) => {
+    if (!checkpoint?.executionId || !checkpoint?.checkpointId) {
+      throw new Error('putWorkflowCheckpoint requires executionId and checkpointId');
+    }
+    const item = {
+      ...workflowCheckpointKey(checkpoint.executionId),
+      ...checkpoint,
+      updatedAt: now(),
+    };
+    await ddb.send(new PutCommand({ TableName: table(), Item: item }));
+    return item;
+  };
+
+  // Read the latest completed checkpoint for export hydration.
+  const getWorkflowCheckpoint = async (executionId) => {
+    const { Item } = await ddb.send(
+      new GetCommand({ TableName: table(), Key: workflowCheckpointKey(executionId) }),
     );
     return Item ?? null;
   };
@@ -2393,6 +2417,8 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
   return {
     createExecution,
     getExecution,
+    putWorkflowCheckpoint,
+    getWorkflowCheckpoint,
     updateExecution,
     deleteExecution,
     putStage,

--- a/lambda/shared/v2-process-store.js
+++ b/lambda/shared/v2-process-store.js
@@ -11,6 +11,7 @@
 import { randomUUID } from 'node:crypto';
 import {
   BatchWriteCommand,
+  DeleteCommand,
   GetCommand,
   PutCommand,
   QueryCommand,
@@ -120,18 +121,37 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     return Item ?? null;
   };
 
-  // One atomic item is the latest-checkpoint pointer and its bounded process
-  // snapshot; overwriting it cannot expose a partially published checkpoint.
+  // Publish the latest checkpoint only while the originating orchestrator still
+  // owns META. The condition and put must share one transaction because they
+  // target different items in the execution partition.
   const putWorkflowCheckpoint = async (checkpoint) => {
-    if (!checkpoint?.executionId || !checkpoint?.checkpointId) {
-      throw new Error('putWorkflowCheckpoint requires executionId and checkpointId');
+    if (!checkpoint?.executionId || !checkpoint?.checkpointId || !checkpoint?.orchestratorRunId) {
+      throw new Error(
+        'putWorkflowCheckpoint requires executionId, checkpointId, and orchestratorRunId',
+      );
     }
     const item = {
       ...workflowCheckpointKey(checkpoint.executionId),
       ...checkpoint,
       updatedAt: now(),
     };
-    await ddb.send(new PutCommand({ TableName: table(), Item: item }));
+    await ddb.send(
+      new TransactWriteCommand({
+        TransactItems: [
+          {
+            ConditionCheck: {
+              TableName: table(),
+              Key: executionMetaKey(checkpoint.executionId),
+              ConditionExpression: 'orchestratorRunId = :orchestratorRunId',
+              ExpressionAttributeValues: {
+                ':orchestratorRunId': checkpoint.orchestratorRunId,
+              },
+            },
+          },
+          { Put: { TableName: table(), Item: item } },
+        ],
+      }),
+    );
     return item;
   };
 
@@ -141,6 +161,18 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
       new GetCommand({ TableName: table(), Key: workflowCheckpointKey(executionId) }),
     );
     return Item ?? null;
+  };
+
+  const deleteWorkflowCheckpoint = async (executionId) => {
+    if (!executionId) throw new Error('deleteWorkflowCheckpoint requires executionId');
+    const { Attributes } = await ddb.send(
+      new DeleteCommand({
+        TableName: table(),
+        Key: workflowCheckpointKey(executionId),
+        ReturnValues: 'ALL_OLD',
+      }),
+    );
+    return Attributes ?? null;
   };
 
   // Update the execution-level status + current phase/stage + pending gate, and
@@ -2424,6 +2456,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     getExecution,
     putWorkflowCheckpoint,
     getWorkflowCheckpoint,
+    deleteWorkflowCheckpoint,
     updateExecution,
     deleteExecution,
     putStage,

--- a/lambda/shared/v2-process-store.js
+++ b/lambda/shared/v2-process-store.js
@@ -149,6 +149,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     agentCli,
     credentialBinding,
     constructionAutonomyMode,
+    projectType,
     // Per-intent skip overlay (stage-skip.js). Only the rewind endpoint writes
     // this: rewinding TO a skipped stage UN-skips it (list shrinks, or null).
     skipStageIds,
@@ -314,6 +315,13 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
       }
       sets.push('constructionAutonomyMode = :cam');
       values[':cam'] = constructionAutonomyMode;
+    }
+    if (projectType !== undefined) {
+      if (projectType !== 'greenfield' && projectType !== 'brownfield') {
+        throw new Error(`invalid projectType: ${projectType}`);
+      }
+      sets.push('projectType = :pt');
+      values[':pt'] = projectType;
     }
     // Per-intent skip overlay (stage-skip.js): a rewind to a skipped stage
     // un-skips it. Validated shape only — the plan resolver owns the policy.

--- a/lambda/shared/v2-process-store.js
+++ b/lambda/shared/v2-process-store.js
@@ -586,6 +586,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     cliSessionId,
     resolvedModel,
     stageCallbackId,
+    aidlcRepoRef,
   }) => {
     const existing = await getStage(executionId, stageInstanceId);
     const ts = now();
@@ -633,6 +634,10 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     if (stageCallbackId !== undefined) {
       sets.push('stageCallbackId = :scb');
       values[':scb'] = stageCallbackId;
+    }
+    if (aidlcRepoRef !== undefined) {
+      sets.push('aidlcRepoRef = :aidlcRepoRef');
+      values[':aidlcRepoRef'] = aidlcRepoRef;
     }
     const { Attributes } = await ddb.send(
       new UpdateCommand({

--- a/lambda/shared/v2-workflow-plan.js
+++ b/lambda/shared/v2-workflow-plan.js
@@ -57,14 +57,75 @@ const listMergedBlocks = async (ddb, tableName, type) => {
   return [...byId.values()];
 };
 
-const loadPlacedStages = async (ddb, tableName, placements) => {
-  const legacyPlacements = placements.filter((placement) => !placement.stageTenant);
+const blockPin = (block) => ({
+  tenantId: block.tenantId,
+  version: Number(block.version),
+});
+
+const pinsForBlocks = (blocks) =>
+  Object.fromEntries(
+    blocks
+      .filter(
+        (block) =>
+          block?.blockId &&
+          block?.tenantId &&
+          Number.isInteger(Number(block.version)) &&
+          Number(block.version) > 0,
+      )
+      .map((block) => [block.blockId, blockPin(block)]),
+  );
+
+const loadPinnedBlocks = async (ddb, tableName, type, pins) => {
+  const entries = Object.entries(pins ?? {});
+  const blocks = await Promise.all(
+    entries.map(async ([blockId, pin]) => {
+      const result = await ddb.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: {
+            pk: blockPk(pin.tenantId, type, blockId),
+            sk: versionSk(Number(pin.version)),
+          },
+        }),
+      );
+      return result.Item ?? null;
+    }),
+  );
+  const missing = entries.filter((_, index) => blocks[index] == null).map(([blockId]) => blockId);
+  if (missing.length) {
+    throw new Error(`Pinned ${type} block versions are unavailable: ${missing.join(', ')}`);
+  }
+  return blocks;
+};
+
+const loadLibraryType = (ddb, tableName, type, methodologyPins) =>
+  methodologyPins?.[type]
+    ? loadPinnedBlocks(ddb, tableName, type, methodologyPins[type])
+    : listMergedBlocks(ddb, tableName, type);
+
+const loadPlacedStages = async (ddb, tableName, placements, stagePins = null) => {
+  const legacyPlacements = placements.filter(
+    (placement) => !placement.stageTenant && !stagePins?.[placement.stageId],
+  );
   const legacyStages = legacyPlacements.length
     ? await listMergedBlocks(ddb, tableName, 'STAGE')
     : [];
   const legacyById = new Map(legacyStages.map((stage) => [stage.id ?? stage.blockId, stage]));
   const stages = await Promise.all(
     placements.map(async (placement) => {
+      const pin = stagePins?.[placement.stageId];
+      if (!placement.stageTenant && pin) {
+        const result = await ddb.send(
+          new GetCommand({
+            TableName: tableName,
+            Key: {
+              pk: blockPk(pin.tenantId, 'STAGE', placement.stageId),
+              sk: versionSk(Number(pin.version)),
+            },
+          }),
+        );
+        return result.Item ?? null;
+      }
       if (!placement.stageTenant) return legacyById.get(placement.stageId) ?? null;
       const tenant = placement.stageTenant;
       const sk =
@@ -105,9 +166,12 @@ const assembleWorkflow = (items, { workflowId, workflowVersion }) => {
   const ruleRefs = [];
   const scopeRefs = [];
   const phases = [];
+  let sourceRef = null;
   for (const it of items) {
     const sk = liveSk(it.sk);
-    if (sk.startsWith('PLACEMENT#')) {
+    if (sk === 'META') {
+      sourceRef = it.sourceRef ?? null;
+    } else if (sk.startsWith('PLACEMENT#')) {
       placements.push({
         stageId: it.stageId,
         stageTenant: it.stageTenant ?? null,
@@ -127,6 +191,7 @@ const assembleWorkflow = (items, { workflowId, workflowVersion }) => {
   return {
     workflowId,
     workflowVersion: Number(workflowVersion),
+    sourceRef,
     placements,
     ruleRefs,
     scopeRefs,
@@ -153,6 +218,7 @@ const loadExecutionPlan = async ({
   skipStageIds = null,
   composedGrid = null,
   strict = false,
+  methodologyPins = null,
 }) => {
   const items = await loadWorkflowItems(ddb, tableName, workflowId, workflowVersion);
   if (!items.length) {
@@ -167,12 +233,13 @@ const loadExecutionPlan = async ({
   // leadAgent / supportAgents / reviewer against agentsById, so omitting them
   // makes EVERY agent-bearing stage fail `unresolved_agent` and rejects the plan
   // before any stage runs (the bodies still load lazily in the runtime container).
-  const [stages, agents, sensors, rules, artifacts] = await Promise.all([
-    loadPlacedStages(ddb, tableName, workflow.placements),
-    listMergedBlocks(ddb, tableName, 'AGENT'),
-    listMergedBlocks(ddb, tableName, 'SENSOR'),
-    listMergedBlocks(ddb, tableName, 'RULE'),
-    listMergedBlocks(ddb, tableName, 'ARTIFACT'),
+  const [stages, agents, sensors, rules, artifacts, knowledge] = await Promise.all([
+    loadPlacedStages(ddb, tableName, workflow.placements, methodologyPins?.STAGE),
+    loadLibraryType(ddb, tableName, 'AGENT', methodologyPins),
+    loadLibraryType(ddb, tableName, 'SENSOR', methodologyPins),
+    loadLibraryType(ddb, tableName, 'RULE', methodologyPins),
+    loadLibraryType(ddb, tableName, 'ARTIFACT', methodologyPins),
+    loadLibraryType(ddb, tableName, 'KNOWLEDGE', methodologyPins),
   ]);
   const library = {
     stagesById: keyById(stages),
@@ -181,7 +248,32 @@ const loadExecutionPlan = async ({
     rulesById: keyById(rules),
     artifactsById: keyById(artifacts),
   };
-  return buildExecutionPlan({ workflow, scope, library, skipStageIds, composedGrid, strict });
+  const result = buildExecutionPlan({
+    workflow,
+    scope,
+    library,
+    skipStageIds,
+    composedGrid,
+    strict,
+  });
+  return {
+    ...result,
+    methodologySourceRefs: [
+      ...new Set(
+        [workflow, ...stages, ...agents, ...sensors, ...rules, ...artifacts, ...knowledge]
+          .map((item) => item?.sourceRef)
+          .filter(Boolean),
+      ),
+    ].toSorted(),
+    methodologyPins: methodologyPins ?? {
+      STAGE: pinsForBlocks(stages),
+      AGENT: pinsForBlocks(agents),
+      SENSOR: pinsForBlocks(sensors),
+      RULE: pinsForBlocks(rules),
+      ARTIFACT: pinsForBlocks(artifacts),
+      KNOWLEDGE: pinsForBlocks(knowledge),
+    },
+  };
 };
 
 // List the scopes a pinned workflow offers (the vocabulary the intent scope
@@ -195,7 +287,7 @@ const loadWorkflowScopes = async ({ ddb, tableName, workflowId, workflowVersion 
   return [...workflowScopes(workflow)];
 };
 
-const __test = { listMergedBlocks, loadPlacedStages };
+const __test = { listMergedBlocks, loadPlacedStages, loadPinnedBlocks, pinsForBlocks };
 export { loadExecutionPlan, loadWorkflowScopes, assembleWorkflow, listMergedBlocks, __test };
 export default {
   loadExecutionPlan,

--- a/lambda/shared/v2-workflow-plan.js
+++ b/lambda/shared/v2-workflow-plan.js
@@ -10,8 +10,8 @@
 // Ownership shadowing matches the rest of the app: a `default` (user) block/
 // workflow shadows the `SYSTEM` baseline of the same id.
 
-import { QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { catalogGsi1Pk } from './blocks.js';
+import { GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { blockPk, catalogGsi1Pk, LATEST, versionSk } from './blocks.js';
 import { workflowPk, workflowVersionPrefix } from './workflows.js';
 import { DEFAULT_TENANT, SYSTEM_TENANT } from './tenant.js';
 import { buildExecutionPlan, workflowScopes } from './v2-execution-plan.js';
@@ -57,6 +57,30 @@ const listMergedBlocks = async (ddb, tableName, type) => {
   return [...byId.values()];
 };
 
+const loadPlacedStages = async (ddb, tableName, placements) => {
+  const legacyPlacements = placements.filter((placement) => !placement.stageTenant);
+  const legacyStages = legacyPlacements.length
+    ? await listMergedBlocks(ddb, tableName, 'STAGE')
+    : [];
+  const legacyById = new Map(legacyStages.map((stage) => [stage.id ?? stage.blockId, stage]));
+  const stages = await Promise.all(
+    placements.map(async (placement) => {
+      if (!placement.stageTenant) return legacyById.get(placement.stageId) ?? null;
+      const tenant = placement.stageTenant;
+      const sk =
+        placement.pinnedVersion == null ? LATEST : versionSk(Number(placement.pinnedVersion));
+      const result = await ddb.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { pk: blockPk(tenant, 'STAGE', placement.stageId), sk },
+        }),
+      );
+      return result.Item ?? null;
+    }),
+  );
+  return stages.filter(Boolean);
+};
+
 // Load the pinned workflow's version snapshot rows (default shadows SYSTEM).
 const loadWorkflowItems = async (ddb, tableName, workflowId, workflowVersion) => {
   for (const tenant of [DEFAULT_TENANT, SYSTEM_TENANT]) {
@@ -86,6 +110,8 @@ const assembleWorkflow = (items, { workflowId, workflowVersion }) => {
     if (sk.startsWith('PLACEMENT#')) {
       placements.push({
         stageId: it.stageId,
+        stageTenant: it.stageTenant ?? null,
+        pinnedVersion: it.pinnedVersion ?? null,
         order: it.order ?? 0,
         phasePath: it.phasePath ?? null,
         scopeMembership: it.scopeMembership ?? {},
@@ -142,7 +168,7 @@ const loadExecutionPlan = async ({
   // makes EVERY agent-bearing stage fail `unresolved_agent` and rejects the plan
   // before any stage runs (the bodies still load lazily in the runtime container).
   const [stages, agents, sensors, rules, artifacts] = await Promise.all([
-    listMergedBlocks(ddb, tableName, 'STAGE'),
+    loadPlacedStages(ddb, tableName, workflow.placements),
     listMergedBlocks(ddb, tableName, 'AGENT'),
     listMergedBlocks(ddb, tableName, 'SENSOR'),
     listMergedBlocks(ddb, tableName, 'RULE'),
@@ -169,7 +195,7 @@ const loadWorkflowScopes = async ({ ddb, tableName, workflowId, workflowVersion 
   return [...workflowScopes(workflow)];
 };
 
-const __test = { listMergedBlocks };
+const __test = { listMergedBlocks, loadPlacedStages };
 export { loadExecutionPlan, loadWorkflowScopes, assembleWorkflow, listMergedBlocks, __test };
 export default {
   loadExecutionPlan,

--- a/lambda/shared/workflow-checkpoint.js
+++ b/lambda/shared/workflow-checkpoint.js
@@ -36,6 +36,7 @@ const META_FIELDS = [
   'skipStageIds',
   'composedGrid',
   'aidlcRepoRef',
+  'methodologyPins',
 ];
 const STAGE_FIELDS = [
   'executionId',
@@ -46,6 +47,7 @@ const STAGE_FIELDS = [
   'attempt',
   'unitSlug',
   'sectionIndex',
+  'aidlcRepoRef',
   'startedAt',
   'completedAt',
   'updatedAt',

--- a/lambda/shared/workflow-checkpoint.js
+++ b/lambda/shared/workflow-checkpoint.js
@@ -1,0 +1,185 @@
+import { createHash } from 'node:crypto';
+
+const MAX_WORKFLOW_CHECKPOINT_BYTES = 380 * 1024;
+
+const INFRA_FIELDS = new Set([
+  'pk',
+  'sk',
+  'GSI1PK',
+  'GSI1SK',
+  'GSI2PK',
+  'GSI2SK',
+  'GSI3PK',
+  'GSI3SK',
+]);
+
+const META_FIELDS = [
+  'executionId',
+  'intentId',
+  'projectId',
+  'status',
+  'workflowId',
+  'workflowVersion',
+  'scope',
+  'title',
+  'prompt',
+  'branch',
+  'baseBranch',
+  'baseBranches',
+  'repos',
+  'repoProviders',
+  'gitProvider',
+  'agentCli',
+  'customRules',
+  'projectType',
+  'startedAt',
+  'skipStageIds',
+  'composedGrid',
+  'aidlcRepoRef',
+];
+const STAGE_FIELDS = [
+  'executionId',
+  'stageInstanceId',
+  'stageId',
+  'phase',
+  'state',
+  'attempt',
+  'unitSlug',
+  'sectionIndex',
+  'startedAt',
+  'completedAt',
+  'updatedAt',
+];
+const HUMAN_TASK_FIELDS = [
+  'executionId',
+  'humanTaskId',
+  'stageInstanceId',
+  'stageId',
+  'phase',
+  'unitSlug',
+  'sectionIndex',
+  'kind',
+  'status',
+  'questions',
+  'answer',
+  'createdAt',
+  'answeredAt',
+];
+const UNIT_PLAN_FIELDS = [
+  'executionId',
+  'units',
+  'batches',
+  'skipMatrix',
+  'walkingSkeleton',
+  'autonomyMode',
+  'sourceArtifactId',
+  'producedByStageInstanceId',
+  'promotedAt',
+  'updatedAt',
+];
+const UNIT_FIELDS = [
+  'executionId',
+  'slug',
+  'sectionIndex',
+  'state',
+  'mergedAt',
+  'completedAt',
+  'updatedAt',
+];
+
+const snapshotRecord = (record, fields = null) =>
+  record
+    ? Object.fromEntries(
+        Object.entries(record).filter(
+          ([key, value]) =>
+            !INFRA_FIELDS.has(key) && value !== undefined && (!fields || fields.includes(key)),
+        ),
+      )
+    : null;
+
+const canonicalJson = (value) => {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .toSorted()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+};
+
+// Derive a stable identity from checkpoint contents; publication time and the
+// boundary label do not change the identity of an otherwise identical snapshot.
+const checkpointIdFor = ({ process, artifactRefs, customRuleRefs }) =>
+  `checkpoint-${createHash('sha256')
+    .update(canonicalJson({ process, artifactRefs, customRuleRefs }))
+    .digest('hex')}`;
+
+// Build the bounded DynamoDB record containing projector state and immutable
+// external references. Artifact and custom-rule bodies stay in their stores.
+const buildWorkflowCheckpoint = ({
+  executionId,
+  createdAt,
+  sourceStageInstanceId = null,
+  records,
+  artifactRefs = [],
+  customRuleRefs = [],
+}) => {
+  const process = {
+    meta: snapshotRecord(records.meta, META_FIELDS),
+    stages: (records.stages ?? []).map((record) => snapshotRecord(record, STAGE_FIELDS)),
+    humanTasks: (records.humanTasks ?? []).map((record) =>
+      snapshotRecord(record, HUMAN_TASK_FIELDS),
+    ),
+    unitPlan: snapshotRecord(records.unitPlan, UNIT_PLAN_FIELDS),
+    units: (records.units ?? []).map((record) => snapshotRecord(record, UNIT_FIELDS)),
+  };
+  const checkpoint = {
+    type: 'WorkflowCheckpoint',
+    executionId,
+    checkpointId: checkpointIdFor({ process, artifactRefs, customRuleRefs }),
+    createdAt,
+    sourceStageInstanceId,
+    process,
+    artifactRefs,
+    customRuleRefs,
+  };
+  const bytes = Buffer.byteLength(JSON.stringify(checkpoint), 'utf8');
+  if (bytes > MAX_WORKFLOW_CHECKPOINT_BYTES) {
+    throw new Error(
+      `workflow-checkpoint: ${bytes} bytes exceeds the ${MAX_WORKFLOW_CHECKPOINT_BYTES}-byte limit`,
+    );
+  }
+  return checkpoint;
+};
+
+// Recover the process-record shape consumed by native workspace projection.
+const checkpointProjection = (checkpoint) => {
+  if (!checkpoint?.process?.meta) {
+    throw new Error('workflow-checkpoint: checkpoint has no execution metadata');
+  }
+  return {
+    meta: checkpoint.process.meta,
+    stages: checkpoint.process.stages ?? [],
+    humanTasks: checkpoint.process.humanTasks ?? [],
+    unitPlan: checkpoint.process.unitPlan ?? null,
+    units: checkpoint.process.units ?? [],
+  };
+};
+
+export {
+  MAX_WORKFLOW_CHECKPOINT_BYTES,
+  buildWorkflowCheckpoint,
+  canonicalJson,
+  checkpointIdFor,
+  checkpointProjection,
+  snapshotRecord,
+};
+export default {
+  MAX_WORKFLOW_CHECKPOINT_BYTES,
+  buildWorkflowCheckpoint,
+  canonicalJson,
+  checkpointIdFor,
+  checkpointProjection,
+  snapshotRecord,
+};

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -469,7 +469,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
     const publishCheckpoint = async (stepName, sourceStageInstanceId = null) => {
       const result = await ctx.step(stepName, async () => {
         try {
-          return await invokeRuntime(
+          return await invokeIntentRuntime(
             {
               command: 'create-workflow-checkpoint',
               projectId,

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -466,6 +466,33 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         ? { name: meta.starterName, email: meta.starterEmail }
         : null;
     const sessionId = sessionIdFor(intentId);
+    const publishCheckpoint = async (stepName, sourceStageInstanceId = null) => {
+      const result = await ctx.step(stepName, async () => {
+        try {
+          return await invokeRuntime(
+            {
+              command: 'create-workflow-checkpoint',
+              projectId,
+              intentId,
+              executionId,
+              sourceStageInstanceId,
+            },
+            sessionId,
+          );
+        } catch (error) {
+          return { ok: false, reason: 'checkpoint_failed', detail: error.message };
+        }
+      });
+      if (!result || result.ok === false) {
+        await emitEvent(
+          ctx,
+          `${stepName}-failed`,
+          'v2.checkpoint.failed',
+          `Workflow checkpoint was not updated: ${result?.detail ?? result?.reason ?? 'no response'}`,
+        );
+      }
+      return result;
+    };
     await emitEvent(
       ctx,
       'init-ws-start',
@@ -528,6 +555,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         /* live fan-out is best-effort */
       }
     });
+    await publishCheckpoint('checkpoint-initial');
 
     // Resolve the ordered stage list once (pure read of pinned block metadata).
     // The per-intent skip overlay snapshotted at create rides along — every
@@ -964,6 +992,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
       emitEvent,
       fail,
       executeStage,
+      publishCheckpoint,
       ids: { projectId, intentId, executionId },
       runId: null, // stamped below once minted
       intentBranch: meta.branch,
@@ -998,6 +1027,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
       if (segment.kind === 'section') {
         const sectionOut = await runParallelSection(segment, sectionToolkit);
         if (sectionOut) return sectionOut;
+        await publishCheckpoint(`checkpoint-section-${segment.index}`);
         continue;
       }
       // The parallel section (if any) that consumes this segment's unit DAG:
@@ -1404,6 +1434,10 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
           );
           dynamicSkipIds.push(flippedId);
         }
+        await publishCheckpoint(
+          `checkpoint-stage-${stage.stageInstanceId ?? stage.stageId}`,
+          stage.stageInstanceId ?? null,
+        );
       }
     }
 

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -475,6 +475,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
               projectId,
               intentId,
               executionId,
+              orchestratorRunId: runId,
               sourceStageInstanceId,
             },
             sessionId,

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -581,6 +581,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         scope,
         ...(intentSkipIds.length ? { skipStageIds: intentSkipIds } : {}),
         ...(composedGrid ? { composedGrid } : {}),
+        ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
       }),
     );
     if (!planResult.valid || !planResult.plan) {
@@ -779,6 +780,8 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         ids: { projectId, intentId, executionId },
         workflowId,
         workflowVersion,
+        ...(meta.aidlcRepoRef ? { aidlcRepoRef: meta.aidlcRepoRef } : {}),
+        ...(meta.methodologyPins ? { methodologyPins: meta.methodologyPins } : {}),
         scope,
         ...(allSkipIds.length ? { skipStageIds: allSkipIds } : {}),
         ...(composedGrid ? { composedGrid } : {}),
@@ -1590,6 +1593,8 @@ const runStage = async (
     ids,
     workflowId,
     workflowVersion,
+    aidlcRepoRef = null,
+    methodologyPins = null,
     scope,
     // Per-run skip overlay (intent-level + accumulated gate-time skips) —
     // forwarded so the container's plan resolution matches the walk's.
@@ -1658,6 +1663,8 @@ const runStage = async (
         sectionIndex,
         workflowId,
         workflowVersion,
+        ...(aidlcRepoRef ? { aidlcRepoRef } : {}),
+        ...(methodologyPins ? { methodologyPins } : {}),
         scope,
         ...(skipStageIds?.length ? { skipStageIds } : {}),
         ...(composedGrid ? { composedGrid } : {}),

--- a/lambda/v2-orchestrator/section.js
+++ b/lambda/v2-orchestrator/section.js
@@ -371,6 +371,7 @@ export const runParallelSection = async (segment, toolkit) => {
     emitEvent, // (ctxArg, stepName, type, summary, extra)
     fail, // (reason, detail) → terminal value
     executeStage, // (ctxArg, stage, opts) → { state, reason?, value? }
+    publishCheckpoint = async () => null,
     ids,
     intentBranch,
     cloneBase, // { repos, baseBranch, baseBranches, gitProvider, repoProviders }
@@ -2240,6 +2241,9 @@ export const runParallelSection = async (segment, toolkit) => {
           }`,
           { unitSlug: skeleton, sectionIndex: segment.index },
         );
+        await publishCheckpoint(
+          `checkpoint-section-${segment.index}-skeleton${revision ? `-v${revision}` : ''}`,
+        );
         break;
       }
       revision += 1;
@@ -2367,6 +2371,9 @@ export const runParallelSection = async (segment, toolkit) => {
               choice === 'accept-as-is' ? ` as-is after ${revision} revision cycle(s)` : ''
             }`,
             { sectionIndex: segment.index },
+          );
+          await publishCheckpoint(
+            `checkpoint-section-${segment.index}-batch-${w}${revision ? `-v${revision}` : ''}`,
           );
           break;
         }

--- a/lambda/v2-orchestrator/test/orchestrator-replay.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator-replay.test.js
@@ -161,9 +161,12 @@ describe('orchestrator on the real durable runner (replay semantics)', () => {
     // Exactly-once side effects across every replay:
     expect(world.invokes.map((p) => p.command)).toEqual([
       'init-ws',
+      'create-workflow-checkpoint', // initial boundary
       'run-stage-start', // a (fresh)
       'run-stage-start', // a (resume h1)
+      'create-workflow-checkpoint', // accepted a
       'run-stage-start', // b
+      'create-workflow-checkpoint', // accepted b
     ]);
     const starts = world.invokes.filter((p) => p.command === 'run-stage-start');
     expect(starts.map((p) => p.stageId)).toEqual(['a', 'a', 'b']);
@@ -378,17 +381,22 @@ describe('WP5 sections on the real durable runner', () => {
       // and ONE merge-lane, in skeleton-then-remaining order.
       expect(world.invokes.map((p) => `${p.command}:${p.stageId ?? p.unitSlug ?? '-'}`)).toEqual([
         'init-ws:-',
+        'create-workflow-checkpoint:-',
         'run-stage-start:gen',
         'derive-artifacts:-',
         'promote-units:-',
+        'create-workflow-checkpoint:-',
         'init-lane:auth',
         'run-stage-start:cg', // auth fresh (parks)
         'run-stage-start:cg', // auth resume h7
         'merge-lane:auth',
+        'create-workflow-checkpoint:-', // approved walking skeleton
         'init-lane:billing',
         'run-stage-start:cg', // billing
         'merge-lane:billing',
+        'create-workflow-checkpoint:-',
         'run-stage-start:bt',
+        'create-workflow-checkpoint:-',
       ]);
       const starts = world.invokes.filter((p) => p.command === 'run-stage-start');
       expect(starts.map((p) => `${p.stageId}:${p.unitSlug ?? '-'}:${p.resumeFrom ?? '-'}`)).toEqual(

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -184,11 +184,9 @@ describe('orchestrator durable handler', () => {
       repos: ['owner/repo'],
     });
     expect(initWs).not.toHaveProperty('gitToken');
-    expect(deps.invokeRuntime.mock.calls.map(([, , target]) => target)).toEqual([
-      MANAGED_RUNTIME_TARGET,
-      MANAGED_RUNTIME_TARGET,
-      MANAGED_RUNTIME_TARGET,
-    ]);
+    expect(deps.invokeRuntime.mock.calls.map(([, , target]) => target)).toEqual(
+      Array.from({ length: 6 }, () => MANAGED_RUNTIME_TARGET),
+    );
     const statuses = deps.store.updateExecution.mock.calls.map((c) => c[0].status);
     expect(statuses).toContain('RUNNING');
     expect(statuses).toContain('SUCCEEDED');

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -172,6 +172,9 @@ describe('orchestrator durable handler', () => {
     ]);
     expect(checkpointInvokes).toHaveLength(3);
     expect(checkpointInvokes.map((p) => p.sourceStageInstanceId)).toEqual([null, null, null]);
+    const checkpointRunIds = [...new Set(checkpointInvokes.map((p) => p.orchestratorRunId))];
+    expect(checkpointRunIds).toHaveLength(1);
+    expect(checkpointRunIds[0]).toMatch(/^run-/);
     // init-ws carries the provider so the runtime picks the right clone scheme.
     const initWs = invokes.find((p) => p.command === 'init-ws');
     expect(initWs).toMatchObject({

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -409,6 +409,27 @@ describe('orchestrator durable handler', () => {
     }
   });
 
+  it('forwards the intent AI-DLC ref and methodology pins to plan and stage execution', async () => {
+    const methodologyPins = {
+      AGENT: { 'aidlc-product-agent': { tenantId: 'SYSTEM', version: 2 } },
+    };
+    deps.store.getExecution = vi.fn(async () => ({
+      ...META,
+      aidlcRepoRef: 'a'.repeat(40),
+      methodologyPins,
+    }));
+
+    await __durableHandler({ action: 'start', intentId: 'i1', executionId: 'i1' }, ctx, deps);
+
+    expect(deps.loadPlan).toHaveBeenCalledWith(expect.objectContaining({ methodologyPins }));
+    for (const start of stageStarts()) {
+      expect(start).toMatchObject({
+        aidlcRepoRef: 'a'.repeat(40),
+        methodologyPins,
+      });
+    }
+  });
+
   it('forwards the clone inputs to run-stage-start so it can self-heal a wiped checkout', async () => {
     await __durableHandler({ action: 'start', intentId: 'i1', executionId: 'i1' }, ctx, deps);
     const starts = stageStarts();

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -58,6 +58,10 @@ const makeCtx = (over = {}) => {
 const makeRuntime = (ctx, script) => {
   let n = 0;
   return vi.fn(async (payload, sessionId) => {
+    if (payload.command === 'create-workflow-checkpoint') {
+      checkpointInvokes.push(payload);
+      return { ok: true, checkpointId: `cp-${checkpointInvokes.length}` };
+    }
     invokes.push(payload);
     sessions.push(sessionId);
     n += 1;
@@ -108,10 +112,12 @@ const META = {
 
 let deps;
 let invokes;
+let checkpointInvokes;
 let sessions;
 let ctx;
 beforeEach(() => {
   invokes = [];
+  checkpointInvokes = [];
   sessions = [];
   ctx = makeCtx();
   deps = {
@@ -164,6 +170,8 @@ describe('orchestrator durable handler', () => {
       'run-stage-start',
       'run-stage-start',
     ]);
+    expect(checkpointInvokes).toHaveLength(3);
+    expect(checkpointInvokes.map((p) => p.sourceStageInstanceId)).toEqual([null, null, null]);
     // init-ws carries the provider so the runtime picks the right clone scheme.
     const initWs = invokes.find((p) => p.command === 'init-ws');
     expect(initWs).toMatchObject({
@@ -1309,6 +1317,10 @@ describe('WP5 — parallel sections: lanes, skeleton, ladder, halt-and-ask', () 
     expect(stopped).toContain('aidlc-intent-i1-s1-billing'.padEnd(33, '0'));
     // Non-lane dispatches carry unitSlug null explicitly (uniform contract).
     expect(stageStarts().find((p) => p.stageId === 'bt').unitSlug).toBeNull();
+    // Initial + units-gen + approved skeleton + approved billing batch +
+    // completed section + bt. Approval checkpoints are captured before the
+    // next construction increment starts.
+    expect(checkpointInvokes).toHaveLength(6);
   });
 
   it('resumes after repair from persisted merged units without replaying the skeleton or its gate', async () => {
@@ -2264,6 +2276,7 @@ describe('WP5 — engine-gate decisions', () => {
     // Approved on the revision gate; the remaining lane then ran.
     expect(eventCalls.some((e) => e.type === 'v2.units.skeleton_approved')).toBe(true);
     expect(invokes.some((p) => p.command === 'init-lane' && p.unitSlug === 'billing')).toBe(true);
+    expect(checkpointInvokes).toHaveLength(6);
   });
 
   it('request-changes on a batch gate re-runs the batch lanes with feedback, then re-asks (gated mode)', async () => {
@@ -2292,6 +2305,7 @@ describe('WP5 — engine-gate decisions', () => {
     const eventCalls = deps.store.appendEvent.mock.calls.map((c) => c[0]);
     expect(eventCalls.some((e) => e.type === 'v2.units.batch_revision_requested')).toBe(true);
     expect(eventCalls.some((e) => e.type === 'v2.units.batch_approved')).toBe(true);
+    expect(checkpointInvokes).toHaveLength(6);
   });
 
   it('an uninterpretable halt-and-ask answer RE-ASKS; the follow-up choice is honored', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -188,8 +188,11 @@
         "@aws-sdk/lib-dynamodb": "^3.1092.0",
         "@aws-sdk/s3-presigned-post": "^3.1092.0",
         "@aws-sdk/s3-request-presigner": "^3.1092.0",
+        "archiver": "^7.0.1",
         "gremlin": "^3.8.1",
-        "gremlin-aws-sigv4": "^3.6.1"
+        "gremlin-aws-sigv4": "^3.6.1",
+        "js-yaml": "^4.1.0",
+        "tar-stream": "^3.2.0"
       }
     },
     "lambda/migrate-tracker-fields": {},
@@ -4388,7 +4391,6 @@
     },
     "node_modules/archiver": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "archiver-utils": "^5.0.2",
@@ -4405,7 +4407,6 @@
     },
     "node_modules/archiver-utils": {
       "version": "5.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob": "^10.0.0",
@@ -4460,7 +4461,6 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-lock": {
@@ -4535,7 +4535,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -4753,7 +4752,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4783,7 +4781,6 @@
     },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -5023,7 +5020,6 @@
     },
     "node_modules/compress-commons": {
       "version": "6.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
@@ -5075,7 +5071,6 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -5108,7 +5103,6 @@
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
@@ -5119,7 +5113,6 @@
     },
     "node_modules/crc32-stream": {
       "version": "6.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.0",
@@ -5723,7 +5716,6 @@
     },
     "node_modules/glob": {
       "version": "13.0.6",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -5749,7 +5741,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/gremlin": {
@@ -5949,7 +5940,6 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5960,7 +5950,6 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6076,7 +6065,6 @@
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.5"
@@ -6087,7 +6075,6 @@
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -6101,12 +6088,10 @@
     },
     "node_modules/lazystream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lazystream/node_modules/string_decoder": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -6440,7 +6425,6 @@
     },
     "node_modules/lodash": {
       "version": "4.18.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -6544,7 +6528,6 @@
     },
     "node_modules/lru-cache": {
       "version": "11.5.1",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -6644,7 +6627,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -6658,7 +6640,6 @@
     },
     "node_modules/minimatch/node_modules/balanced-match": {
       "version": "4.0.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6666,7 +6647,6 @@
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
       "version": "5.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6677,7 +6657,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6798,7 +6777,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7022,7 +7000,6 @@
     },
     "node_modules/path-scurry": {
       "version": "2.0.2",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -7117,7 +7094,6 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/projects": {
@@ -7290,7 +7266,6 @@
     },
     "node_modules/readdir-glob": {
       "version": "1.1.3",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.1.0"
@@ -7298,7 +7273,6 @@
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -8210,7 +8184,6 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -8572,7 +8545,6 @@
     },
     "node_modules/zip-stream": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "archiver-utils": "^5.0.0",

--- a/scripts/deploy-terraform.sh
+++ b/scripts/deploy-terraform.sh
@@ -14,7 +14,8 @@ PLAN_FILE="$TF_DIR/tfplan"
 TF_VAR_ARGS=()
 AUTH_MODE_OVERRIDE=""
 SSO_CONFIG_FILE=""
-USAGE="Usage: $0 [environment] [--phase plan|apply|all] [--plan-file path] [--auth-mode local|hybrid|sso-only] [--sso-config path] [--var KEY=VALUE]..."
+SKIP_SEED="false"
+USAGE="Usage: $0 [environment] [--phase plan|apply|all] [--plan-file path] [--auth-mode local|hybrid|sso-only] [--sso-config path] [--skip-seed] [--var KEY=VALUE]..."
 
 if [[ $# -gt 0 && "$1" != --* ]]; then
     ENVIRONMENT="$1"
@@ -48,6 +49,10 @@ while [[ $# -gt 0 ]]; do
         --sso-config)
             SSO_CONFIG_FILE="${2:?--sso-config requires a JSON file}"
             shift 2
+            ;;
+        --skip-seed)
+            SKIP_SEED="true"
+            shift
             ;;
         *)
             echo "$USAGE" >&2
@@ -323,34 +328,37 @@ if [[ "${AIDLC_KEEP_PLAN:-0}" != "1" ]]; then
     rm -f "$PLAN_FILE"
 fi
 
-# Reseed the SYSTEM baseline (vendor-owned blocks + default workflow). reseed
-# clears the existing SYSTEM partitions and rewrites them from the current
-# baseline, so a deploy that changed baseline-blocks.js actually takes effect —
-# the default insert-only mode would skip every already-existing block. Scoped
-# to SYSTEM only; customer forks (per-tenant partitions) are never touched.
-echo "Applying AI-DLC default workflow and building blocks (reseed)"
-# Pin --region to the deployed stack's region: without it the AWS CLI falls
-# back to the profile default, which fails with "Function not found" whenever
-# the profile region differs from the deployment region.
-SEED_RESULT_FILE="$(mktemp "${TMPDIR:-/tmp}/aidlc-seed.XXXXXX")"
-SEED_FUNCTION_ERROR="$(
-    aws lambda invoke \
-        --function-name "$(tf_output seed_blocks_lambda_name)" \
-        --region "$(tf_output aws_region)" \
-        --payload '{"reseed":true}' \
-        --cli-binary-format raw-in-base64-out \
-        "$SEED_RESULT_FILE" \
-        --query FunctionError \
-        --output text
-)"
-if [[ -n "$SEED_FUNCTION_ERROR" && "$SEED_FUNCTION_ERROR" != "None" ]]; then
-    echo "Error: baseline seed Lambda failed ($SEED_FUNCTION_ERROR):" >&2
-    cat "$SEED_RESULT_FILE" >&2
+if [[ "$SKIP_SEED" == "true" ]]; then
+    echo "Skipping AI-DLC default workflow and building-block reseed (--skip-seed)."
+else
+    # Reseed the SYSTEM baseline (vendor-owned blocks + default workflow).
+    # reseed clears the existing SYSTEM partitions and rewrites them from the
+    # current baseline. Scoped to SYSTEM only; customer forks are untouched.
+    echo "Applying AI-DLC default workflow and building blocks (reseed)"
+    # Pin --region to the deployed stack's region: without it the AWS CLI falls
+    # back to the profile default. Disable AWS CLI retries because Lambda Invoke
+    # is not idempotent, and let the Lambda's 300-second timeout bound the job.
+    SEED_RESULT_FILE="$(mktemp "${TMPDIR:-/tmp}/aidlc-seed.XXXXXX")"
+    SEED_FUNCTION_ERROR="$(
+        AWS_MAX_ATTEMPTS=1 aws lambda invoke \
+            --function-name "$(tf_output seed_blocks_lambda_name)" \
+            --region "$(tf_output aws_region)" \
+            --payload '{"reseed":true}' \
+            --cli-binary-format raw-in-base64-out \
+            --cli-read-timeout 0 \
+            "$SEED_RESULT_FILE" \
+            --query FunctionError \
+            --output text
+    )"
+    if [[ -n "$SEED_FUNCTION_ERROR" && "$SEED_FUNCTION_ERROR" != "None" ]]; then
+        echo "Error: baseline seed Lambda failed ($SEED_FUNCTION_ERROR):" >&2
+        cat "$SEED_RESULT_FILE" >&2
+        rm -f "$SEED_RESULT_FILE"
+        exit 1
+    fi
     rm -f "$SEED_RESULT_FILE"
-    exit 1
+    echo "AI-DLC default workflow and building blocks applied."
 fi
-rm -f "$SEED_RESULT_FILE"
-echo "AI-DLC default workflow and building blocks applied."
 
 if [[ "${AIDLC_MANAGED_INSTALL:-0}" != "1" ]]; then
     print_deployment_summary

--- a/scripts/phaseb.sh
+++ b/scripts/phaseb.sh
@@ -67,8 +67,9 @@ outputs)
 seed)
   LAMBDA="$(tfout seed_blocks_lambda_name)"
   echo "=== invoking seed-blocks lambda: $LAMBDA ==="
-  aws lambda invoke --function-name "$LAMBDA" \
-    --payload '{}' --cli-binary-format raw-in-base64-out /tmp/aidlc-seed.json
+  AWS_MAX_ATTEMPTS=1 aws lambda invoke --function-name "$LAMBDA" \
+    --payload '{}' --cli-binary-format raw-in-base64-out \
+    --cli-read-timeout 0 /tmp/aidlc-seed.json
   echo "--- result ---"; cat /tmp/aidlc-seed.json; echo
   ;;
 

--- a/scripts/test/release-tools.test.mjs
+++ b/scripts/test/release-tools.test.mjs
@@ -115,6 +115,15 @@ test('Yjs image pins readable ownership and modes for non-root runtime files', (
   );
 });
 
+test('baseline seeding waits for Lambda without retrying the invocation', () => {
+  const terraformDeployment = readFileSync(deployTerraform, 'utf8');
+
+  assert.match(terraformDeployment, /AWS_MAX_ATTEMPTS=1 aws lambda invoke/);
+  assert.match(terraformDeployment, /--cli-read-timeout 0/);
+  assert.match(terraformDeployment, /--skip-seed/);
+  assert.match(terraformDeployment, /Skipping AI-DLC default workflow/);
+});
+
 test('release check accepts prerelease metadata but final mode requires a date', () => {
   const fixture = mkdtempSync(join(tmpdir(), 'aidlc-release-check-'));
   const version = '2.0.0-preview0';
@@ -324,6 +333,7 @@ const standaloneDeployEnv = (dir, { customDomain = false } = {}) => {
   const bin = join(dir, 'bin');
   const config = join(dir, 'config/environments');
   const terraformLog = join(dir, 'terraform.log');
+  const awsLog = join(dir, 'aws.log');
   mkdirSync(bin, { recursive: true });
   mkdirSync(config, { recursive: true });
   writeFileSync(
@@ -371,6 +381,7 @@ esac
   writeFileSync(
     join(bin, 'aws'),
     `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$AIDLC_AWS_LOG"
 if [[ "$*" == *"ecs describe-clusters"* ]]; then
   printf 'None\\n'
   exit 0
@@ -391,6 +402,7 @@ fi
       AIDLC_CONFIG_DIR: join(dir, 'config'),
       AIDLC_SKIP_NPM_CI: '1',
       AIDLC_TERRAFORM_LOG: terraformLog,
+      AIDLC_AWS_LOG: awsLog,
       ...(customDomain
         ? {
             AIDLC_FAKE_CUSTOM_DOMAIN: 'true',
@@ -401,6 +413,7 @@ fi
         : {}),
     },
     terraformLog,
+    awsLog,
     planFile: join(dir, 'summary.tfplan'),
   };
 };
@@ -447,6 +460,21 @@ test('standalone deployment omits --var entirely when none are given', () => {
     .split('\n')
     .find((line) => line.startsWith('plan '));
   assert.doesNotMatch(planLine, /-var /);
+});
+
+test('standalone deployment can skip the post-apply baseline seed', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'aidlc-deploy-skip-seed-'));
+  const { env, awsLog, planFile } = standaloneDeployEnv(dir);
+
+  const deployed = run(
+    'bash',
+    [deployTerraform, 'summary', '--plan-file', planFile, '--skip-seed'],
+    { env },
+  );
+
+  assert.equal(deployed.status, 0, deployed.stderr);
+  assert.match(deployed.stdout, /Skipping AI-DLC default workflow/);
+  assert.doesNotMatch(readFileSync(awsLog, 'utf8'), /lambda invoke/);
 });
 
 test('standalone deployment rejects malformed and misplaced --var', () => {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -354,6 +354,7 @@ module "lambda" {
   project_name                = var.project_name
   environment                 = var.environment
   lambda_vpc_scope            = var.lambda_vpc_scope
+  aidlc_repo_ref              = var.aidlc_repo_ref
   application_url             = local.app_url
   vpc_id                      = module.networking.vpc_id
   private_subnet_ids          = module.networking.private_subnet_ids

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -2366,8 +2366,8 @@ resource "aws_iam_role_policy" "intents" {
         Resource = "${var.artifacts_bucket_arn}/aidlc-catalogs/*"
       },
       {
-        # S3 only returns NoSuchKey for a missing cache object when the caller
-        # can list that prefix; otherwise GetObject masks the miss as 403.
+        # Allow cache-prefix listing where S3 evaluates it; cache readers also
+        # tolerate GetObject masking a missing key as 403.
         Effect   = "Allow"
         Action   = ["s3:ListBucket"]
         Resource = var.artifacts_bucket_arn

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -606,6 +606,25 @@ resource "aws_iam_role_policy" "neptune_artifacts" {
           StringLike = { "s3:prefix" = ["intent-attachments/*"] }
         }
       },
+      # The intent cascade (reused by project deletion) also purges each child
+      # intent's native workspace export archives, all versions.
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:DeleteObjectVersion",
+        ]
+        Resource = ["${var.artifacts_bucket_arn}/workflow-exports/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucketVersions"]
+        Resource = [var.artifacts_bucket_arn]
+        Condition = {
+          StringLike = { "s3:prefix" = ["workflow-exports/*"] }
+        }
+      },
       # Project-tier MCP secrets: the projects lambda lists (set-state only),
       # rotates (Put) and clears (Delete) per-var SecureStrings under
       # projects/<id>/mcp-secrets/*. It also READS the GLOBAL custom-mcp-servers
@@ -2378,8 +2397,15 @@ resource "aws_iam_role_policy" "intents" {
         }
       },
       {
-        Effect   = "Allow"
-        Action   = ["s3:PutObject", "s3:GetObject"]
+        # Native workspace export archives: written on export, and purged (all
+        # versions) when the owning intent is deleted.
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:DeleteObjectVersion",
+        ]
         Resource = "${var.artifacts_bucket_arn}/workflow-exports/*"
       },
       {

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -731,10 +731,11 @@ resource "aws_iam_role_policy" "neptune_tasks" {
 # -----------------------------------------------------------------------------
 # Role 7: blocks (2 Lambdas — building-blocks CRUD + seed-blocks)
 # DynamoDB RW on the blocks table + its GSI1, plus S3 RW scoped to the blocks/
-# prefix (content-addressed block bodies/scripts) and the aidlc-runtime/ prefix
-# (the seed job's commit-pinned internal runtime snapshot) of the artifacts
-# bucket. No Neptune; seed-blocks optionally uses VPC NAT egress to download the
-# pinned workflow source from codeload.github.com.
+# prefix (content-addressed block bodies/scripts), the aidlc-runtime/ prefix
+# (the seed job's commit-pinned internal runtime snapshot), and aidlc-catalogs/
+# (structured methodology snapshots used by historical exports). No Neptune;
+# seed-blocks optionally uses VPC NAT egress to download the pinned workflow
+# source from codeload.github.com.
 # -----------------------------------------------------------------------------
 resource "aws_iam_role" "blocks" {
   name               = "${var.project_name}-blocks-${var.environment}"
@@ -781,6 +782,7 @@ resource "aws_iam_role_policy" "blocks" {
         Resource = [
           "${var.artifacts_bucket_arn}/blocks/*",
           "${var.artifacts_bucket_arn}/aidlc-runtime/*",
+          "${var.artifacts_bucket_arn}/aidlc-catalogs/*",
         ]
       }
     ]
@@ -2357,6 +2359,13 @@ resource "aws_iam_role_policy" "intents" {
         Resource = "${var.artifacts_bucket_arn}/aidlc-distributions/*"
       },
       {
+        # Preserve and lazily rebuild the structured SYSTEM methodology needed
+        # to export intents created before a baseline reseed.
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
+        Resource = "${var.artifacts_bucket_arn}/aidlc-catalogs/*"
+      },
+      {
         # S3 only returns NoSuchKey for a missing cache object when the caller
         # can list that prefix; otherwise GetObject masks the miss as 403.
         Effect   = "Allow"
@@ -2364,7 +2373,7 @@ resource "aws_iam_role_policy" "intents" {
         Resource = var.artifacts_bucket_arn
         Condition = {
           StringLike = {
-            "s3:prefix" = ["aidlc-distributions/*"]
+            "s3:prefix" = ["aidlc-distributions/*", "aidlc-catalogs/*"]
           }
         }
       },

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -2377,7 +2377,7 @@ resource "aws_iam_role_policy" "intents" {
         # Project-uploaded Markdown rules are copied into the selected native
         # harness's auto-loaded rules directory.
         Effect   = "Allow"
-        Action   = ["s3:GetObject"]
+        Action   = ["s3:GetObject", "s3:GetObjectVersion"]
         Resource = "${var.artifacts_bucket_arn}/custom-rules/*"
       },
       {

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -2426,6 +2426,7 @@ module "intents_lambda" {
   handler       = "index.handler"
   runtime       = "nodejs24.x"
   timeout       = 120
+  memory_size   = 512
 
   source_path = [
     {

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -2111,6 +2111,7 @@ module "seed_blocks_lambda" {
   handler       = "index.handler"
   runtime       = "nodejs24.x"
   timeout       = 300
+  memory_size   = 512
 
   source_path = [
     {
@@ -2349,6 +2350,37 @@ resource "aws_iam_role_policy" "intents" {
         Resource = "${var.artifacts_bucket_arn}/compose-reports/*"
       },
       {
+        # Native AI-DLC workflow export: lazily cache the exact commit-pinned
+        # harness, then read it for subsequent exports.
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
+        Resource = "${var.artifacts_bucket_arn}/aidlc-distributions/*"
+      },
+      {
+        # S3 only returns NoSuchKey for a missing cache object when the caller
+        # can list that prefix; otherwise GetObject masks the miss as 403.
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = var.artifacts_bucket_arn
+        Condition = {
+          StringLike = {
+            "s3:prefix" = ["aidlc-distributions/*"]
+          }
+        }
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:PutObject", "s3:GetObject"]
+        Resource = "${var.artifacts_bucket_arn}/workflow-exports/*"
+      },
+      {
+        # Project-uploaded Markdown rules are copied into the selected native
+        # harness's auto-loaded rules directory.
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "${var.artifacts_bucket_arn}/custom-rules/*"
+      },
+      {
         # DRAFT intent prompt attachments: mint browser PUT URLs, validate
         # committed objects, and purge removed/versioned objects.
         Effect   = "Allow"
@@ -2435,6 +2467,9 @@ module "intents_lambda" {
     RUNTIME_COMPATIBILITY_VERSION = var.runtime_compatibility_version
     # Compose report uploads (presigned PUT + bounded read-back at dispatch).
     ARTIFACTS_BUCKET = var.artifacts_bucket_name
+    # Default upstream ref for legacy intents created before the ref was
+    # persisted. Native distributions are fetched and cached on export.
+    AIDLC_REPO_REF = var.aidlc_repo_ref
     # Server-origin realtime reload hints (artifact edited/verified, quorum
     # edit lifecycle) on the intent channel — lambda/shared/ws-fanout.js.
     CONNECTIONS_TABLE  = var.connections_table_name
@@ -2604,7 +2639,7 @@ resource "aws_iam_role_policy" "v2_orchestrator" {
       {
         # Blocks table: load the pinned workflow + block metadata for the plan.
         Effect   = "Allow"
-        Action   = ["dynamodb:Query"]
+        Action   = ["dynamodb:GetItem", "dynamodb:Query"]
         Resource = [var.blocks_table_arn, "${var.blocks_table_arn}/index/*"]
       },
       {

--- a/terraform/modules/api/lambda/variables.tf
+++ b/terraform/modules/api/lambda/variables.tf
@@ -67,7 +67,6 @@ variable "blocks_table_arn" {
 variable "aidlc_repo_ref" {
   description = "Pinned ref (commit SHA, tag, or branch) of awslabs/aidlc-workflows the seed-blocks lambda fetches the baseline from"
   type        = string
-  default     = "ba0cfe999856033ecb909a9135b46fe10811bf55"
 }
 
 variable "github_oauth_secret_name" {

--- a/terraform/modules/api/routes.tf
+++ b/terraform/modules/api/routes.tf
@@ -1174,6 +1174,12 @@ resource "aws_api_gateway_resource" "intent_graph" {
   path_part   = "graph"
 }
 
+resource "aws_api_gateway_resource" "intent_export" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  parent_id   = aws_api_gateway_resource.intent.id
+  path_part   = "export"
+}
+
 # Aggregated process/graph-read evidence (reads ledger, enrichment spend,
 # sensor findings) — the intent Audit view.
 resource "aws_api_gateway_resource" "intent_audit" {
@@ -1409,6 +1415,7 @@ locals {
     item_patch             = { resource = aws_api_gateway_resource.intent.id, method = "PATCH" }
     item_delete            = { resource = aws_api_gateway_resource.intent.id, method = "DELETE" }
     graph_get              = { resource = aws_api_gateway_resource.intent_graph.id, method = "GET" }
+    export_post            = { resource = aws_api_gateway_resource.intent_export.id, method = "POST" }
     audit_get              = { resource = aws_api_gateway_resource.intent_audit.id, method = "GET" }
     derive_post            = { resource = aws_api_gateway_resource.intent_derive.id, method = "POST" }
     outputs_get            = { resource = aws_api_gateway_resource.intent_outputs.id, method = "GET" }
@@ -1468,6 +1475,12 @@ module "cors_intents_metrics" {
   source      = "./cors"
   rest_api_id = aws_api_gateway_rest_api.main.id
   resource_id = aws_api_gateway_resource.intents_metrics.id
+}
+
+module "cors_intent_export" {
+  source      = "./cors"
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  resource_id = aws_api_gateway_resource.intent_export.id
 }
 
 module "cors_intent_attachments" {

--- a/terraform/modules/data/s3/main.tf
+++ b/terraform/modules/data/s3/main.tf
@@ -40,7 +40,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
 
     noncurrent_version_transition {
       noncurrent_days = 90
-      storage_class   = "GLACIER"
+      storage_class   = "GLACIER_IR"
     }
   }
 

--- a/terraform/modules/data/s3/main.tf
+++ b/terraform/modules/data/s3/main.tf
@@ -64,6 +64,23 @@ resource "aws_s3_bucket_lifecycle_configuration" "artifacts" {
       noncurrent_days = 1
     }
   }
+
+  rule {
+    id     = "expire_workflow_exports"
+    status = "Enabled"
+
+    filter {
+      prefix = "workflow-exports/"
+    }
+
+    expiration {
+      days = 1
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+  }
 }
 
 # Code snapshots bucket for agent code outputs

--- a/zensical.toml
+++ b/zensical.toml
@@ -25,6 +25,7 @@ nav = [
   { "Using the Platform" = [
     "using-the-platform/projects.md",
     "using-the-platform/creating-intents.md",
+    "using-the-platform/exporting-workspaces.md",
     "using-the-platform/intent-observability.md",
     "using-the-platform/workflows.md",
     "using-the-platform/platform-settings.md",


### PR DESCRIPTION
## Summary

### Native workspace export

- Export a stable Collaborative AI-DLC checkpoint as a runnable native AI-DLC workspace for Claude, Codex, Kiro CLI, Kiro IDE, or OpenCode.
- Reconstruct native State Version 7 with the workflow scope, completed and skipped stages, and the correct resume point.
- Materialize generated Markdown work products in their canonical native phase, stage, and per-unit paths.
- Reconstruct pending and answered `*-questions.md` files from human gates when no persisted Markdown artifact exists.
- Preserve arbitrary custom workflow compositions by registering their native scope definition, stage frontmatter, `stage-graph.json`, and `scope-grid.json`.
- Include custom project rules and repository URL/branch metadata. Source code and credentials are intentionally excluded.
- Reconstruct multi-unit Construction state: complete Bolt DAG, merged-unit receipts, autonomy mode, and next-unit resume point.
  - Reconstruct native audit stage events and runtime-graph.json.

### Version and snapshot fidelity

- Resolve the native harness from the intent's pinned AI-DLC commit, fetch it on demand, and cache the immutable archive in S3.
- Support both legacy `aidlc-docs/` and newer `aidlc/spaces/...` workspace layouts by inspecting the selected harness.
- Preserve pinned stage versions and compatibility with legacy workflow snapshots.
- Detect whether the pinned harness ships aidlc-workspace-sync.ts; otherwise provide manual sibling-repository setup.
- Use the root Terraform AI-DLC pin consistently across Lambdas.

### Platform integration

- Add the export API, archive generation, presigned downloads, S3 lifecycle cleanup, IAM permissions, and deployment support.
- Increase export Lambda capacity for uncached harness retrieval.

### User experience

- Add a workspace download action with harness selection:

<img width="947" height="335" alt="image" src="https://github.com/user-attachments/assets/3d90c6a6-ecac-4ca0-a09d-a5f16fc89fc5" />

- Warn that subsequent local work will not synchronize back into Collaborative AI-DLC traceability:

<img width="558" height="292" alt="image" src="https://github.com/user-attachments/assets/d3a9dc01-6503-46ce-9088-eb7597615ede" />

- Provide post-download repository and workspace setup commands when the exported checkpoint is entering Construction or a later phase:

<img width="1042" height="895" alt="image" src="https://github.com/user-attachments/assets/f5850fbe-8a11-475c-ada4-76a3b0a5ac6c" />


## Verification

- pre-commit hook: 125 test files, 2,490 tests passed
- frontend production build passed
- intents Lambda build passed
- frontend lint and formatting checks passed
- intents lint and formatting checks passed
- Add native runtime recompilation checks against pinned 2.3.3 and current v2, see screenshots.
- Tested live against "legacy" AIDLC (`ba0cfe999856033ecb909a9135b46fe10811bf55`) and a multi-repo space with newer version (`83ed7a812c4024904f2c5e4d744e28077e0a5acd`)


Fixes #400
