### PR TITLE
fix(installer): preserve readable checkout permissions

### DIFF
--- a/lambda/yjs-server/Dockerfile
+++ b/lambda/yjs-server/Dockerfile
@@ -2,10 +2,10 @@ FROM public.ecr.aws/docker/library/node:24.15.0-alpine3.23@sha256:d1b3b4da11eefd
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+COPY --chown=node:node --chmod=0644 package.json package-lock.json ./
 RUN npm ci --omit=dev
 
-COPY server.js realtime-token.js doc-name.js ./
+COPY --chown=node:node --chmod=0644 server.js realtime-token.js doc-name.js ./
 
 USER node
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -666,13 +666,22 @@ select_version() {
     fi
 }
 
+clone_checkout() (
+    # The installer keeps a restrictive umask for credentials and generated
+    # configuration. Source checkouts are build inputs, though: Docker COPY
+    # preserves their modes, and runtime images execute as an unprivileged user.
+    # Clone with normal source permissions so regular files are readable.
+    umask 022
+    git clone "$@"
+)
+
 checkout_release() {
     local version="$1" destination="$RELEASES_DIR/v$1" temporary
     mkdir -p "$RELEASES_DIR"
     if [[ ! -d "$destination/.git" ]]; then
         temporary="$destination.tmp.$$"
         rm -rf "$temporary"
-        git clone --quiet --depth 1 --branch "v$version" "$REPOSITORY_URL" "$temporary"
+        clone_checkout --quiet --depth 1 --branch "v$version" "$REPOSITORY_URL" "$temporary"
         mv "$temporary" "$destination"
     fi
     local local_commit local_tag_commit remote_commit
@@ -716,7 +725,7 @@ checkout_ref() {
     if [[ ! -d "$destination/.git" ]]; then
         temporary="$destination.tmp.$$"
         rm -rf "$temporary"
-        git clone --quiet --depth 1 --branch "$ref" "$REPOSITORY_URL" "$temporary"
+        clone_checkout --quiet --depth 1 --branch "$ref" "$REPOSITORY_URL" "$temporary"
         local_commit="$(git -C "$temporary" rev-parse HEAD)"
         if [[ "$local_commit" != "$commit" ]]; then
             echo "Branch $ref changed while cloning; rerun the installer." >&2

--- a/scripts/test/release-tools.test.mjs
+++ b/scripts/test/release-tools.test.mjs
@@ -9,6 +9,7 @@ import {
   readdirSync,
   readlinkSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -25,6 +26,7 @@ const destroyTerraform = join(root, 'scripts/destroy.sh');
 const generateEnv = join(root, 'scripts/generate-env.sh');
 const releaseWorkflow = join(root, '.github/workflows/release.yml');
 const demoWorkflow = join(root, '.github/workflows/deploy-demo.yml');
+const yjsDockerfile = join(root, 'lambda/yjs-server/Dockerfile');
 
 const run = (file, args, options = {}) =>
   spawnSync(file, args, {
@@ -93,6 +95,23 @@ test('deployment scripts enforce locked dependencies without install hooks', () 
   assert.match(terraformDeployment, /npm ci --ignore-scripts/);
   assert.match(terraformDeployment, /terraform init -lockfile=readonly/);
   assert.match(frontendDeployment, /npm ci --ignore-scripts/);
+});
+
+test('Yjs image pins readable ownership and modes for non-root runtime files', () => {
+  const dockerfile = readFileSync(yjsDockerfile, 'utf8');
+
+  assert.match(
+    dockerfile,
+    /COPY --chown=node:node --chmod=0644 package\.json package-lock\.json \.\//,
+  );
+  assert.match(
+    dockerfile,
+    /COPY --chown=node:node --chmod=0644 server\.js realtime-token\.js doc-name\.js \.\//,
+  );
+  assert.ok(
+    dockerfile.indexOf('--chmod=0644 server.js') < dockerfile.indexOf('USER node'),
+    'runtime source permissions must be fixed before dropping privileges',
+  );
 });
 
 test('release check accepts prerelease metadata but final mode requires a date', () => {
@@ -715,9 +734,11 @@ const createReleaseRepository = () => {
   mkdirSync(join(repository, 'scripts'), { recursive: true });
   mkdirSync(join(repository, 'config'), { recursive: true });
   mkdirSync(join(repository, 'frontend'), { recursive: true });
+  mkdirSync(join(repository, 'lambda/yjs-server'), { recursive: true });
   cpSync(join(root, 'scripts/sso-config.mjs'), join(repository, 'scripts/sso-config.mjs'));
   cpSync(join(root, 'config/platform-roles.json'), join(repository, 'config/platform-roles.json'));
   writeJson(join(repository, 'frontend/package.json'), { name: 'frontend', private: true });
+  writeFileSync(join(repository, 'lambda/yjs-server/server.js'), 'console.log("ready");\n');
   writeFileSync(
     join(repository, 'terraform/environments/dev.tfvars.example'),
     [
@@ -811,6 +832,7 @@ test('installer supports fresh install, v1 adoption, v1-to-v2 update, and recove
   assert.equal(fresh.status, 0, fresh.stderr);
   const freshCurrent = readlinkSync(join(freshEnv.XDG_DATA_HOME, 'collaborative-ai-dlc/current'));
   assert.match(freshCurrent, /releases\/v2\.0\.0$/);
+  assert.equal(statSync(join(freshCurrent, 'lambda/yjs-server/server.js')).mode & 0o777, 0o644);
   const configText = readFileSync(
     join(freshEnv.XDG_CONFIG_HOME, 'collaborative-ai-dlc/install.conf'),
     'utf8',
@@ -870,6 +892,7 @@ test('installer tracks an explicitly selected branch by immutable commit', () =>
   const currentLink = join(env.XDG_DATA_HOME, 'collaborative-ai-dlc/current');
   const firstCheckout = readlinkSync(currentLink);
   assert.match(firstCheckout, /checkouts\/[0-9a-f]{40}$/);
+  assert.equal(statSync(join(firstCheckout, 'lambda/yjs-server/server.js')).mode & 0o777, 0o644);
 
   writeFileSync(join(repository, 'branch-update.txt'), 'next\n');
   execFileSync('git', ['add', 'branch-update.txt'], { cwd: repository });


### PR DESCRIPTION
Root cause: the managed installer globally sets umask 077 to protect credentials and generated configuration. Its git clone operations inherited that umask, creating regular source files as 0600.

Docker preserved those permissions when copying `server.js` into the Yjs image as root:root. The container then switched to the unprivileged node user, which could not read `/app/server.js`, causing `EACCES`.

Normal developer checkouts use umask 022, producing 0644 files, which explains why the issue was environment-specific.

This fix:
  - Clones managed release and branch checkouts under umask 022.
  - Explicitly sets Yjs runtime files to node:node and 0644.
  - Adds regression coverage for both checkout paths.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
