### PR TITLE
feat(networking): route provider authentication through static NAT egress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Optional static egress for OAuth connectors, credential resolution, and seed-blocks through `lambda_vpc_scope = "public-egress"`, with NAT public IP outputs and addresses printed in the deployment summary for external allow-lists.
+
 ## [2.0.0] - 2026-08-06
 
 Second and final step of the v2 release, building on `2.0.0-preview0`. Everything listed below is new since that preview; see the `2.0.0-preview0` entry for the v2 platform itself.

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -282,6 +282,7 @@ Bootstrap creates `terraform/environments/dev.s3.tfbackend`. The environment arg
 ./scripts/bootstrap.sh dev
 cp terraform/environments/dev.tfvars.example terraform/environments/dev.tfvars
 # Set aws_region = "<aws-region>" in dev.tfvars.
+# For static provider egress IPs, set lambda_vpc_scope = "public-egress".
 # For a custom domain, also set app_domain plus either acm_certificate_arn or
 # route53_zone_id — see "Custom domain → Without the installer" above.
 ./scripts/deploy-terraform.sh dev
@@ -318,6 +319,8 @@ These environment variables are useful when iterating:
 | `AIDLC_TFVARS_FILE`   | Path to an alternative `.tfvars`, overriding the `<environment>.tfvars` convention.                        |
 | `AIDLC_BACKEND_FILE`  | Path to an alternative `.s3.tfbackend`.                                                                    |
 | `AIDLC_CONFIG_DIR`    | Directory holding `environments/`, if you keep Terraform configuration outside the checkout.               |
+
+With `lambda_vpc_scope = "public-egress"`, the deployment summary prints the NAT addresses to add to provider allow-lists. Development environments expose one address and production environments expose two; allow-list every address printed. See [Git and Tracker Integration → Static egress IPs](../using-the-platform/git-integration.md#static-egress-ips) for the affected services.
 
 ### Bootstrap the first platform administrator
 

--- a/docs/using-the-platform/git-integration.md
+++ b/docs/using-the-platform/git-integration.md
@@ -15,6 +15,14 @@ Before users can connect their accounts, an administrator registers OAuth apps w
 
 The status of each provider is visible in **Admin → Trackers**. Until a provider shows **Configured**, the corresponding **Connect** button in Project Settings stays disabled with a hint pointing back to the admin panel.
 
+### Static egress IPs
+
+`lambda_vpc_scope` defaults to `"required"`. In this mode, only Lambdas that require access to private resources are attached to the VPC. Repository and tracker operations from `source-control` and `trackers`, along with the AgentCore runtime in its default VPC mode, already use NAT egress regardless of this setting.
+
+Deployments that require provider IP allow-listing can set it to `"public-egress"` in the environment's `.tfvars` file. This also routes the OAuth connectors, credential broker, and seed-blocks through the NAT gateways.
+
+Development environments have one address; production environments have two, and both must be allow-listed to avoid intermittent provider failures. These addresses are printed after applying the Terraform configuration.
+
 ### Project-bound authentication
 
 GitHub OAuth and GitHub App configuration remain available at the same time. There is no platform-wide runtime mode:

--- a/scripts/deploy-terraform.sh
+++ b/scripts/deploy-terraform.sh
@@ -115,13 +115,14 @@ tf_output() {
 }
 
 print_deployment_summary() {
-    local application_url region deployed_environment custom_domain aliases auth_mode providers
+    local application_url region deployed_environment custom_domain aliases auth_mode providers lambda_vpc_scope nat_ips
     local oidc_callback saml_acs saml_entity_id
     application_url="$(tf_output application_url)"
     region="$(tf_output aws_region)"
     deployed_environment="$(tf_output environment)"
     custom_domain="$(tf_output custom_domain_enabled)"
     auth_mode="$(tf_output auth_mode)"
+    lambda_vpc_scope="$(tf_output lambda_vpc_scope)"
 
     echo ""
     echo "Infrastructure deployment complete"
@@ -157,6 +158,10 @@ print_deployment_summary() {
     [[ -n "$oidc_callback" ]] && printf '  OIDC callback:   %s\n' "$oidc_callback"
     [[ -n "$saml_acs" ]] && printf '  SAML ACS:        %s\n' "$saml_acs"
     [[ -n "$saml_entity_id" ]] && printf '  SAML entity ID:  %s\n' "$saml_entity_id"
+    if [[ "$lambda_vpc_scope" == "public-egress" ]]; then
+        nat_ips="$(terraform -chdir="$TF_DIR" output -json nat_egress_public_ips 2>/dev/null || true)"
+        [[ -n "$nat_ips" ]] && printf '  NAT egress IPs:  %s\n' "$nat_ips"
+    fi
     printf '  Next step:       %s/deploy-frontend.sh %s\n' "$SCRIPT_DIR" "$ENVIRONMENT"
 }
 

--- a/terraform/environments/dev.tfvars.example
+++ b/terraform/environments/dev.tfvars.example
@@ -1,6 +1,11 @@
 environment = "dev"
 aws_region  = "us-east-1"
 
+# Keep only Lambdas already requiring private resources in the VPC. Set to
+# "public-egress" to also route OAuth connectors, credential resolution, and
+# seed-blocks through NAT.
+lambda_vpc_scope = "required"
+
 # Bedrock model pinning (for claude and opencode drivers)
 bedrock_model = "us.anthropic.claude-sonnet-4-6"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -353,6 +353,7 @@ module "lambda" {
 
   project_name                = var.project_name
   environment                 = var.environment
+  lambda_vpc_scope            = var.lambda_vpc_scope
   application_url             = local.app_url
   vpc_id                      = module.networking.vpc_id
   private_subnet_ids          = module.networking.private_subnet_ids

--- a/terraform/modules/api/lambda/main.tf
+++ b/terraform/modules/api/lambda/main.tf
@@ -3,8 +3,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 locals {
-  partition  = data.aws_partition.current.partition
-  dns_suffix = data.aws_partition.current.dns_suffix
+  partition            = data.aws_partition.current.partition
+  dns_suffix           = data.aws_partition.current.dns_suffix
+  enable_public_egress = var.lambda_vpc_scope == "public-egress"
 
   # Lambdas that bundle code from lambda/shared/** via esbuild are packaged by
   # the terraform-aws-modules/lambda module,
@@ -182,6 +183,13 @@ resource "aws_iam_role" "github_connector" {
 resource "aws_iam_role_policy_attachment" "github_connector_basic" {
   role       = aws_iam_role.github_connector.name
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "github_connector_vpc" {
+  count = local.enable_public_egress ? 1 : 0
+
+  role       = aws_iam_role.github_connector.name
+  policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy" "github_connector" {
@@ -704,7 +712,8 @@ resource "aws_iam_role_policy" "neptune_tasks" {
 # DynamoDB RW on the blocks table + its GSI1, plus S3 RW scoped to the blocks/
 # prefix (content-addressed block bodies/scripts) and the aidlc-runtime/ prefix
 # (the seed job's commit-pinned internal runtime snapshot) of the artifacts
-# bucket. No Neptune, no VPC — pure DDB + S3.
+# bucket. No Neptune; seed-blocks optionally uses VPC NAT egress to download the
+# pinned workflow source from codeload.github.com.
 # -----------------------------------------------------------------------------
 resource "aws_iam_role" "blocks" {
   name               = "${var.project_name}-blocks-${var.environment}"
@@ -714,6 +723,13 @@ resource "aws_iam_role" "blocks" {
 resource "aws_iam_role_policy_attachment" "blocks_basic" {
   role       = aws_iam_role.blocks.name
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "blocks_vpc" {
+  count = local.enable_public_egress ? 1 : 0
+
+  role       = aws_iam_role.blocks.name
+  policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy" "blocks" {
@@ -900,6 +916,13 @@ resource "aws_iam_role_policy_attachment" "credential_broker_basic" {
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+resource "aws_iam_role_policy_attachment" "credential_broker_vpc" {
+  count = local.enable_public_egress ? 1 : 0
+
+  role       = aws_iam_role.credential_broker.name
+  policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
 resource "aws_iam_role_policy" "credential_broker" {
   name = "agentcore-credential-resolution"
   role = aws_iam_role.credential_broker.id
@@ -977,6 +1000,9 @@ module "credential_broker_lambda" {
 
   create_role = false
   lambda_role = aws_iam_role.credential_broker.arn
+
+  vpc_subnet_ids         = local.enable_public_egress ? var.private_subnet_ids : null
+  vpc_security_group_ids = local.enable_public_egress ? [aws_security_group.lambda.id] : null
 
   cloudwatch_logs_retention_in_days = var.environment == "prod" ? 30 : 7
 
@@ -1461,6 +1487,9 @@ module "github_lambda" {
   create_role = false
   lambda_role = aws_iam_role.github_connector.arn
 
+  vpc_subnet_ids         = local.enable_public_egress ? var.private_subnet_ids : null
+  vpc_security_group_ids = local.enable_public_egress ? [aws_security_group.lambda.id] : null
+
   environment_variables = {
     GITHUB_OAUTH_SECRET_NAME           = var.github_oauth_secret_name
     GIT_CONNECTIONS_TABLE              = var.git_connections_table_name
@@ -1486,6 +1515,13 @@ resource "aws_iam_role" "gitlab_connector" {
 resource "aws_iam_role_policy_attachment" "gitlab_connector_basic" {
   role       = aws_iam_role.gitlab_connector.name
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "gitlab_connector_vpc" {
+  count = local.enable_public_egress ? 1 : 0
+
+  role       = aws_iam_role.gitlab_connector.name
+  policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy" "gitlab_connector" {
@@ -1550,6 +1586,9 @@ module "gitlab_lambda" {
   create_role = false
   lambda_role = aws_iam_role.gitlab_connector.arn
 
+  vpc_subnet_ids         = local.enable_public_egress ? var.private_subnet_ids : null
+  vpc_security_group_ids = local.enable_public_egress ? [aws_security_group.lambda.id] : null
+
   environment_variables = {
     GITLAB_OAUTH_SECRET_NAME       = var.gitlab_oauth_secret_name
     GIT_CONNECTIONS_TABLE          = var.git_connections_table_name
@@ -1575,6 +1614,13 @@ resource "aws_iam_role" "bitbucket_connector" {
 resource "aws_iam_role_policy_attachment" "bitbucket_connector_basic" {
   role       = aws_iam_role.bitbucket_connector.name
   policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "bitbucket_connector_vpc" {
+  count = local.enable_public_egress ? 1 : 0
+
+  role       = aws_iam_role.bitbucket_connector.name
+  policy_arn = "arn:${local.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_iam_role_policy" "bitbucket_connector" {
@@ -1638,6 +1684,9 @@ module "bitbucket_lambda" {
 
   create_role = false
   lambda_role = aws_iam_role.bitbucket_connector.arn
+
+  vpc_subnet_ids         = local.enable_public_egress ? var.private_subnet_ids : null
+  vpc_security_group_ids = local.enable_public_egress ? [aws_security_group.lambda.id] : null
 
   environment_variables = {
     BITBUCKET_OAUTH_SECRET_NAME    = var.bitbucket_oauth_secret_name
@@ -2046,6 +2095,9 @@ module "seed_blocks_lambda" {
 
   create_role = false
   lambda_role = aws_iam_role.blocks.arn
+
+  vpc_subnet_ids         = local.enable_public_egress ? var.private_subnet_ids : null
+  vpc_security_group_ids = local.enable_public_egress ? [aws_security_group.lambda.id] : null
 
   environment_variables = {
     BLOCKS_TABLE     = var.blocks_table_name

--- a/terraform/modules/api/lambda/variables.tf
+++ b/terraform/modules/api/lambda/variables.tf
@@ -23,6 +23,11 @@ variable "private_subnet_ids" {
   type        = list(string)
 }
 
+variable "lambda_vpc_scope" {
+  description = "Lambda VPC placement scope"
+  type        = string
+}
+
 variable "neptune_endpoint" {
   description = "Neptune cluster endpoint"
   type        = string

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -28,6 +28,11 @@ output "nat_gateway_ids" {
   value       = aws_nat_gateway.main[*].id
 }
 
+output "nat_public_ips" {
+  description = "Static public IPv4 addresses used for private-subnet egress"
+  value       = aws_eip.nat[*].public_ip
+}
+
 output "default_security_group_id" {
   description = "ID of the default security group"
   value       = aws_security_group.default.id

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -279,6 +279,16 @@ output "private_subnet_ids" {
   value       = module.networking.private_subnet_ids
 }
 
+output "nat_egress_public_ips" {
+  description = "Static public IPv4 addresses to add to external allowlists"
+  value       = module.networking.nat_public_ips
+}
+
+output "lambda_vpc_scope" {
+  description = "Applied Lambda VPC placement scope"
+  value       = var.lambda_vpc_scope
+}
+
 output "aws_region" {
   description = "AWS region"
   value       = var.aws_region

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,6 +16,17 @@ variable "environment" {
   default     = "dev"
 }
 
+variable "lambda_vpc_scope" {
+  description = "Lambda VPC placement scope: required keeps only private-resource Lambdas in the VPC; public-egress also routes selected public-service traffic through NAT"
+  type        = string
+  default     = "required"
+
+  validation {
+    condition     = contains(["required", "public-egress"], var.lambda_vpc_scope)
+    error_message = "lambda_vpc_scope must be one of: required, public-egress."
+  }
+}
+
 variable "bedrock_model" {
   description = "Bedrock inference profile ID for the primary model. E.g. us.anthropic.claude-sonnet-4-6"
   type        = string


### PR DESCRIPTION
*Issue #, if available:*
Relates partially to https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/398

*Description of changes:*
Related to [#398](https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/398), which proposes optional advanced security features including VPC placement for all Lambda functions. This PR implements the narrower static provider-egress use case as we require stable egress IP addresses for allow-listing on GitHub organizations and other providers.

This change:
- attaches the GitHub, GitLab, Bitbucket, and credential-broker Lambdas to the existing private subnets and Lambda security group;
- grants their custom execution roles the permissions required for VPC access;
- routes their outbound traffic through the existing NAT gateways;
- exposes the NAT gateway public IP addresses as a Terraform output for allow-listing.

This introduces a NAT dependency for these Lambdas, with corresponding NAT cost
and potential cold-start latency. It does not attempt the broader all-Lambda VPC
placement proposed by [#398](https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/398).

This contribution can be treated independently or closed in favor of a broader implementation of [#398](https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/398) if that direction is preferred.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.