### PR TITLE
fix(auth): sign out only after definitive session expiry

### DIFF
--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   isAuthenticated: vi.fn(),
+  getCurrentUser: vi.fn(),
+  logout: vi.fn(),
   loginWithSso: vi.fn(),
+  completeSsoLogin: vi.fn(),
+  consumeReturnTo: vi.fn(),
 }));
 
 vi.mock('../services/auth', () => ({
@@ -12,13 +16,19 @@ vi.mock('../services/auth', () => ({
 }));
 
 import { AuthProvider, useAuth } from './AuthContext';
+import {
+  currentSessionEpoch,
+  notifySessionExpired,
+  resetSessionExpiry,
+} from '../services/sessionExpiry';
 
 function SsoLoginHarness() {
-  const { isLoading, loginWithSso } = useAuth();
+  const { user, isLoading, loginWithSso, completeSsoLogin } = useAuth();
 
   return (
     <>
       <span>{isLoading ? 'loading' : 'idle'}</span>
+      <span>{user?.username ?? 'anonymous'}</span>
       <button
         type="button"
         onClick={() => {
@@ -27,13 +37,24 @@ function SsoLoginHarness() {
       >
         Start SSO
       </button>
+      <button
+        type="button"
+        onClick={() => {
+          void completeSsoLogin();
+        }}
+      >
+        Complete SSO
+      </button>
     </>
   );
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetSessionExpiry();
   mocks.isAuthenticated.mockResolvedValue(false);
+  mocks.logout.mockResolvedValue(undefined);
+  mocks.consumeReturnTo.mockReturnValue('/dashboard');
 });
 
 describe('AuthProvider SSO state', () => {
@@ -53,6 +74,7 @@ describe('AuthProvider SSO state', () => {
       </AuthProvider>,
     );
     expect(await screen.findByText('idle')).toBeInTheDocument();
+    expect(mocks.isAuthenticated).toHaveBeenCalledOnce();
 
     await user.click(screen.getByRole('button', { name: 'Start SSO' }));
     expect(screen.getByText('loading')).toBeInTheDocument();
@@ -61,5 +83,51 @@ describe('AuthProvider SSO state', () => {
       rejectRedirect(new Error('Redirect failed'));
     });
     expect(await screen.findByText('idle')).toBeInTheDocument();
+  });
+
+  it('starts a new session epoch after successful SSO completion', async () => {
+    mocks.completeSsoLogin.mockResolvedValue({
+      userId: 'sso-user',
+      username: 'sso@example.com',
+      groups: [],
+      identitySource: 'sso',
+    });
+    const epoch = currentSessionEpoch();
+
+    render(
+      <AuthProvider>
+        <SsoLoginHarness />
+      </AuthProvider>,
+    );
+    expect(await screen.findByText('idle')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Complete SSO' }));
+
+    expect(currentSessionEpoch()).toBe(epoch + 1);
+  });
+
+  it('clears an authenticated user and logs out once when the session expires', async () => {
+    mocks.isAuthenticated.mockResolvedValue(true);
+    mocks.getCurrentUser.mockResolvedValue({
+      userId: 'user-1',
+      username: 'user@example.com',
+      groups: [],
+      identitySource: 'cognito',
+    });
+
+    render(
+      <AuthProvider>
+        <SsoLoginHarness />
+      </AuthProvider>,
+    );
+    expect(await screen.findByText('user@example.com')).toBeInTheDocument();
+
+    act(() => {
+      notifySessionExpired();
+      notifySessionExpired();
+    });
+
+    expect(await screen.findByText('anonymous')).toBeInTheDocument();
+    expect(mocks.logout).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,7 +1,16 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
 import type { ReactNode } from 'react';
 import { authService } from '../services/auth';
 import type { User } from '../services/auth';
+import { armSessionExpiry, onSessionExpired, resetSessionExpiry } from '../services/sessionExpiry';
 
 interface AuthContextType {
   user: User | null;
@@ -39,11 +48,34 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [needsNewPassword, setNeedsNewPassword] = useState(false);
   const [needsDisplayName, setNeedsDisplayName] = useState(false);
+  const userRef = useRef<User | null>(null);
+  userRef.current = user;
+
+  useEffect(
+    () =>
+      onSessionExpired(() => {
+        const wasSignedIn = userRef.current !== null;
+        setUser(null);
+        setNeedsNewPassword(false);
+        setNeedsDisplayName(false);
+        // Nobody was signed in (e.g. an API call from a public route): there is
+        // no Amplify state or persisted cache to tear down.
+        if (!wasSignedIn) return;
+        // Best-effort: the session may already be invalid server-side.
+        void authService.logout().catch((error) => {
+          console.error('Sign-out after session expiry failed:', error);
+        });
+      }),
+    [],
+  );
 
   const checkAuthState = useCallback(async () => {
     try {
       const isAuth = await authService.isAuthenticated();
       if (isAuth) {
+        // Re-arm without a new epoch: requests fired at mount carry the current
+        // one and their 401s must still be able to report an expiry.
+        armSessionExpiry();
         const currentUser = await authService.getCurrentUser();
         setUser(currentUser);
         setNeedsDisplayName(!currentUser.displayName);
@@ -63,6 +95,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setIsLoading(true);
     try {
       const result = await authService.login(username, password);
+      resetSessionExpiry();
       if (result.nextStep === 'NEW_PASSWORD_REQUIRED') {
         setNeedsNewPassword(true);
       } else if (result.user) {
@@ -81,6 +114,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setIsLoading(true);
     try {
       const authedUser = await authService.completeNewPassword(newPassword);
+      resetSessionExpiry();
       setNeedsNewPassword(false);
       setUser(authedUser);
       setNeedsDisplayName(!authedUser.displayName);
@@ -105,6 +139,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     setIsLoading(true);
     try {
       const authedUser = await authService.completeSsoLogin();
+      resetSessionExpiry();
       setUser(authedUser);
       setNeedsDisplayName(!authedUser.displayName);
       return authService.consumeReturnTo();

--- a/frontend/src/hooks/useYjsDocument.test.tsx
+++ b/frontend/src/hooks/useYjsDocument.test.tsx
@@ -6,13 +6,19 @@ import * as awarenessProtocol from 'y-protocols/awareness';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  getSession: vi.fn(),
+  resolveSession: vi.fn(),
+  notifySessionExpired: vi.fn(),
   getRealtimeToken: vi.fn(),
   getYjsUrl: vi.fn(),
 }));
 
 vi.mock('../services/auth', () => ({
-  authService: { getSession: mocks.getSession },
+  authService: { resolveSession: mocks.resolveSession },
+}));
+
+vi.mock('../services/sessionExpiry', () => ({
+  currentSessionEpoch: () => 7,
+  notifySessionExpired: mocks.notifySessionExpired,
 }));
 
 vi.mock('../services/realtime', () => ({
@@ -67,7 +73,10 @@ const instances: MockWebSocket[] = [];
 describe('useYjsDocument', () => {
   beforeEach(() => {
     instances.length = 0;
-    mocks.getSession.mockReset().mockResolvedValue({ idToken: 'id-token' });
+    mocks.resolveSession
+      .mockReset()
+      .mockResolvedValue({ session: { idToken: 'id-token' }, expired: false });
+    mocks.notifySessionExpired.mockReset();
     mocks.getRealtimeToken
       .mockReset()
       .mockResolvedValue({ token: 'scope-token', exp: Math.floor(Date.now() / 1000) + 600 });
@@ -111,5 +120,15 @@ describe('useYjsDocument', () => {
     unmount();
     mirrorAwareness.destroy();
     mirrorDoc.destroy();
+  });
+
+  it('notifies when Cognito reports definitive session expiry', async () => {
+    mocks.resolveSession.mockResolvedValue({ session: null, expired: true });
+
+    const { unmount } = renderHook(() => useYjsDocument('inception-project-1', 'Alice'));
+
+    await waitFor(() => expect(mocks.notifySessionExpired).toHaveBeenCalledWith(7));
+    expect(instances).toHaveLength(0);
+    unmount();
   });
 });

--- a/frontend/src/hooks/useYjsDocument.ts
+++ b/frontend/src/hooks/useYjsDocument.ts
@@ -6,6 +6,7 @@ import * as syncProtocol from 'y-protocols/sync';
 import * as awarenessProtocol from 'y-protocols/awareness';
 import { realtimeService } from '../services/realtime';
 import { authService } from '../services/auth';
+import { currentSessionEpoch, notifySessionExpired } from '../services/sessionExpiry';
 import {
   getRealtimeToken,
   invalidateRealtimeToken,
@@ -104,7 +105,10 @@ export function useYjsDocument(
       // refreshes automatically when the token is near expiry.
       let session;
       try {
-        session = await authService.getSession();
+        const epoch = currentSessionEpoch();
+        const resolution = await authService.resolveSession();
+        session = resolution.session;
+        if (resolution.expired) notifySessionExpired(epoch);
       } catch (error) {
         console.error('Yjs: failed to refresh Cognito session:', error);
         scheduleReconnect();

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  resolveSession: vi.fn(),
+  currentSessionEpoch: vi.fn(() => 7),
+  isSessionExpiryNotified: vi.fn(() => false),
+  notifySessionExpired: vi.fn(),
+}));
+
+vi.mock('./auth', () => ({
+  authService: { resolveSession: (...args: unknown[]) => mocks.resolveSession(...args) },
+}));
+
+vi.mock('./sessionExpiry', () => ({
+  currentSessionEpoch: mocks.currentSessionEpoch,
+  isSessionExpiryNotified: mocks.isSessionExpiryNotified,
+  notifySessionExpired: mocks.notifySessionExpired,
+}));
+
+import { api, ApiError } from './api';
+
+const session = {
+  accessToken: 'access',
+  idToken: 'id',
+  refreshToken: 'refresh',
+};
+
+describe('authenticated API session expiry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not expire the session after a transient refresh failure', async () => {
+    mocks.resolveSession.mockResolvedValue({ session: null, expired: false });
+
+    await expect(api.get('/projects')).rejects.toMatchObject({ status: 401 });
+
+    expect(mocks.notifySessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('expires the session when Cognito can no longer resolve tokens', async () => {
+    mocks.resolveSession.mockResolvedValue({ session: null, expired: true });
+
+    await expect(api.get('/projects')).rejects.toMatchObject({ status: 401 });
+
+    expect(mocks.notifySessionExpired).toHaveBeenCalledWith(7);
+  });
+
+  it('does not expire a valid Cognito session for a provider 401 response', async () => {
+    mocks.resolveSession
+      .mockResolvedValueOnce({ session, expired: false })
+      .mockResolvedValueOnce({ session, expired: false });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: vi.fn().mockResolvedValue('Provider unauthorized'),
+      }),
+    );
+
+    await expect(api.get('/source-control')).rejects.toBeInstanceOf(ApiError);
+
+    expect(mocks.resolveSession).toHaveBeenLastCalledWith({ forceRefresh: true });
+    expect(mocks.notifySessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('expires the session when a provider 401 coincides with failed Cognito refresh', async () => {
+    mocks.resolveSession
+      .mockResolvedValueOnce({ session, expired: false })
+      .mockResolvedValueOnce({ session: null, expired: true });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        text: vi.fn().mockResolvedValue('Unauthorized'),
+      }),
+    );
+
+    await expect(api.get('/source-control')).rejects.toMatchObject({ status: 401 });
+
+    expect(mocks.notifySessionExpired).toHaveBeenCalledWith(7);
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,9 @@
 import { authService } from './auth';
+import {
+  currentSessionEpoch,
+  isSessionExpiryNotified,
+  notifySessionExpired,
+} from './sessionExpiry';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
@@ -18,8 +23,16 @@ export class ApiError extends Error {
 }
 
 async function fetchWithAuth(path: string, options: RequestInit = {}): Promise<Response> {
-  const session = await authService.getSession();
+  // Tagging the request with the current epoch keeps a late 401 from a
+  // previous session from signing out a user who has since re-authenticated.
+  const epoch = currentSessionEpoch();
+  const { session, expired } = await authService.resolveSession();
   if (!session) {
+    // A transient refresh failure (offline) leaves the refresh token valid, so
+    // only a definitive expiry signs the user out.
+    if (expired) {
+      notifySessionExpired(epoch);
+    }
     throw new ApiError(401, 'Not authenticated');
   }
 
@@ -33,6 +46,17 @@ async function fetchWithAuth(path: string, options: RequestInit = {}): Promise<R
   });
 
   if (!response.ok) {
+    // A 401 is not proof the Cognito session is dead: endpoints forward
+    // upstream provider statuses verbatim, so a revoked GitHub/GitLab/Jira
+    // token surfaces as a 401 too. Only sign out when a forced refresh shows
+    // the session itself is unusable. (403 is authorization — admin gates —
+    // and never means expiry.)
+    if (response.status === 401 && !isSessionExpiryNotified()) {
+      const refreshed = await authService.resolveSession({ forceRefresh: true });
+      if (refreshed.expired) {
+        notifySessionExpired(epoch);
+      }
+    }
     const rawText = await response.text().catch(() => '');
     let parsed: Record<string, unknown> | undefined;
     try {

--- a/frontend/src/services/auth.test.ts
+++ b/frontend/src/services/auth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const authMocks = vi.hoisted(() => ({
   signIn: vi.fn(),
@@ -48,8 +48,72 @@ vi.mock('aws-amplify/auth/cognito', () => ({
   },
 }));
 
-import { cognitoOauthScopes, parseSsoProviders } from './auth';
+import { authService as sessionAuthService, cognitoOauthScopes, parseSsoProviders } from './auth';
 import { isSsoAccessDeniedError } from './authErrors';
+
+function amplifyError(name: string): Error {
+  const error = new Error(name);
+  error.name = name;
+  return error;
+}
+
+describe('authService.resolveSession', () => {
+  beforeEach(() => {
+    authMocks.fetchAuthSession.mockReset();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('reports a live session', async () => {
+    authMocks.fetchAuthSession.mockResolvedValue({
+      tokens: { accessToken: 'access', idToken: 'id' },
+    });
+
+    await expect(sessionAuthService.resolveSession()).resolves.toEqual({
+      session: { accessToken: 'access', idToken: 'id', refreshToken: '' },
+      expired: false,
+    });
+  });
+
+  it('treats an empty token set as a definitive expiry', async () => {
+    authMocks.fetchAuthSession.mockResolvedValue({});
+
+    await expect(sessionAuthService.resolveSession()).resolves.toEqual({
+      session: null,
+      expired: true,
+    });
+  });
+
+  it('does not expire the session on a transient network failure', async () => {
+    authMocks.fetchAuthSession.mockRejectedValue(amplifyError('NetworkError'));
+
+    await expect(sessionAuthService.resolveSession()).resolves.toEqual({
+      session: null,
+      expired: false,
+    });
+  });
+
+  it.each([
+    'NotAuthorizedException',
+    'TokenRevokedException',
+    'UserNotFoundException',
+    'RefreshTokenReuseException',
+  ])('expires the session when Cognito refuses the refresh (%s)', async (name) => {
+    authMocks.fetchAuthSession.mockRejectedValue(amplifyError(name));
+
+    await expect(sessionAuthService.resolveSession()).resolves.toEqual({
+      session: null,
+      expired: true,
+    });
+  });
+
+  it('forces a refresh when asked to', async () => {
+    authMocks.fetchAuthSession.mockResolvedValue({});
+
+    await sessionAuthService.resolveSession({ forceRefresh: true });
+
+    expect(authMocks.fetchAuthSession).toHaveBeenCalledWith({ forceRefresh: true });
+  });
+});
 
 describe('SSO frontend configuration', () => {
   const providers = [

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -115,6 +115,33 @@ export interface AuthSession {
   refreshToken: string;
 }
 
+export interface SessionResolution {
+  session: AuthSession | null;
+  /** True only when Cognito reports the session is definitively gone (no
+   *  tokens, or a refusal such as `NotAuthorizedException`). Transient
+   *  failures — offline, service errors — resolve to false so callers do not
+   *  sign the user out while the refresh token is still valid. */
+  expired: boolean;
+}
+
+/** Cognito errors meaning the refresh token itself is no longer usable, as
+ *  opposed to a transient transport failure. Mirrors Amplify's own
+ *  `TokenOrchestrator.isAuthenticationError` list, which is what decides
+ *  whether it discards the stored tokens. */
+const SESSION_REFUSED_ERRORS = [
+  'NotAuthorizedException',
+  'TokenRevokedException',
+  'UserNotFoundException',
+  'PasswordResetRequiredException',
+  'UserNotConfirmedException',
+  'RefreshTokenReuseException',
+];
+
+function isSessionRefusedError(error: unknown): boolean {
+  const name = error instanceof Error ? error.name : '';
+  return SESSION_REFUSED_ERRORS.some((refusal) => name.startsWith(refusal));
+}
+
 export interface AuthResult {
   user?: User;
   nextStep?: 'NEW_PASSWORD_REQUIRED' | 'MFA_REQUIRED';
@@ -299,21 +326,32 @@ export const authService = {
     await updateUserAttributes({ userAttributes: attrs });
   },
 
-  async getSession(): Promise<AuthSession | null> {
+  async resolveSession(options: { forceRefresh?: boolean } = {}): Promise<SessionResolution> {
     try {
-      const session = await fetchAuthSession();
+      const session = await fetchAuthSession(options);
       if (session.tokens) {
         return {
-          accessToken: session.tokens.accessToken.toString(),
-          idToken: session.tokens.idToken?.toString() || '',
-          refreshToken: (session.tokens as any).refreshToken?.toString() || '',
+          session: {
+            accessToken: session.tokens.accessToken.toString(),
+            idToken: session.tokens.idToken?.toString() || '',
+            refreshToken: (session.tokens as any).refreshToken?.toString() || '',
+          },
+          expired: false,
         };
       }
-      return null;
+      // No tokens means either "never signed in" or a refresh Cognito refused:
+      // `TokenOrchestrator.refreshTokens` swallows only `NotAuthorizedException`
+      // and rethrows every transient failure, so this is always definitive.
+      return { session: null, expired: true };
     } catch (error) {
       console.error('Get session error:', error);
-      return null;
+      return { session: null, expired: isSessionRefusedError(error) };
     }
+  },
+
+  async getSession(): Promise<AuthSession | null> {
+    const { session } = await authService.resolveSession();
+    return session;
   },
 
   async isAuthenticated(): Promise<boolean> {

--- a/frontend/src/services/realtime.test.ts
+++ b/frontend/src/services/realtime.test.ts
@@ -1,14 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  getSession: vi.fn(),
+  resolveSession: vi.fn(),
+  notifySessionExpired: vi.fn(),
   getRealtimeToken: vi.fn(),
   invalidateRealtimeToken: vi.fn(),
   msUntilRefresh: vi.fn(),
 }));
 
 vi.mock('./auth', () => ({
-  authService: { getSession: (...args: unknown[]) => mocks.getSession(...args) },
+  authService: { resolveSession: (...args: unknown[]) => mocks.resolveSession(...args) },
+}));
+
+vi.mock('./sessionExpiry', () => ({
+  currentSessionEpoch: () => 7,
+  notifySessionExpired: mocks.notifySessionExpired,
 }));
 
 vi.mock('../lib/realtimeToken', () => ({
@@ -70,7 +76,10 @@ describe('RealtimeService', () => {
     vi.useFakeTimers();
     MockWebSocket.instances = [];
     vi.stubGlobal('WebSocket', MockWebSocket);
-    mocks.getSession.mockReset().mockResolvedValue({ idToken: 'id-token' });
+    mocks.resolveSession
+      .mockReset()
+      .mockResolvedValue({ session: { idToken: 'id-token' }, expired: false });
+    mocks.notifySessionExpired.mockReset();
     mocks.getRealtimeToken
       .mockReset()
       .mockResolvedValue({ token: 'scope-token', exp: 123, scopes: [] });
@@ -98,6 +107,20 @@ describe('RealtimeService', () => {
     expect(mocks.getRealtimeToken).toHaveBeenNthCalledWith(1, target);
     expect(mocks.getRealtimeToken).toHaveBeenNthCalledWith(2, target);
     expect(MockWebSocket.instances[1].url).toContain('documentId=intent%3Aintent-1');
+  });
+
+  it('notifies when Cognito reports definitive session expiry', async () => {
+    mocks.resolveSession.mockResolvedValue({ session: null, expired: true });
+    const service = new RealtimeService(false);
+
+    await expect(
+      service.connect('intent:intent-1', {
+        intentId: 'intent-1',
+        projectId: 'project-1',
+      }),
+    ).rejects.toThrow('Not authenticated');
+
+    expect(mocks.notifySessionExpired).toHaveBeenCalledWith(7);
   });
 
   it('reconnects an unexpectedly closed intent channel with the same target', async () => {

--- a/frontend/src/services/realtime.ts
+++ b/frontend/src/services/realtime.ts
@@ -1,4 +1,5 @@
 import { authService } from './auth';
+import { currentSessionEpoch, notifySessionExpired } from './sessionExpiry';
 import {
   getRealtimeToken,
   invalidateRealtimeToken,
@@ -96,7 +97,9 @@ export class RealtimeService {
   }
 
   private async doConnect(request: ConnectionRequest): Promise<void> {
-    const session = await authService.getSession();
+    const epoch = currentSessionEpoch();
+    const { session, expired } = await authService.resolveSession();
+    if (expired) notifySessionExpired(epoch);
     if (!session?.idToken) throw new Error('Not authenticated');
 
     const docToken = await getRealtimeToken(request.scopeTarget);

--- a/frontend/src/services/sessionExpiry.test.ts
+++ b/frontend/src/services/sessionExpiry.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  armSessionExpiry,
+  currentSessionEpoch,
+  isSessionExpiryNotified,
+  notifySessionExpired,
+  onSessionExpired,
+  resetSessionExpiry,
+} from './sessionExpiry';
+
+describe('sessionExpiry', () => {
+  beforeEach(() => {
+    resetSessionExpiry();
+  });
+
+  it('notifies every subscriber once per expiry', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const unregisterFirst = onSessionExpired(first);
+    const unregisterSecond = onSessionExpired(second);
+
+    notifySessionExpired();
+    notifySessionExpired();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(isSessionExpiryNotified()).toBe(true);
+
+    armSessionExpiry();
+    expect(isSessionExpiryNotified()).toBe(false);
+    notifySessionExpired();
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+
+    unregisterFirst();
+    unregisterSecond();
+    armSessionExpiry();
+    notifySessionExpired();
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores an expiry reported for a superseded session', () => {
+    const handler = vi.fn();
+    const unregister = onSessionExpired(handler);
+    const epoch = currentSessionEpoch();
+
+    resetSessionExpiry(); // a new sign-in happened while the request was in flight
+    notifySessionExpired(epoch);
+
+    expect(handler).not.toHaveBeenCalled();
+    unregister();
+  });
+
+  it('replays a pending expiry to every later subscriber', () => {
+    notifySessionExpired();
+
+    const first = vi.fn();
+    const second = vi.fn();
+    const unregisterFirst = onSessionExpired(first);
+    const unregisterSecond = onSessionExpired(second);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    unregisterFirst();
+    unregisterSecond();
+  });
+});

--- a/frontend/src/services/sessionExpiry.ts
+++ b/frontend/src/services/sessionExpiry.ts
@@ -1,0 +1,41 @@
+type SessionExpiredHandler = () => void;
+
+const handlers = new Set<SessionExpiredHandler>();
+let epoch = 0;
+let notified = false;
+
+export function currentSessionEpoch(): number {
+  return epoch;
+}
+
+export function isSessionExpiryNotified(): boolean {
+  return notified;
+}
+
+export function onSessionExpired(handler: SessionExpiredHandler): () => void {
+  handlers.add(handler);
+  if (notified) {
+    handler();
+  }
+  return () => {
+    handlers.delete(handler);
+  };
+}
+
+export function notifySessionExpired(atEpoch: number = epoch): void {
+  // Ignore a late failure from a session that has since been replaced.
+  if (notified || atEpoch !== epoch) return;
+  notified = true;
+  for (const handler of handlers) {
+    handler();
+  }
+}
+
+export function armSessionExpiry(): void {
+  notified = false;
+}
+
+export function resetSessionExpiry(): void {
+  epoch += 1;
+  armSessionExpiry();
+}


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
## Problem
When Cognito can no longer refresh a session, API calls fail with 401 but AuthContext retains the previous user. The UI remains authenticated and continues issuing failing requests.
Logging out on every API 401 is unsafe because provider endpoints can also return GitHub, GitLab, Bitbucket, or Jira 401 responses while the Cognito session remains valid.

<img width="494" height="256" alt="image" src="https://github.com/user-attachments/assets/157a8f77-b77c-43f1-9167-de46a2b0bfba" />
<img width="815" height="383" alt="image" src="https://github.com/user-attachments/assets/fd46f348-1639-440d-8cec-dc268db96544" />


## Reproducer
1. Sign in and open any authenticated page.
2. In another browser tab or through the Cognito administration API, revoke the user's refresh token or invalidate the session.
3. Return to the application after the access token expires and trigger an API request, such as refreshing the spaces list.
4. Observe that the request fails with 401, but the application still considers the previous user authenticated and remains on the protected page.
5. Trigger additional actions and observe repeated 401 responses instead of a return to the login page.

## Solution
Classify session resolution as valid, definitively expired, or transiently unavailable. On an API 401, force a Cognito refresh before notifying AuthContext. A small epoch-aware bridge coalesces expiry notifications and prevents late requests from an old session from signing out a newly authenticated local or SSO session.

## Impact
Expired users return cleanly to login. Network failures and provider-specific 401 responses no longer cause false logout, and stale requests cannot expire a replacement session.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
