### PR TITLE
chore: Reduce AgentCore image size and harden Docker build

### DIFF
--- a/lambda/agentcore/Dockerfile
+++ b/lambda/agentcore/Dockerfile
@@ -7,65 +7,94 @@
 #
 # Build context is the repo `lambda/` dir (so the image can COPY both the
 # agentcore package and the shared/ helpers it imports via ../shared).
-FROM public.ecr.aws/docker/library/node:24.15.0-slim
+FROM public.ecr.aws/docker/library/node:24.19.0-slim@sha256:be8929e08ae137e81b5e1edba02259e6c4cb2f5ad655092bb9f56b97e41c4536
 
 # Base tools: git (workspace checkout), curl/unzip (CLI installs), jq, procps,
 # python3 (bare-`python`/`python3` MCP servers; `python`→`python3` symlink so
 # both resolve — uv/uvx manage their own Python separately).
-RUN apt-get update -o Acquire::AllowInsecureRepositories=true \
-    && apt-get install -y --no-install-recommends --allow-unauthenticated ca-certificates gnupg \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends git curl unzip jq procps python3 \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git curl unzip jq procps python3 \
     && ln -sf /usr/bin/python3 /usr/local/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
 # Agent CLIs — installed for all supported drivers; selectCli picks what's
 # present at runtime. Kiro (API-key auth), Claude Code + OpenCode + Codex
 # (Bedrock).
-RUN curl -fsSL https://cli.kiro.dev/install | bash \
+ARG KIRO_CLI_VERSION=2.19.2
+ARG KIRO_CLI_SHA256=84df9ddcf02156d9563910850c7a07805ea41cf6a32bc30438741878f10a5af5
+RUN curl -fsSLo /tmp/kiro-cli.zip \
+        "https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux-musl.zip" \
+    && echo "${KIRO_CLI_SHA256}  /tmp/kiro-cli.zip" | sha256sum -c - \
+    && unzip -q /tmp/kiro-cli.zip -d /tmp/kiro-cli \
+    && KIRO_CLI_SKIP_SETUP=1 /tmp/kiro-cli/kirocli/install.sh \
     && mkdir -p /opt/kiro \
     && cp -a /root/.local/bin /opt/kiro/bin \
     && ln -sf /opt/kiro/bin/kiro-cli /usr/local/bin/kiro-cli \
-    && rm -rf /root/.local
-RUN npm install -g @anthropic-ai/claude-code
+    && kiro-cli --version | grep -F "${KIRO_CLI_VERSION}" \
+    && rm -rf /root/.local /tmp/kiro-cli /tmp/kiro-cli.zip
+ARG CLAUDE_CODE_VERSION=2.1.246
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && claude --version | grep -F "${CLAUDE_CODE_VERSION}" \
+    && npm cache clean --force
 ARG OPENCODE_VERSION=1.17.20
+ARG OPENCODE_SHA256=0a41572e83a896eb008683589dfe09e17b941d06122608510f3e5f16d86d9afc
 RUN mkdir -p /opt/opencode/bin \
-    && curl -fsSL "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-arm64.tar.gz" \
-    | tar -xz -C /opt/opencode/bin \
+    && curl -fsSLo /tmp/opencode.tar.gz \
+        "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-arm64.tar.gz" \
+    && echo "${OPENCODE_SHA256}  /tmp/opencode.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/opencode.tar.gz -C /opt/opencode/bin \
     && chmod +x /opt/opencode/bin/opencode \
-    && /opt/opencode/bin/opencode --version | grep -F "${OPENCODE_VERSION}"
+    && /opt/opencode/bin/opencode --version | grep -F "${OPENCODE_VERSION}" \
+    && rm -f /tmp/opencode.tar.gz
 # Codex — pinned for reproducibility (the npm package ships the arm64 binary).
 # The per-stage CODEX_HOME (config.toml) is materialized at run time; the
 # version assert catches a broken/mismatched install at build time.
 ARG CODEX_VERSION=0.145.0
 RUN npm install -g @openai/codex@${CODEX_VERSION} \
-    && codex --version | grep -F "${CODEX_VERSION}"
+    && codex --version | grep -F "${CODEX_VERSION}" \
+    && npm cache clean --force
 
 # Bun — the runtime the deterministic CODE sensors (linter, type-check) run on.
 # They shell out to `bunx eslint`/`bunx tsc` against the workspace checkout, so
 # the binary must be on PATH for the script-kind sensor runner. Document-shape
 # sensors run in-process (no bun) — this is only for the code-quality axis.
-RUN curl -fsSL https://bun.sh/install | bash \
-    && mkdir -p /opt/bun \
-    && cp -a /root/.bun/bin /opt/bun/bin \
+ARG BUN_VERSION=1.4.0
+ARG BUN_SHA256=4b1a332ee861983eb93bcfe6f770fff94e3e31b2c388bdaea3c8ed35e58eed0e
+RUN mkdir -p /opt/bun/bin \
+    && curl -fsSLo /tmp/bun.zip \
+        "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-aarch64.zip" \
+    && echo "${BUN_SHA256}  /tmp/bun.zip" | sha256sum -c - \
+    && unzip -q /tmp/bun.zip -d /tmp/bun \
+    && install -m 0755 /tmp/bun/bun-linux-aarch64/bun /opt/bun/bin/bun \
+    && ln -sf /opt/bun/bin/bun /opt/bun/bin/bunx \
     && ln -sf /opt/bun/bin/bun /usr/local/bin/bun \
     && ln -sf /opt/bun/bin/bunx /usr/local/bin/bunx \
-    && rm -rf /root/.bun
+    && bun --version | grep -Fx "${BUN_VERSION}" \
+    && rm -rf /tmp/bun /tmp/bun.zip
 
 # uv / uvx — the standard launcher for Python-based MCP servers (e.g.
 # `uvx mcp-server-fetch`). Custom MCP servers configured per-project/globally
 # may reference it, and the mcp-validator allows `uv`/`uvx` as bare commands, so
-# the binaries must be on PATH. Same install→/opt→symlink pattern as Kiro/bun.
-# UV_NO_MODIFY_PATH: we set PATH explicitly below; skip the installer's shell
-# profile edits (noise/failure in a non-interactive image build).
-RUN curl -LsSf https://astral.sh/uv/install.sh \
-    | env UV_INSTALL_DIR=/opt/uv/bin UV_NO_MODIFY_PATH=1 sh \
+# the binaries must be on PATH.
+ARG UV_VERSION=0.12.6
+ARG UV_SHA256=d58030acd26159499ac82f32da12d1b3c12a3a1bfc414232d9082070c03e128d
+RUN mkdir -p /opt/uv/bin \
+    && curl -fsSLo /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-aarch64-unknown-linux-gnu.tar.gz" \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tar.gz -C /tmp \
+    && install -m 0755 /tmp/uv-aarch64-unknown-linux-gnu/uv /opt/uv/bin/uv \
+    && install -m 0755 /tmp/uv-aarch64-unknown-linux-gnu/uvx /opt/uv/bin/uvx \
     && ln -sf /opt/uv/bin/uv /usr/local/bin/uv \
-    && ln -sf /opt/uv/bin/uvx /usr/local/bin/uvx
+    && ln -sf /opt/uv/bin/uvx /usr/local/bin/uvx \
+    && uv --version | grep -F "uv ${UV_VERSION}" \
+    && rm -rf /tmp/uv-aarch64-unknown-linux-gnu /tmp/uv.tar.gz
 
 # Install the agentcore package deps (its own package.json — isolated).
 COPY agentcore/package.json /opt/agentcore/package.json
-RUN cd /opt/agentcore && npm install --omit=dev
+RUN cd /opt/agentcore \
+    && npm install --omit=dev \
+    && npm cache clean --force
 
 # App code: the agentcore package + the shared/ helpers it imports via ../shared.
 COPY agentcore/ /opt/agentcore/
@@ -77,10 +106,14 @@ COPY shared/ /opt/shared/
 RUN ln -s /opt/agentcore/node_modules /opt/shared/node_modules
 
 # /mnt/workspace is the AgentCore managed-session-storage mount (present only at
-# invocation time). Create a fallback dir for local/non-AgentCore runs; chown so
-# the node user can write the checkout + CLI stores when the mount is absent.
-RUN mkdir -p /mnt/workspace /home/node/.codex-state /home/node/.codex-runs \
-    && chown -R node:node /mnt/workspace /opt/agentcore /opt/shared /opt/kiro /opt/opencode /opt/bun /opt/uv /home/node/.codex-state /home/node/.codex-runs
+# invocation time). Create the local fallback and ephemeral CLI-state directories
+# with their final ownership immediately. The application and CLI trees under
+# /opt are immutable at runtime and only need to be readable/executable by node;
+# recursively chowning them would duplicate their contents in a new image layer.
+RUN install -d -o node -g node \
+    /mnt/workspace \
+    /home/node/.codex-state \
+    /home/node/.codex-runs
 
 WORKDIR /mnt/workspace
 USER node
@@ -111,14 +144,6 @@ ENV HOME=/home/node \
     V2_CODEX_HOME_ROOT=/home/node/.codex-runs \
     V2_CODEX_STORE_DIR=/mnt/workspace/.aidlc/codex-home \
     V2_MCP_ENTRY=/opt/agentcore/mcp/index.js
-
-# The AgentCore managed-session-storage mount (/mnt/workspace) is owned by a uid
-# that differs from the node user, so git refuses to operate on the checkout
-# ("detected dubious ownership"). Mark all workspace checkouts safe. A wildcard
-# (not a single path) is required because multi-repo intents clone into
-# /mnt/workspace/<owner>/<repo> subdirs, each of which trips the per-repo check.
-# Written as the node user so it lands in this user's global ~/.gitconfig.
-RUN git config --global --add safe.directory '*'
 
 # AgentCore Runtime contract: listen on 8080. /ping is the health surface.
 EXPOSE 8080

--- a/lambda/agentcore/Dockerfile
+++ b/lambda/agentcore/Dockerfile
@@ -90,6 +90,18 @@ RUN mkdir -p /opt/uv/bin \
     && uv --version | grep -F "uv ${UV_VERSION}" \
     && rm -rf /tmp/uv-aarch64-unknown-linux-gnu /tmp/uv.tar.gz
 
+# Pre-create the application directories before COPY --chmod writes into them.
+# Otherwise BuildKit may apply a file's 0644 mode to an auto-created parent,
+# making /opt/agentcore non-traversable. Create the local workspace fallback and
+# ephemeral CLI-state directories here too, with their final ownership, so no
+# recursive chown layer is needed later.
+RUN install -d -o node -g node -m 0755 \
+    /opt/agentcore \
+    /opt/shared \
+    /mnt/workspace \
+    /home/node/.codex-state \
+    /home/node/.codex-runs
+
 # Install the agentcore package deps (its own package.json — isolated).
 COPY --chown=node:node --chmod=0644 agentcore/package.json /opt/agentcore/package.json
 RUN cd /opt/agentcore \
@@ -104,16 +116,6 @@ COPY --chown=node:node shared/ /opt/shared/
 # @aws-sdk deps upward from /opt/shared — never into /opt/agentcore/node_modules
 # where they are installed. Symlink so the shared helpers see the same deps.
 RUN ln -s /opt/agentcore/node_modules /opt/shared/node_modules
-
-# /mnt/workspace is the AgentCore managed-session-storage mount (present only at
-# invocation time). Create the local fallback and ephemeral CLI-state directories
-# with their final ownership immediately. The application and CLI trees under
-# /opt are immutable at runtime and only need to be readable/executable by node;
-# recursively chowning them would duplicate their contents in a new image layer.
-RUN install -d -o node -g node \
-    /mnt/workspace \
-    /home/node/.codex-state \
-    /home/node/.codex-runs
 
 WORKDIR /mnt/workspace
 USER node

--- a/lambda/agentcore/Dockerfile
+++ b/lambda/agentcore/Dockerfile
@@ -91,14 +91,14 @@ RUN mkdir -p /opt/uv/bin \
     && rm -rf /tmp/uv-aarch64-unknown-linux-gnu /tmp/uv.tar.gz
 
 # Install the agentcore package deps (its own package.json — isolated).
-COPY agentcore/package.json /opt/agentcore/package.json
+COPY --chown=node:node --chmod=0644 agentcore/package.json /opt/agentcore/package.json
 RUN cd /opt/agentcore \
     && npm install --omit=dev \
     && npm cache clean --force
 
 # App code: the agentcore package + the shared/ helpers it imports via ../shared.
-COPY agentcore/ /opt/agentcore/
-COPY shared/ /opt/shared/
+COPY --chown=node:node agentcore/ /opt/agentcore/
+COPY --chown=node:node shared/ /opt/shared/
 
 # The shared/ helpers are CommonJS loaded from /opt/shared, so Node resolves their
 # @aws-sdk deps upward from /opt/shared — never into /opt/agentcore/node_modules

--- a/lambda/agentcore/test/container-deps.test.js
+++ b/lambda/agentcore/test/container-deps.test.js
@@ -145,6 +145,15 @@ describe('container dependency closure (Dockerfile installs ONLY agentcore/packa
 
 describe('container runtime file ownership', () => {
   it('makes restrictive managed-checkout files readable by the node runtime user', () => {
+    const createDirs = dockerfile.indexOf('RUN install -d -o node -g node -m 0755');
+    const copyManifest = dockerfile.indexOf(
+      'COPY --chown=node:node --chmod=0644 agentcore/package.json',
+    );
+    expect(createDirs).toBeGreaterThan(-1);
+    expect(createDirs).toBeLessThan(copyManifest);
+    expect(dockerfile).toMatch(
+      /RUN install -d -o node -g node -m 0755 \\\n\s+\/opt\/agentcore \\\n\s+\/opt\/shared/,
+    );
     expect(dockerfile).toContain(
       'COPY --chown=node:node --chmod=0644 agentcore/package.json /opt/agentcore/package.json',
     );

--- a/lambda/agentcore/test/container-deps.test.js
+++ b/lambda/agentcore/test/container-deps.test.js
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'node:url';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const agentcoreDir = path.join(here, '..');
 const sharedDir = path.join(here, '..', '..', 'shared');
+const dockerfile = readFileSync(path.join(agentcoreDir, 'Dockerfile'), 'utf8');
 
 const pkg = JSON.parse(readFileSync(path.join(agentcoreDir, 'package.json'), 'utf8'));
 const declared = new Set(Object.keys(pkg.dependencies ?? {}));
@@ -139,5 +140,16 @@ describe('container dependency closure (Dockerfile installs ONLY agentcore/packa
     expect([...externals.keys()]).toContain('js-yaml');
     expect([...externals.keys()]).toContain('gremlin');
     void sharedDir; // documented anchor of the second copied tree
+  });
+});
+
+describe('container runtime file ownership', () => {
+  it('makes restrictive managed-checkout files readable by the node runtime user', () => {
+    expect(dockerfile).toContain(
+      'COPY --chown=node:node --chmod=0644 agentcore/package.json /opt/agentcore/package.json',
+    );
+    expect(dockerfile).toContain('COPY --chown=node:node agentcore/ /opt/agentcore/');
+    expect(dockerfile).toContain('COPY --chown=node:node shared/ /opt/shared/');
+    expect(dockerfile).not.toMatch(/chown -R .*\/opt\/(?:agentcore|shared)/);
   });
 });

--- a/lambda/agentcore/test/init-ws.test.js
+++ b/lambda/agentcore/test/init-ws.test.js
@@ -6,6 +6,7 @@ import {
   checkoutRepos as checkoutReposImpl,
   checkoutRepo as checkoutRepoImpl,
   ensureWorkspaceSource as ensureWorkspaceSourceImpl,
+  trustGitDirectory,
 } from '../workspace.js';
 
 const TEST_SECRET = ['broker', 'credential'].join('-');
@@ -23,6 +24,7 @@ const credentialContext = {
   executionId: 'e1',
   gitProvider: 'github',
   withGitCredential: withTestCredential,
+  trustDirectory: async () => true,
 };
 const checkoutRepo = (args) => checkoutRepoImpl({ ...credentialContext, ...args });
 const checkoutRepos = (args) => checkoutReposImpl({ ...credentialContext, ...args });
@@ -931,5 +933,34 @@ describe('ensureWorkspaceSource (self-heal a wiped checkout)', () => {
       statFn: statFor([]),
     });
     expect(res).toMatchObject({ restored: true, repos: ['acme/api'], failed: ['acme/api'] });
+  });
+});
+
+describe('trustGitDirectory', () => {
+  it('adds only the exact repository path when it is not already trusted', async () => {
+    const commands = [];
+    const runner = async (command, args) => {
+      commands.push([command, ...args].join(' '));
+      return { code: args.includes('--get-all') ? 1 : 0 };
+    };
+
+    await expect(trustGitDirectory({ targetDir: '/ws/acme/api', runner })).resolves.toBe(true);
+    expect(commands).toEqual([
+      'git config --global --fixed-value --get-all safe.directory /ws/acme/api',
+      'git config --global --add safe.directory /ws/acme/api',
+    ]);
+  });
+
+  it('does not add a duplicate exact repository path', async () => {
+    const commands = [];
+    const runner = async (command, args) => {
+      commands.push([command, ...args].join(' '));
+      return { code: 0 };
+    };
+
+    await expect(trustGitDirectory({ targetDir: '/ws/acme/api', runner })).resolves.toBe(true);
+    expect(commands).toEqual([
+      'git config --global --fixed-value --get-all safe.directory /ws/acme/api',
+    ]);
   });
 });

--- a/lambda/agentcore/workspace.js
+++ b/lambda/agentcore/workspace.js
@@ -30,6 +30,24 @@ const run = (command, args, { cwd, env = {}, spawnFn = spawn } = {}) =>
 
 const cloneUrl = (repo, gitProvider) => buildCloneUrl(gitProvider, repo, '');
 
+// Managed-session storage can restore a checkout with an owner that differs
+// from the runtime node user. Trust only the exact repository root selected by
+// the validated project configuration; never opt out globally with '*'.
+export const trustGitDirectory = async ({ targetDir, runner = run }) => {
+  const existing = await runner(
+    'git',
+    ['config', '--global', '--fixed-value', '--get-all', 'safe.directory', targetDir],
+    {},
+  );
+  if (existing.code === 0) return true;
+  const added = await runner(
+    'git',
+    ['config', '--global', '--add', 'safe.directory', targetDir],
+    {},
+  );
+  return added.code === 0;
+};
+
 // Clone one repo and check out (creating if needed) the working branch off the
 // base branch. `runner`/`ensureDir`
 // injectable for tests. The origin remote is left TOKEN-FREE in both outcomes.
@@ -58,8 +76,18 @@ export const checkoutRepo = async ({
   statFn = stat,
   removeDir = (d) => rm(d, { recursive: true, force: true }),
   readGitConfig = (d) => readFile(path.join(d, '.git', 'config'), 'utf8'),
+  trustDirectory = trustGitDirectory,
 }) => {
   await ensureDir(targetDir);
+  if (!(await trustDirectory({ targetDir, runner }))) {
+    return {
+      repo,
+      targetDir,
+      cloned: false,
+      branchOk: false,
+      error: 'safe_directory_config_failed',
+    };
+  }
   const cleanUrl = cloneUrl(repo, gitProvider);
   const scrubRemote = async () => {
     const setUrl = await runner('git', ['remote', 'set-url', 'origin', cleanUrl], {
@@ -210,6 +238,7 @@ export const checkoutRepos = async ({
   runner = run,
   withGitCredential,
   ensureDir,
+  trustDirectory = trustGitDirectory,
 }) => {
   const out = [];
   const multi = repos.length > 1;
@@ -233,6 +262,7 @@ export const checkoutRepos = async ({
         runner,
         withGitCredential,
         ensureDir,
+        trustDirectory,
       }),
     );
   }
@@ -376,6 +406,7 @@ export const ensureWorkspaceSource = async ({
   withGitCredential,
   ensureDir,
   statFn = stat,
+  trustDirectory = trustGitDirectory,
 }) => {
   const multi = repos.length > 1;
   const restoredRepos = [];
@@ -388,7 +419,10 @@ export const ensureWorkspaceSource = async ({
       gitProvider ||
       'github';
     const targetDir = repoTargetDir({ url, workspaceDir, multi });
-    if (await hasCheckout(targetDir, statFn)) continue;
+    if (await hasCheckout(targetDir, statFn)) {
+      if (!(await trustDirectory({ targetDir, runner }))) failed.push(url);
+      continue;
+    }
     // Missing: re-clone this one. A failure leaves no reusable `.git` state.
     const res = await checkoutRepo({
       repo: url,
@@ -401,6 +435,7 @@ export const ensureWorkspaceSource = async ({
       runner,
       withGitCredential,
       ensureDir,
+      trustDirectory,
     });
     restoredRepos.push(url);
     if (!res.cloned || res.branchOk === false) failed.push(url);


### PR DESCRIPTION
## Summary

Reduces the AgentCore container image size and improves build reproducibility and security.

The primary issue was a recursive `chown` over `/opt`, which duplicated the installed CLI and application files into a new Docker layer.

  ## Changes

  - Replace recursive `chown -R` with ownership-correct directory creation.
  - Remove insecure APT repository options.
  - Pin Kiro, Claude Code, OpenCode, Codex, Bun, and uv versions.
  - Verify downloaded CLI artifacts using SHA-256 checksums.
  - Pin the ARM64 Node.js base image by digest.
  - Clean npm caches after installation.
  - Remove the global safe.directory '*' Git bypass.
  - Register only exact runtime checkout paths as trusted Git directories.
  - Add tests for scoped Git trust registration.

  ## Image-size results

  ECR compressed image size:


| Version  | Size |                                                                                                                                               
|---------|-----|
| Previous |  1.867 GB |
| Updated |  1.228 GB|

   **Reduction    638.9 MB (34.2%)**

  The updated image uses approximately 61.4% of AgentCore’s 2 GB limit, leaving about 771.7 MB of headroom.

  ## Validation

  - ARM64 Docker image built successfully.
  - Dockerfile static validation passed.
  - Formatting passed for changed files.
  - Lint passed with pre-existing warnings only.
  - Secret scanning passed.
  - 126 test files passed.
  - 2,500 tests passed.
  - Deployed and tested with a new intent