### PR TITLE
fix(frontend): notify subscribers after persisted cache hydration

### DIFF
--- a/frontend/src/hooks/useProjectsCache.test.ts
+++ b/frontend/src/hooks/useProjectsCache.test.ts
@@ -1,6 +1,25 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
 import { deriveActivity } from './useProjectsCache';
 import type { Intent, IntentStatus } from '@/services/intents';
+import type { Sprint } from '@/services/sprints';
+
+const cacheServiceMocks = vi.hoisted(() => ({
+  listProjects: vi.fn(() => Promise.reject(new Error('unexpected projects fetch'))),
+  listSprints: vi.fn(() => Promise.reject(new Error('unexpected sprints fetch'))),
+}));
+
+vi.mock('@/services/projects', () => ({
+  projectsService: {
+    list: cacheServiceMocks.listProjects,
+  },
+}));
+vi.mock('@/services/sprints', () => ({
+  sprintsService: { list: cacheServiceMocks.listSprints },
+}));
+vi.mock('@/services/intents', () => ({
+  intentsService: { list: vi.fn(() => Promise.reject(new Error('unexpected intents fetch'))) },
+}));
 
 // Only `status` matters to deriveActivity; keep fixtures minimal.
 const intent = (status: IntentStatus): Intent => ({ status }) as Intent;
@@ -40,5 +59,55 @@ describe('deriveActivity — dashboard per-project counts', () => {
       intent('CANCELLED'), //  ignored
     ];
     expect(deriveActivity(intents)).toEqual({ inProgress: 3, attention: 2 });
+  });
+});
+
+describe('useProjectsCache — sessionStorage hydration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    sessionStorage.clear();
+  });
+
+  it('re-renders subscribers that mounted before a fresh persisted cache is adopted', async () => {
+    sessionStorage.setItem(
+      'aidlc-cache:v1:projects',
+      JSON.stringify({
+        data: [
+          {
+            project: { id: 'p1', name: 'Space One' },
+            latestSprint: null,
+            latestIntent: null,
+            lastIntentActivityAt: null,
+            activity: { inProgress: 0, attention: 0 },
+          },
+        ],
+        fetchedAt: Date.now(),
+      }),
+    );
+
+    const { useProjectsCache } = await import('./useProjectsCache');
+    const { result } = renderHook(() => useProjectsCache());
+
+    await waitFor(() => expect(result.current.projects).toHaveLength(1));
+    expect(result.current.projects[0].project.id).toBe('p1');
+    expect(cacheServiceMocks.listProjects).not.toHaveBeenCalled();
+  });
+
+  it('re-renders sprint subscribers after adopting a fresh persisted cache', async () => {
+    sessionStorage.setItem(
+      'aidlc-cache:v1:sprints:p1',
+      JSON.stringify({
+        data: [{ id: 's1', name: 'Sprint One', createdAt: '2026-08-18T00:00:00.000Z' }],
+        fetchedAt: Date.now(),
+      }),
+    );
+
+    const { useProjectSprintsCache } = await import('./useProjectsCache');
+    const { result } = renderHook(() => useProjectSprintsCache('p1'));
+
+    await waitFor(() => expect(result.current.sprints).toHaveLength(1));
+    expect(result.current.sprints[0]).toMatchObject({ id: 's1', name: 'Sprint One' } as Sprint);
+    expect(cacheServiceMocks.listSprints).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useProjectsCache.ts
+++ b/frontend/src/hooks/useProjectsCache.ts
@@ -202,6 +202,8 @@ function revalidateProjects(force = false): Promise<void> {
     const persisted = loadPersisted<ProjectWithSprint[]>('projects');
     if (persisted && !projectsCache) {
       projectsCache = persisted;
+      // A fresh persisted entry skips the fetch below, so hydration must emit.
+      notifyProjectListeners();
     }
   }
   if (projectsInflight) {
@@ -256,6 +258,7 @@ function revalidateSprints(projectId: string, force = false): Promise<void> {
     const persisted = loadPersisted<Sprint[]>(`sprints:${projectId}`);
     if (persisted) {
       sprintsCache.set(projectId, persisted);
+      notifySprintListeners(projectId);
     }
   }
   const inflight = sprintsInflight.get(projectId);


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
## Problem
Projects and sprints are hydrated from sessionStorage inside mount effects. Subscribers render before hydration and initially observe an empty external store. When the persisted entry is fresh, network revalidation returns early, so no version change occurs and mounted views can remain empty indefinitely.
<img width="1913" height="390" alt="image" src="https://github.com/user-attachments/assets/2e4ab806-539c-44e2-b768-f573e1a361ff" />

## Solution
Notify the existing project and per-project sprint external-store subscribers immediately after adopting persisted cache entries.

## Impact
Dashboard, space, and sprint views rerender with fresh persisted data without requiring an unnecessary network request. Cache TTL and refresh behavior are unchanged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
