### PR TITLE
feat(install): support any Docker-API-socket container runtime (#420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Optional static egress for OAuth connectors, credential resolution, and seed-blocks through `lambda_vpc_scope = "public-egress"`, with NAT public IP outputs and addresses printed in the deployment summary for external allow-lists.
+- Configurable container runtime via `CONTAINER_RUNTIME` / `DOCKER_HOST` — any Docker-API-socket runtime works (Podman, Rancher Desktop verified); Finch unsupported ([#420](https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/420)).
 
 ## [2.0.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Optional static egress for OAuth connectors, credential resolution, and seed-blocks through `lambda_vpc_scope = "public-egress"`, with NAT public IP outputs and addresses printed in the deployment summary for external allow-lists.
-- Configurable container runtime via `CONTAINER_RUNTIME` / `DOCKER_HOST` — any Docker-API-socket runtime works (Podman, Rancher Desktop verified); Finch unsupported ([#420](https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/420)).
+- Configurable container runtime via `DOCKER_HOST` — any Docker-API-socket runtime works without requiring a container CLI (Podman, Rancher Desktop verified); Finch unsupported ([#420](https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/420)).
 
 ## [2.0.0] - 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ Full documentation lives at [aws-samples.github.io/sample-collaborative-ai-dlc](
 | AWS CLI   | v2            |
 | Docker    | Recent stable |
 
+### Using an alternative container runtime
+
+Docker is the default container runtime and needs no configuration. The image build connects to a Docker Engine API socket via `DOCKER_HOST`, so **any runtime that exposes such a socket works** — Podman and Rancher Desktop are validated end-to-end, and Colima and OrbStack use the same mechanism. Finch and other CLI-only/daemonless build tools (Buildah, nerdctl, Kaniko, BuildKit) do not expose a Docker-API socket and are not supported for the builds.
+
+See [Using an alternative container runtime](https://aws-samples.github.io/sample-collaborative-ai-dlc/getting-started/prerequisites/#using-an-alternative-container-runtime) for the socket paths, per-runtime setup, and the `CONTAINER_RUNTIME` / `DOCKER_HOST` contract.
+
 You need an AWS account with permissions to manage VPC, ECS, ECR, Lambda, API Gateway, DynamoDB, Neptune, S3, CloudFront, Cognito, Bedrock AgentCore, Secrets Manager, Systems Manager Parameter Store, and IAM. See [Prerequisites](https://aws-samples.github.io/sample-collaborative-ai-dlc/getting-started/prerequisites/) for the full service list and verification commands.
 
 Agent CLIs authenticate through credentials you configure after install, in **Admin → Agents**:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Full documentation lives at [aws-samples.github.io/sample-collaborative-ai-dlc](
 
 Docker is the default container runtime and needs no configuration. The image build connects to a Docker Engine API socket via `DOCKER_HOST`, so **any runtime that exposes such a socket works** — Podman and Rancher Desktop are validated end-to-end, and Colima and OrbStack use the same mechanism. Finch and other CLI-only/daemonless build tools (Buildah, nerdctl, Kaniko, BuildKit) do not expose a Docker-API socket and are not supported for the builds.
 
-See [Using an alternative container runtime](https://aws-samples.github.io/sample-collaborative-ai-dlc/getting-started/prerequisites/#using-an-alternative-container-runtime) for the socket paths, per-runtime setup, and the `CONTAINER_RUNTIME` / `DOCKER_HOST` contract.
+See [Using an alternative container runtime](https://aws-samples.github.io/sample-collaborative-ai-dlc/getting-started/prerequisites/#using-an-alternative-container-runtime) for the socket paths, per-runtime setup, and the `DOCKER_HOST` contract.
 
 You need an AWS account with permissions to manage VPC, ECS, ECR, Lambda, API Gateway, DynamoDB, Neptune, S3, CloudFront, Cognito, Bedrock AgentCore, Secrets Manager, Systems Manager Parameter Store, and IAM. See [Prerequisites](https://aws-samples.github.io/sample-collaborative-ai-dlc/getting-started/prerequisites/) for the full service list and verification commands.
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -24,10 +24,10 @@ git --version    # Expected output: 2.x
 
 To deploy AIDLC Collaborative to AWS, install the following additional tools. For detailed deployment instructions, see [Setup](setup.md).
 
-| Tool                                                                                                                  | Version        | Purpose                                                                            |
-| --------------------------------------------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------- |
-| [Terraform](https://developer.hashicorp.com/terraform/install)                                                        | 1.4 or later   | Infrastructure provisioning                                                        |
-| [AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) | v2             | AWS resource management and credential handling                                    |
+| Tool                                                                                                                  | Version        | Purpose                                                                               |
+| --------------------------------------------------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------- |
+| [Terraform](https://developer.hashicorp.com/terraform/install)                                                        | 1.4 or later   | Infrastructure provisioning                                                           |
+| [AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) | v2             | AWS resource management and credential handling                                       |
 | [Docker](https://docs.docker.com/get-docker/) (default)                                                               | 20.10 or later | Lambda packaging and container builds; alternatives use the override documented below |
 
 Run the following commands to confirm the default Docker-based deployment tools are installed. If you use an alternative container runtime, follow the section below instead of the Docker verification command.
@@ -47,13 +47,13 @@ Docker is the default container runtime; no configuration is needed when the `do
 
 Because the image build talks to the Docker Engine API socket (rather than shelling out to a CLI), **any runtime that exposes such a socket works**. Point `DOCKER_HOST` at the runtime's socket and the build behaves exactly as it does with Docker.
 
-| Runtime | Docker API socket | Status |
-| --- | --- | --- |
-| Docker (default) | standard `/var/run/docker.sock` | Supported |
-| Podman | derived at runtime (see below) | Verified end-to-end |
-| Rancher Desktop (dockerd/moby mode) | `~/.rd/docker.sock` | Verified end-to-end |
-| Colima | `~/.colima/default/docker.sock` | Compatible (same mechanism) |
-| OrbStack | `~/.orbstack/run/docker.sock` | Compatible (same mechanism) |
+| Runtime                             | Docker API socket               | Status                      |
+| ----------------------------------- | ------------------------------- | --------------------------- |
+| Docker (default)                    | standard `/var/run/docker.sock` | Supported                   |
+| Podman                              | derived at runtime (see below)  | Verified end-to-end         |
+| Rancher Desktop (dockerd/moby mode) | `~/.rd/docker.sock`             | Verified end-to-end         |
+| Colima                              | `~/.colima/default/docker.sock` | Compatible (same mechanism) |
+| OrbStack                            | `~/.orbstack/run/docker.sock`   | Compatible (same mechanism) |
 
 Podman example:
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -24,19 +24,60 @@ git --version    # Expected output: 2.x
 
 To deploy AIDLC Collaborative to AWS, install the following additional tools. For detailed deployment instructions, see [Setup](setup.md).
 
-| Tool                                                                                                                  | Version        | Purpose                                         |
-| --------------------------------------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------- |
-| [Terraform](https://developer.hashicorp.com/terraform/install)                                                        | 1.4 or later   | Infrastructure provisioning                     |
-| [AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) | v2             | AWS resource management and credential handling |
-| [Docker](https://docs.docker.com/get-docker/)                                                                         | 20.10 or later | Lambda packaging and container builds           |
+| Tool                                                                                                                  | Version        | Purpose                                                                            |
+| --------------------------------------------------------------------------------------------------------------------- | -------------- | ---------------------------------------------------------------------------------- |
+| [Terraform](https://developer.hashicorp.com/terraform/install)                                                        | 1.4 or later   | Infrastructure provisioning                                                        |
+| [AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) | v2             | AWS resource management and credential handling                                    |
+| [Docker](https://docs.docker.com/get-docker/) (default)                                                               | 20.10 or later | Lambda packaging and container builds; alternatives use the override documented below |
 
-Run the following commands to confirm your deployment tools are installed.
+Run the following commands to confirm the default Docker-based deployment tools are installed. If you use an alternative container runtime, follow the section below instead of the Docker verification command.
 
 ```bash
 terraform --version  # Expected output: v1.4 or later
 aws --version        # Expected output: aws-cli/2.x
 docker --version     # Expected output: Docker version 20.10 or later
 ```
+
+### Using an alternative container runtime
+
+Docker is the default container runtime; no configuration is needed when the `docker` CLI and standard Docker socket are available. Two independent settings control the runtime:
+
+- `CONTAINER_RUNTIME` (default: `docker`) — the CLI name the installer's prerequisite check looks for.
+- `DOCKER_HOST` — the Docker Engine API socket that Terraform's `kreuzwerker/docker` provider connects to when it builds and pushes the container images.
+
+Because the image build talks to the Docker Engine API socket (rather than shelling out to a CLI), **any runtime that exposes such a socket works**. Point `DOCKER_HOST` at the runtime's socket and the build behaves exactly as it does with Docker.
+
+| Runtime | Docker API socket | Status |
+| --- | --- | --- |
+| Docker (default) | standard `/var/run/docker.sock` | Supported |
+| Podman | derived at runtime (see below) | Verified end-to-end |
+| Rancher Desktop (dockerd/moby mode) | `~/.rd/docker.sock` | Verified end-to-end |
+| Colima | `~/.colima/default/docker.sock` | Compatible (same mechanism) |
+| OrbStack | `~/.orbstack/run/docker.sock` | Compatible (same mechanism) |
+
+Podman example:
+
+```bash
+# macOS
+podman machine start
+export CONTAINER_RUNTIME=podman
+export DOCKER_HOST="unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')"
+
+# Rootless Linux (after starting `podman system service`)
+export CONTAINER_RUNTIME=podman
+export DOCKER_HOST="unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')"
+```
+
+Rancher Desktop example (set the container engine to **dockerd (moby)** in Rancher Desktop settings):
+
+```bash
+export CONTAINER_RUNTIME=docker      # Rancher provides a docker-compatible CLI
+export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
+```
+
+!!! warning "Finch and CLI-only build tools are not supported"
+
+    Setting `CONTAINER_RUNTIME=finch` only makes the installer's prerequisite check look for the `finch` CLI. Finch does not expose a Docker Engine API socket by default, so there is no socket for `DOCKER_HOST` to use and the Terraform image build cannot run. The same applies to daemonless/CLI-only build tools such as Buildah, nerdctl, Kaniko, and BuildKit. Use Docker, Podman, or another socket-based runtime from the table above.
 
 You must also have an AWS account with permissions to manage the following services.
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -40,10 +40,7 @@ docker --version     # Expected output: Docker version 20.10 or later
 
 ### Using an alternative container runtime
 
-Docker is the default container runtime; no configuration is needed when the `docker` CLI and standard Docker socket are available. Two independent settings control the runtime:
-
-- `CONTAINER_RUNTIME` (default: `docker`) — the CLI name the installer's prerequisite check looks for.
-- `DOCKER_HOST` — the Docker Engine API socket that Terraform's `kreuzwerker/docker` provider connects to when it builds and pushes the container images.
+Docker is the default container runtime; no configuration is needed when its standard socket is available. `DOCKER_HOST` selects the Docker Engine API socket that Terraform's `kreuzwerker/docker` provider connects to when it builds and pushes the container images. The installer does not invoke or require a container-runtime CLI.
 
 Because the image build talks to the Docker Engine API socket (rather than shelling out to a CLI), **any runtime that exposes such a socket works**. Point `DOCKER_HOST` at the runtime's socket and the build behaves exactly as it does with Docker.
 
@@ -60,24 +57,21 @@ Podman example:
 ```bash
 # macOS
 podman machine start
-export CONTAINER_RUNTIME=podman
 export DOCKER_HOST="unix://$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')"
 
 # Rootless Linux (after starting `podman system service`)
-export CONTAINER_RUNTIME=podman
 export DOCKER_HOST="unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')"
 ```
 
 Rancher Desktop example (set the container engine to **dockerd (moby)** in Rancher Desktop settings):
 
 ```bash
-export CONTAINER_RUNTIME=docker      # Rancher provides a docker-compatible CLI
 export DOCKER_HOST="unix://$HOME/.rd/docker.sock"
 ```
 
 !!! warning "Finch and CLI-only build tools are not supported"
 
-    Setting `CONTAINER_RUNTIME=finch` only makes the installer's prerequisite check look for the `finch` CLI. Finch does not expose a Docker Engine API socket by default, so there is no socket for `DOCKER_HOST` to use and the Terraform image build cannot run. The same applies to daemonless/CLI-only build tools such as Buildah, nerdctl, Kaniko, and BuildKit. Use Docker, Podman, or another socket-based runtime from the table above.
+    Finch does not expose a Docker Engine API socket by default, so there is no socket for `DOCKER_HOST` to use and the Terraform image build cannot run. The same applies to daemonless/CLI-only build tools such as Buildah, nerdctl, Kaniko, and BuildKit. Use Docker, Podman, or another socket-based runtime from the table above.
 
 You must also have an AWS account with permissions to manage the following services.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,6 +50,8 @@ PERSISTED_AUTH_MODE="local"
 SOURCE=""
 ASSUME_YES="${AIDLC_YES:-0}"
 ALLOW_DOWNGRADE="${AIDLC_ALLOW_DOWNGRADE:-0}"
+# Binary checked by require_commands; image builds select their daemon with DOCKER_HOST.
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
 usage() {
     cat <<'EOF'
@@ -586,7 +588,7 @@ require_terraform_version() {
 
 require_commands() {
     local missing=0 command
-    local commands="git node npm terraform aws docker"
+    local commands="git node npm terraform aws $CONTAINER_RUNTIME"
     [[ "${AIDLC_TEST_MODE:-0}" == 1 ]] && commands="git node"
     for command in $commands; do
         if ! command -v "$command" >/dev/null 2>&1; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -50,8 +50,6 @@ PERSISTED_AUTH_MODE="local"
 SOURCE=""
 ASSUME_YES="${AIDLC_YES:-0}"
 ALLOW_DOWNGRADE="${AIDLC_ALLOW_DOWNGRADE:-0}"
-# Binary checked by require_commands; image builds select their daemon with DOCKER_HOST.
-CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
 
 usage() {
     cat <<'EOF'
@@ -588,7 +586,7 @@ require_terraform_version() {
 
 require_commands() {
     local missing=0 command
-    local commands="git node npm terraform aws $CONTAINER_RUNTIME"
+    local commands="git node npm terraform aws"
     [[ "${AIDLC_TEST_MODE:-0}" == 1 ]] && commands="git node"
     for command in $commands; do
         if ! command -v "$command" >/dev/null 2>&1; then

--- a/scripts/test/release-tools.test.mjs
+++ b/scripts/test/release-tools.test.mjs
@@ -10,10 +10,11 @@ import {
   readlinkSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { delimiter, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
@@ -962,7 +963,6 @@ exit 0
     { mode: 0o755 },
   );
   writeFileSync(join(bin, 'npm'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
-  writeFileSync(join(bin, 'docker'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
   return {
     ...env,
     PATH: `${bin}:${process.env.PATH}`,
@@ -970,6 +970,46 @@ exit 0
     AIDLC_TEST_MODE: '',
   };
 };
+
+const isolatedInstallerPath = (env) => {
+  const bin = env.PATH.split(delimiter)[0];
+  const commands = {
+    bash: '/bin/bash',
+    dirname: '/usr/bin/dirname',
+    git: '/usr/bin/git',
+    node: process.execPath,
+  };
+  for (const [command, source] of Object.entries(commands)) {
+    const destination = join(bin, command);
+    if (existsSync(destination)) continue;
+    symlinkSync(source, destination);
+  }
+  return bin;
+};
+
+test('installer accepts a non-default DOCKER_HOST without a container CLI on PATH', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'aidlc-container-socket-'));
+  const env = mockedCommandEnv(dir, join(dir, 'unused-repository'));
+  const path = isolatedInstallerPath(env);
+  const runtimeEnv = {
+    ...env,
+    PATH: path,
+    DOCKER_HOST: 'unix:///tmp/podman.sock',
+  };
+  const dataRoot = join(env.XDG_DATA_HOME, 'collaborative-ai-dlc');
+  mkdirSync(dataRoot, { recursive: true });
+  symlinkSync(dir, join(dataRoot, 'current'));
+
+  const dockerLookup = run('bash', ['-c', 'command -v docker'], { env: runtimeEnv });
+  assert.notEqual(dockerLookup.status, 0, 'docker must not be available in the controlled PATH');
+
+  const installed = run('bash', [installer, 'install', '--version', '2.0.0'], {
+    env: runtimeEnv,
+  });
+  assert.equal(installed.status, 1);
+  assert.match(installed.stderr, /A managed installation already exists/);
+  assert.doesNotMatch(installed.stderr, /Missing required command: docker/);
+});
 
 test('installer rejects Terraform older than 1.4 during preflight', () => {
   const repository = createReleaseRepository();

--- a/terraform/modules/compute/agentcore/main.tf
+++ b/terraform/modules/compute/agentcore/main.tf
@@ -29,6 +29,8 @@ terraform {
 }
 
 provider "docker" {
+  # Support for Podman via DOCKER_HOST environment variable (e.g., unix:///path/to/podman.sock)
+  # If DOCKER_HOST is not set, defaults to the standard Docker socket
   registry_auth {
     address  = format("%v.dkr.ecr.%v.%v", data.aws_caller_identity.current.account_id, data.aws_region.current.region, data.aws_partition.current.dns_suffix)
     username = data.aws_ecr_authorization_token.token.user_name

--- a/terraform/modules/compute/agents/main.tf
+++ b/terraform/modules/compute/agents/main.tf
@@ -13,6 +13,8 @@ data "aws_partition" "current" {}
 data "aws_ecr_authorization_token" "token" {}
 
 provider "docker" {
+  # Support for Podman via DOCKER_HOST environment variable (e.g., unix:///path/to/podman.sock)
+  # If DOCKER_HOST is not set, defaults to the standard Docker socket
   # Compatibility shim for destroying orphaned v1 agent image-build state.
   registry_auth {
     address  = format("%v.dkr.ecr.%v.%v", data.aws_caller_identity.current.account_id, data.aws_region.current.region, data.aws_partition.current.dns_suffix)


### PR DESCRIPTION
*Issue #, if available:* fixes #420

Docker is hardcoded as the only container runtime for installation. Make it configurable so users on Podman, Rancher Desktop, and other socket-based runtimes can install without Docker.

- scripts/install.sh: prerequisite check honors CONTAINER_RUNTIME (default docker) instead of hardcoding "docker"
- terraform: document the DOCKER_HOST socket override on all three kreuzwerker/docker provider blocks (now consistent)
- docs: README summary + prerequisites section explaining the CONTAINER_RUNTIME / DOCKER_HOST contract; list verified runtimes (Docker, Podman, Rancher Desktop) and compatible ones (Colima, OrbStack); Finch and CLI-only build tools are unsupported (no Docker-API socket)

The image build talks to the Docker Engine API socket via DOCKER_HOST, so any runtime exposing such a socket works with no code change. Verified end-to-end (build → ECR push → AgentCore runtime) with Podman and Rancher Desktop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
