### PR TITLE
fix(frontend): discover repositories through the bound auth method

### DIFF
--- a/frontend/src/components/project-settings/RepositoriesTab.test.tsx
+++ b/frontend/src/components/project-settings/RepositoriesTab.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Project } from '@/services/projects';
-import type { ProjectSourceControlStatus } from '@/services/sourceControl';
+import type { ProjectSourceControlStatus, SourceControlAuthType } from '@/services/sourceControl';
+import type { GitProvider, GitRepo } from '@/services/gitProvider';
 
 const sourceStatus = vi.hoisted(() => ({
   value: {
@@ -22,18 +24,31 @@ const sourceStatus = vi.hoisted(() => ({
 }));
 
 const getStatus = vi.hoisted(() => vi.fn());
+const bind = vi.hoisted(() => vi.fn());
 vi.mock('@/services/sourceControl', async (importOriginal) => {
-  // Keep the real auth-option metadata (SOURCE_CONTROL_AUTH_OPTIONS +
-  // defaultAuthTypeFor — pure data, no side effects) that
-  // SourceControlBindingSection consumes; mock only the network service.
   const actual = await importOriginal<typeof import('@/services/sourceControl')>();
   return {
     ...actual,
     sourceControlService: {
+      ...actual.sourceControlService,
       getStatus: (...args: unknown[]) => getStatus(...args),
-      bind: vi.fn(),
+      bind: (...args: unknown[]) => bind(...args),
       unbind: vi.fn(),
     },
+  };
+});
+
+const appListRepos = vi.hoisted(() => vi.fn());
+const githubOauthListRepos = vi.hoisted(() => vi.fn());
+vi.mock('@/services/gitProvider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/gitProvider')>();
+  return {
+    ...actual,
+    githubAppService: { ...actual.githubAppService, listRepos: appListRepos },
+    getGitProviderService: (provider: GitProvider) => ({
+      ...actual.getGitProviderService(provider),
+      listRepos: githubOauthListRepos,
+    }),
   };
 });
 
@@ -55,8 +70,43 @@ const project = {
   repos: [{ url: 'acme/api', provider: 'github', role: 'primary' }],
 } as Project;
 
+const repo = (fullName: string): GitRepo => ({
+  id: 1,
+  name: fullName.split('/')[1],
+  fullName,
+  private: false,
+  defaultBranch: 'main',
+});
+
+const boundStatus = (
+  provider: GitProvider,
+  authType: SourceControlAuthType,
+  repoName: string,
+): ProjectSourceControlStatus => ({
+  ready: true,
+  repositories: [
+    {
+      provider,
+      repo: repoName,
+      authType,
+      status: 'active',
+      invalidReason: null,
+      capabilities: { repositoryWrite: true },
+      verifiedAt: '2026-07-20T00:00:00Z',
+      updatedAt: '2026-07-20T00:00:00Z',
+    },
+  ],
+});
+
+const openAddDialog = async () => {
+  await userEvent.click(await screen.findByRole('button', { name: 'Add' }));
+};
+
 beforeEach(() => {
+  vi.clearAllMocks();
   getStatus.mockReset().mockImplementation(() => Promise.resolve(sourceStatus.value));
+  appListRepos.mockResolvedValue([]);
+  githubOauthListRepos.mockResolvedValue([]);
 });
 
 describe('RepositoriesTab', () => {
@@ -94,5 +144,44 @@ describe('RepositoriesTab', () => {
 
     expect(await screen.findByText('Write verified')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /bind/i })).not.toBeInTheDocument();
+  });
+
+  it('discovers App repositories for a GitHub-App-bound space without personal OAuth', async () => {
+    sourceStatus.value = boundStatus('github', 'github-app', 'acme/api');
+    appListRepos.mockResolvedValue([repo('acme/app-only')]);
+    githubOauthListRepos.mockRejectedValue(new Error('GitHub not connected'));
+
+    render(<RepositoriesTab project={project} canEdit reload={vi.fn()} />);
+    await openAddDialog();
+
+    expect(await screen.findByText('acme/app-only')).toBeInTheDocument();
+    expect(appListRepos).toHaveBeenCalled();
+    expect(githubOauthListRepos).not.toHaveBeenCalled();
+    expect(screen.queryByText('GitHub not connected')).not.toBeInTheDocument();
+  });
+
+  it('discovers personal repositories for a GitHub-OAuth-bound space', async () => {
+    sourceStatus.value = boundStatus('github', 'github-oauth', 'acme/api');
+    githubOauthListRepos.mockResolvedValue([repo('acme/oauth-only')]);
+
+    render(<RepositoriesTab project={project} canEdit reload={vi.fn()} />);
+    await openAddDialog();
+
+    expect(await screen.findByText('acme/oauth-only')).toBeInTheDocument();
+    expect(githubOauthListRepos).toHaveBeenCalled();
+    expect(appListRepos).not.toHaveBeenCalled();
+  });
+
+  it('follows a rebinding without a page reload', async () => {
+    sourceStatus.value = boundStatus('github', 'github-app', 'acme/api');
+    appListRepos.mockResolvedValue([repo('acme/app-only')]);
+    githubOauthListRepos.mockResolvedValue([repo('acme/oauth-only')]);
+    bind.mockResolvedValue(boundStatus('github', 'github-oauth', 'acme/api'));
+
+    render(<RepositoriesTab project={project} canEdit reload={vi.fn()} />);
+    await userEvent.click(await screen.findByRole('button', { name: 'Rebind and verify' }));
+    await openAddDialog();
+
+    expect(await screen.findByText('acme/oauth-only')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/project-settings/RepositoriesTab.tsx
+++ b/frontend/src/components/project-settings/RepositoriesTab.tsx
@@ -30,6 +30,7 @@ import { gitProviderTerminology, type GitProvider, type GitRepo } from '@/servic
 import { GitRepoSelect } from '@/components/GitRepoSelect';
 import { SettingsCard } from '@/components/settings/SettingsCard';
 import { SourceControlBindingSection } from './SourceControlBindingSection';
+import type { ProjectSourceControlStatus } from '@/services/sourceControl';
 
 const REPO_ROLE_COLORS: Record<string, string> = {
   primary: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
@@ -54,6 +55,9 @@ export function RepositoriesTab({ project, canEdit, reload }: Props) {
   const provider = (project.gitProvider ?? 'github') as GitProvider;
   const providerLabel = gitProviderTerminology(provider).label;
   const [error, setError] = useState<string | null>(null);
+  const [sourceControlStatus, setSourceControlStatus] = useState<ProjectSourceControlStatus | null>(
+    null,
+  );
 
   // Add dialog
   const [showAddRepo, setShowAddRepo] = useState(false);
@@ -65,6 +69,11 @@ export function RepositoriesTab({ project, canEdit, reload }: Props) {
   const [removingRepo, setRemovingRepo] = useState<string | null>(null);
   const [settingPrimary, setSettingPrimary] = useState<string | null>(null);
   const [confirmRemoveRepo, setConfirmRemoveRepo] = useState<string | null>(null);
+
+  const boundAuthType =
+    sourceControlStatus?.repositories.find((r) => r.provider === provider && r.authType)
+      ?.authType ?? null;
+  const repoSource = boundAuthType === 'github-app' ? 'github-app' : 'oauth';
 
   const handleAddRepos = async () => {
     if (selectedNewRepos.length === 0) return;
@@ -125,7 +134,11 @@ export function RepositoriesTab({ project, canEdit, reload }: Props) {
 
   return (
     <div className="space-y-6">
-      <SourceControlBindingSection project={project} canEdit={canEdit} />
+      <SourceControlBindingSection
+        project={project}
+        canEdit={canEdit}
+        onStatusChange={setSourceControlStatus}
+      />
 
       <SettingsCard
         icon={<GitBranch />}
@@ -255,6 +268,7 @@ export function RepositoriesTab({ project, canEdit, reload }: Props) {
                   setSelectedNewRepos(selected.map((r) => r.fullName));
                 }}
                 exclude={repos.map((r) => r.url)}
+                repoSource={repoSource}
               />
               {addError && <p className="text-sm text-destructive">{addError}</p>}
             </div>

--- a/frontend/src/components/project-settings/SourceControlBindingSection.tsx
+++ b/frontend/src/components/project-settings/SourceControlBindingSection.tsx
@@ -34,6 +34,7 @@ import {
 interface Props {
   project: Project;
   canEdit: boolean;
+  onStatusChange?: (status: ProjectSourceControlStatus) => void;
 }
 
 const authOptions = (provider: GitProvider): SourceControlAuthType[] =>
@@ -124,7 +125,7 @@ function ProviderBindingControl({
   );
 }
 
-export function SourceControlBindingSection({ project, canEdit }: Props) {
+export function SourceControlBindingSection({ project, canEdit, onStatusChange }: Props) {
   const [status, setStatus] = useState<ProjectSourceControlStatus | null>(null);
   const [authTypes, setAuthTypes] = useState<Partial<Record<GitProvider, SourceControlAuthType>>>(
     {},
@@ -152,6 +153,7 @@ export function SourceControlBindingSection({ project, canEdit }: Props) {
     try {
       const next = await sourceControlService.getStatus(project.id);
       setStatus(next);
+      onStatusChange?.(next);
       setAuthTypes((current) => {
         const updated = { ...current };
         for (const provider of providers) {
@@ -192,7 +194,9 @@ export function SourceControlBindingSection({ project, canEdit }: Props) {
     setSaving(true);
     setError(null);
     try {
-      setStatus(await sourceControlService.bind(project.id, selections));
+      const next = await sourceControlService.bind(project.id, selections);
+      setStatus(next);
+      onStatusChange?.(next);
     } catch (saveError) {
       setError(saveError instanceof Error ? saveError.message : 'Failed to bind source control');
     } finally {


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
## Problem
The Add Repositories picker always uses personal OAuth discovery. A space bound through the platform GitHub App can therefore fail to list repositories when the current user has no personal GitHub OAuth connection.
<img width="1620" height="513" alt="image" src="https://github.com/user-attachments/assets/ead28f12-a5d3-4d69-bbf0-3bbbbd86594e" />
<img width="475" height="207" alt="image" src="https://github.com/user-attachments/assets/c8ce476c-235c-4367-9ee6-e748c6f4503f" />


## Reproducer
1. Configure the platform GitHub App.
2. Create a space containing a GitHub repository and bind its source control using `GitHub App`.
3. Sign in as a space owner or administrator who has not connected a personal GitHub OAuth identity.
4. Open **Space settings → Source control**.
5. Select **Add** under Repositories.

The picker calls the personal OAuth repository endpoint (`/github/repos`) and fails with `OAUTH_NOT_CONFIGURED` or a GitHub connection error. No repositories from the space's GitHub App installation are shown.

### Expected behavior
Because the space is bound through `github-app`, the picker should use the GitHub App repository endpoint (`/github/app/repos`) and list repositories available to the installation without requiring personal OAuth.

## Solution
Propagate the source-control status already loaded by the binding section and select GitHub App discovery only for a confirmed `github-app` binding. All other bindings retain OAuth discovery. Status is propagated after rebinding so
the picker updates without a page reload.

## Impact
GitHub App-bound spaces can add repositories without requiring personal OAuth. Existing OAuth, GitLab, and Bitbucket behavior is unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
