### PR TITLE
fix(agentcore): trust restored lane checkouts

### DIFF
--- a/lambda/agentcore/commands/lane.js
+++ b/lambda/agentcore/commands/lane.js
@@ -29,6 +29,7 @@ import {
 import {
   checkoutRepo as defaultCheckoutRepo,
   ensureWorkspaceSource as defaultEnsureWorkspaceSource,
+  trustGitDirectory as defaultTrustGitDirectory,
 } from '../workspace.js';
 import { stat } from 'node:fs/promises';
 import { repoUrl, repoProvider } from '../../shared/repo-provider.js';
@@ -66,6 +67,7 @@ export const initLane = async (
     broadcast = async () => {},
     checkoutRepo = defaultCheckoutRepo,
     ensureLaneBranch = defaultEnsureLaneBranch,
+    trustDirectory = defaultTrustGitDirectory,
     statFn = stat,
     urlsFor = null, // test seam for file:// remotes
   } = deps;
@@ -92,11 +94,11 @@ export const initLane = async (
     const url = repoUrl(repo);
     const provider = repoProvider(repo, gitProvider, repoProviders);
     const dir = repoTargetDir({ url, workspaceDir, multi });
+    const checkoutExists = await hasCheckout(dir, statFn);
     // Fresh lane mount → clone first. Checkout the INTENT branch (it exists on
     // the remote — the pre-section stages pushed it); the unit branch is
-    // created from it below. A repo that already has a checkout (re-init in a
-    // live session) skips the clone — ensureLaneBranch fetches what it needs.
-    if (!(await hasCheckout(dir, statFn))) {
+    // created from it below.
+    if (!checkoutExists) {
       const cloned = await checkoutRepo({
         repo: url,
         branch: intentBranch,
@@ -113,6 +115,14 @@ export const initLane = async (
           detail: `${url}: ${cloned?.error ?? 'clone failed (repository or project binding unavailable)'}`,
         };
       }
+    } else if (!(await trustDirectory({ targetDir: dir }))) {
+      // A continued lane can restore a checkout owned by the previous runtime
+      // user. Re-establish trust before ensureLaneBranch's first `git fetch`.
+      return {
+        ok: false,
+        reason: 'safe_directory_config_failed',
+        detail: `${url}: could not trust restored checkout ${dir}`,
+      };
     }
     const lane = await ensureLaneBranch({
       dir,

--- a/lambda/agentcore/test/lane.test.js
+++ b/lambda/agentcore/test/lane.test.js
@@ -130,6 +130,50 @@ describe('init-lane', () => {
     expect(await readFile(path.join(ws, 'auth.txt'), 'utf8')).toBe('lane work\n');
   });
 
+  it('trusts a restored checkout before fetching when continuing a lane', async () => {
+    const ws = path.join(root, 'restored-lane-ws');
+    const calls = [];
+    const res = await initLane(basePayload(ws), {
+      store: spyStore(),
+      statFn: async (candidate) => {
+        expect(candidate).toBe(path.join(ws, '.git'));
+        return {};
+      },
+      checkoutRepo: async () => {
+        throw new Error('existing checkout must not be cloned');
+      },
+      trustDirectory: async ({ targetDir }) => {
+        calls.push(`trust:${targetDir}`);
+        return true;
+      },
+      ensureLaneBranch: async ({ dir }) => {
+        calls.push(`fetch:${dir}`);
+        return { ready: true, created: false, sha: 'abc123' };
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual([`trust:${ws}`, `fetch:${ws}`]);
+  });
+
+  it('fails before fetching when a restored checkout cannot be trusted', async () => {
+    const ws = path.join(root, 'restored-lane-ws');
+    const ensureLaneBranch = vi.fn();
+    const res = await initLane(basePayload(ws), {
+      store: spyStore(),
+      statFn: async () => ({}),
+      trustDirectory: async () => false,
+      ensureLaneBranch,
+    });
+
+    expect(res).toMatchObject({
+      ok: false,
+      reason: 'safe_directory_config_failed',
+      detail: `o/r: could not trust restored checkout ${ws}`,
+    });
+    expect(ensureLaneBranch).not.toHaveBeenCalled();
+  });
+
   it('a repo-less project is a successful no-op', async () => {
     const res = await initLane(basePayload('/nope', { repos: [] }), { store: spyStore() });
     expect(res).toMatchObject({ ok: true, unitSlug: 'auth', repos: [] });


### PR DESCRIPTION
## Summary

  - Trust restored lane checkouts before `ensureLaneBranch` runs `git fetch`.
  - Return `safe_directory_config_failed` if Git trust cannot be configured.
  - Add regression tests for continued AgentCore lane sessions.

## Root cause

  - Defect introduced in #421  
 - Fresh clones configure Git's `safe.directory` through `checkoutRepo`. Continued lanes detect the existing `.git` directory and skip that path. When AgentCore restores a workspace owned by a previous runtime user, the subsequent fetch fails with “detected dubious ownership”.

## Validation

  - 55 tests passed
  - Formatting, lint, and secret scanning passed
  - Tested on deployed instance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
