### PR TITLE
fix(trackers): hide Bitbucket from tracker settings

### DIFF
--- a/frontend/src/components/admin/tabs/TrackersTab.tsx
+++ b/frontend/src/components/admin/tabs/TrackersTab.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 // Trackers that piggyback on a source-control OAuth app instead of having
 // credentials of their own.
-const GIT_BACKED_TRACKERS = new Set(['github-issues', 'gitlab-issues', 'bitbucket-issues']);
+const GIT_BACKED_TRACKERS = new Set(['github-issues', 'gitlab-issues']);
 
 export function TrackersTab({ providers, providersLoading, onProvidersChanged }: Props) {
   // Skeleton only on the very first load — post-save refreshes keep the cards


### PR DESCRIPTION
Bitbucket issues was still in the admin as an available tracker, despite not implemented (deprecated by Atlassian in August in favor of Jira)

Removing it from admin page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
