### PR TITLE
fix(trackers): hide OAuth reconnect for GitHub App bindings in Trackers tab

### DIFF
--- a/frontend/src/components/admin/tabs/TrackersTab.tsx
+++ b/frontend/src/components/admin/tabs/TrackersTab.tsx
@@ -61,7 +61,7 @@ export function TrackersTab({ providers, providersLoading, onProvidersChanged }:
         <SettingsCard
           icon={<Link2 />}
           title="Source-control trackers"
-          description="These reuse the source-control OAuth apps — one connection covers repos and issues."
+          description="These authenticate through each space's source-control binding — GitHub App or delegated OAuth. One binding covers repos and issues."
         >
           <div className="divide-y rounded-lg border">
             {gitBacked.map((p) => {

--- a/frontend/src/components/project-settings/TrackersTab.test.tsx
+++ b/frontend/src/components/project-settings/TrackersTab.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import type { Project } from '@/services/projects';
+import type { Project, TrackerBinding } from '@/services/projects';
+import type { ProjectSourceControlStatus } from '@/services/sourceControl';
 
 // The tab reads tracker connections + operator OAuth-app config on mount. Stub
 // both to empty so the component renders without network access — this test is
@@ -23,6 +24,18 @@ vi.mock('@/hooks/useTrackerProviders', () => ({
   useTrackerProviders: () => ({ providers: [] }),
 }));
 
+const getSourceControlStatus = vi.hoisted(() => vi.fn());
+vi.mock('@/services/sourceControl', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/sourceControl')>();
+  return {
+    ...actual,
+    sourceControlService: {
+      ...actual.sourceControlService,
+      getStatus: (...args: unknown[]) => getSourceControlStatus(...args),
+    },
+  };
+});
+
 import { TrackersTab } from './TrackersTab';
 
 const makeProject = (overrides: Partial<Project>): Project =>
@@ -33,8 +46,38 @@ const makeProject = (overrides: Partial<Project>): Project =>
     ...overrides,
   }) as Project;
 
+const makeTracker = (overrides: Partial<TrackerBinding>): TrackerBinding => ({
+  id: 'tracker-1',
+  provider: 'github-issues',
+  instance: null,
+  externalProjectKey: 'acme/api',
+  displayName: 'acme/api',
+  createdAt: null,
+  createdBy: null,
+  ...overrides,
+});
+
+const sourceControlStatus = (
+  authType: 'github-app' | 'github-oauth' | 'gitlab-oauth',
+): ProjectSourceControlStatus => ({
+  ready: true,
+  repositories: [
+    {
+      provider: authType.startsWith('github') ? 'github' : 'gitlab',
+      repo: 'acme/api',
+      authType,
+      status: 'active',
+      invalidReason: null,
+      capabilities: { repositoryWrite: true },
+      verifiedAt: null,
+      updatedAt: null,
+    },
+  ],
+});
+
 beforeEach(() => {
   listConnections.mockReset().mockResolvedValue([]);
+  getSourceControlStatus.mockReset().mockResolvedValue({ ready: false, repositories: [] });
 });
 
 describe('TrackersTab — git tracker CTA', () => {
@@ -62,5 +105,116 @@ describe('TrackersTab — git tracker CTA', () => {
     expect(await screen.findByText('Trackers')).toBeInTheDocument();
     expect(screen.getByText(/Start sprints from/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^Add GitHub Issues/i })).toBeInTheDocument();
+  });
+});
+
+describe('TrackersTab — tracker reconnection', () => {
+  it('hides OAuth reconnection for a tracker backed by a GitHub App binding', async () => {
+    getSourceControlStatus.mockResolvedValue(sourceControlStatus('github-app'));
+
+    render(
+      <TrackersTab
+        project={makeProject({ trackers: [makeTracker({})] })}
+        canEdit
+        reload={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getSourceControlStatus).toHaveBeenCalledWith('project-1');
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Reconnect' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+  });
+
+  it.each([
+    ['a read-only GitHub Issues binding', makeProject({ trackers: [makeTracker({})] }), false],
+    ['a tracker-free project', makeProject({ trackers: [] }), true],
+    [
+      'a legacy GitHub Issues binding',
+      makeProject({ trackers: [makeTracker({ id: 'legacy-github' })] }),
+      true,
+    ],
+    [
+      'a GitLab Issues binding',
+      makeProject({
+        gitProvider: 'gitlab',
+        trackers: [makeTracker({ provider: 'gitlab-issues' })],
+      }),
+      true,
+    ],
+    [
+      'a Jira binding',
+      makeProject({
+        trackers: [makeTracker({ provider: 'jira-cloud', externalProjectKey: 'AIDLC' })],
+      }),
+      true,
+    ],
+  ] as const)('does not load source-control status for %s', async (_, project, canEdit) => {
+    render(<TrackersTab project={project} canEdit={canEdit} reload={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(listConnections).toHaveBeenCalledOnce();
+    });
+    expect(getSourceControlStatus).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['GitHub OAuth', 'github', 'github-issues', 'github-oauth'],
+    ['GitLab OAuth', 'gitlab', 'gitlab-issues', 'gitlab-oauth'],
+  ] as const)(
+    'offers reconnection for a tracker backed by %s',
+    async (_, provider, tracker, auth) => {
+      getSourceControlStatus.mockResolvedValue(sourceControlStatus(auth));
+
+      render(
+        <TrackersTab
+          project={makeProject({
+            gitProvider: provider,
+            trackers: [makeTracker({ provider: tracker })],
+          })}
+          canEdit
+          reload={vi.fn()}
+        />,
+      );
+
+      expect(await screen.findByRole('button', { name: 'Reconnect' })).toBeInTheDocument();
+    },
+  );
+
+  it('keeps reconnection available for Jira trackers', async () => {
+    render(
+      <TrackersTab
+        project={makeProject({
+          trackers: [
+            makeTracker({
+              provider: 'jira-cloud',
+              externalProjectKey: 'AIDLC',
+              displayName: 'AI-DLC',
+            }),
+          ],
+        })}
+        canEdit
+        reload={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Reconnect' })).toBeInTheDocument();
+  });
+
+  it('keeps reconnection available when binding status cannot be loaded', async () => {
+    getSourceControlStatus.mockRejectedValue(new Error('status unavailable'));
+
+    render(
+      <TrackersTab
+        project={makeProject({ trackers: [makeTracker({})] })}
+        canEdit
+        reload={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Reconnect' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/project-settings/TrackersTab.tsx
+++ b/frontend/src/components/project-settings/TrackersTab.tsx
@@ -13,6 +13,7 @@ import {
   trackerIdForGitProvider,
   type GitTrackerProviderId,
 } from '@/services/gitProvider';
+import { sourceControlService, type ProjectSourceControlStatus } from '@/services/sourceControl';
 import { getTrackerProvider, TRACKER_PROVIDERS } from '@/lib/trackerProviders';
 import { useTrackerProviders } from '@/hooks/useTrackerProviders';
 import { MigrateTrackerCard } from '@/components/MigrateTrackerCard';
@@ -38,6 +39,7 @@ export function TrackersTab({ project, canEdit, reload }: Props) {
   const { providers: trackerProviders } = useTrackerProviders();
   const [connectingJira, setConnectingJira] = useState(false);
   const [showJiraProjectPicker, setShowJiraProjectPicker] = useState(false);
+  const [sourceControl, setSourceControl] = useState<ProjectSourceControlStatus | null>(null);
 
   // Tracker-abstraction migration (#194 Phase 1).
   const [migrating, setMigrating] = useState(false);
@@ -54,6 +56,29 @@ export function TrackersTab({ project, canEdit, reload }: Props) {
   }, []);
 
   const bindings = project.trackers ?? [];
+  const needsSourceControlStatus =
+    canEdit &&
+    bindings.some(
+      (binding) => binding.provider === 'github-issues' && binding.id !== 'legacy-github',
+    );
+
+  useEffect(() => {
+    if (!needsSourceControlStatus) return;
+
+    sourceControlService
+      .getStatus(project.id)
+      .then(setSourceControl)
+      .catch(() => setSourceControl(null));
+  }, [needsSourceControlStatus, project.id]);
+
+  // GitHub App bindings have no OAuth identity to reconnect.
+  const canReconnect = (binding: TrackerBinding) => {
+    if (binding.provider !== 'github-issues') return true;
+    const repository = sourceControl?.repositories.find(
+      (repo) => repo.provider === 'github' && repo.repo === binding.externalProjectKey,
+    );
+    return repository?.authType !== 'github-app';
+  };
 
   // Add the git-issues tracker matching the project's git provider
   // (github-issues / gitlab-issues). Both reuse the project's git connection.
@@ -230,15 +255,17 @@ export function TrackersTab({ project, canEdit, reload }: Props) {
                     </div>
                     {canEdit && !isLegacy && (
                       <div className="flex shrink-0 items-center gap-1">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="h-7 px-2.5 text-[11px]"
-                          onClick={() => handleReconnectTracker(b)}
-                          disabled={togglingTracker}
-                        >
-                          Reconnect
-                        </Button>
+                        {canReconnect(b) && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2.5 text-[11px]"
+                            onClick={() => handleReconnectTracker(b)}
+                            disabled={togglingTracker}
+                          >
+                            Reconnect
+                          </Button>
+                        )}
                         <Button
                           size="sm"
                           variant="ghost"


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
## Problem
The project tracker settings show a Reconnect action for every non-legacy Git-backed tracker. For GitHub Issues backed by a GitHub App project binding, that action starts personal GitHub OAuth even though the binding has no personal OAuth identity to refresh. On App-only deployments it can fail with OAUTH_NOT_CONFIGURED.

## Reproducer
1. Configure the platform with a GitHub App.
2. Create a space whose GitHub repository is bound using `github-app`.
3. Open **Space settings → Trackers**.
4. Observe that the GitHub Issues tracker displays **Reconnect**.
5. Select **Reconnect**.

The UI starts a personal GitHub OAuth flow even though the tracker authenticates
through the space's GitHub App binding. That flow cannot repair or refresh the
App binding. If no GitHub OAuth app is configured, it also fails with
`OAUTH_NOT_CONFIGURED`.

## Solution
Load the project's source-control binding status and hide Reconnect only when the matching GitHub repository is authenticated through `github-app`. Reconnect remains available for GitHub OAuth, GitLab OAuth, Jira, and when binding status cannot be loaded.

## Impact
Users no longer see a recovery action that cannot repair GitHub App-backed trackers. OAuth-backed tracker recovery is unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
