### PR TITLE
Fix(433): intent header UI/UX

### DIFF
--- a/frontend/src/components/intent/IntentConfigurationDialog.tsx
+++ b/frontend/src/components/intent/IntentConfigurationDialog.tsx
@@ -1,8 +1,16 @@
-import { Boxes, ExternalLink } from 'lucide-react';
+import {
+  Boxes,
+  Check,
+  ExternalLink,
+  GitBranch,
+  LoaderCircle,
+  Workflow,
+  XCircle,
+} from 'lucide-react';
 import { useIntent } from '@/contexts/IntentContext';
 import { AGENT_CLI_METADATA, AGENT_CREDENTIAL_SOURCE_LABELS } from '@/lib/agentCli';
 import { getIntentStageSelection } from '@/lib/intentStageSelection';
-import { formatTrackerSourceLabel } from '@/lib/trackerSourceLabel';
+import { getTrackerProvider } from '@/lib/trackerProviders';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -15,10 +23,27 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
+import type { IntentSource } from '@/services/intents';
 
 interface IntentConfigurationDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onOpenReshape?: () => void;
+}
+
+function trackerProviderId(provider: string) {
+  if (provider === 'github') return 'github-issues';
+  if (provider === 'gitlab') return 'gitlab-issues';
+  if (provider === 'bitbucket') return 'bitbucket-issues';
+  return provider;
+}
+
+function formatSourceReference(source: IntentSource) {
+  const resourceType = (source.resourceType || 'issue').toLowerCase();
+  const resourceId = source.resourceId.startsWith('#')
+    ? source.resourceId
+    : `#${source.resourceId}`;
+  return `${resourceType} ${resourceId}`;
 }
 
 function Definition({
@@ -51,7 +76,11 @@ function Definition({
   );
 }
 
-export function IntentConfigurationDialog({ open, onOpenChange }: IntentConfigurationDialogProps) {
+export function IntentConfigurationDialog({
+  open,
+  onOpenChange,
+  onOpenReshape,
+}: IntentConfigurationDialogProps) {
   const { detail, compiled, initializationPhasePaths } = useIntent();
   if (!detail) return null;
 
@@ -66,6 +95,13 @@ export function IntentConfigurationDialog({ open, onOpenChange }: IntentConfigur
       : 'UNKNOWN';
   const intentModel =
     intent.agentCli && intent.cliModels ? intent.cliModels[intent.agentCli] : undefined;
+  const sourceProvider = intent.source
+    ? getTrackerProvider(trackerProviderId(intent.source.provider))
+    : null;
+  const waiting = intent.status === 'WAITING';
+  const running = intent.status === 'RUNNING' || intent.status === 'CREATED';
+  const succeeded = intent.status === 'SUCCEEDED';
+  const failed = intent.status === 'FAILED';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -76,57 +112,16 @@ export function IntentConfigurationDialog({ open, onOpenChange }: IntentConfigur
         </DialogHeader>
 
         <div className="divide-y">
-          <section className="space-y-4 px-6 py-5">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h3 className="text-sm font-semibold">Execution</h3>
-              </div>
-              <Badge variant="outline" className="shrink-0 text-[10px]">
-                {intent.status}
-              </Badge>
-            </div>
-            <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2">
-              <Definition label="Scope" value={intent.scope ?? 'Default'} />
-              <Definition
-                label="Selected steps"
-                value={
-                  selection
-                    ? `${selection.selected.length} of ${selection.available.length}`
-                    : 'Unavailable'
-                }
-              />
-              <Definition
-                label="Agent"
-                value={intent.agentCli ? AGENT_CLI_METADATA[intent.agentCli].label : 'Default'}
-                secondaryValue={intentModel ?? 'CLI default'}
-              />
-              <Definition
-                label="Credentials"
-                value={
-                  intent.credentialSource
-                    ? `${AGENT_CREDENTIAL_SOURCE_LABELS[intent.credentialSource]} key`
-                    : 'Default'
-                }
-              />
-            </dl>
-          </section>
-
           {intent.source && (
-            <section className="space-y-4 px-6 py-5">
-              <div>
-                <h3 className="text-sm font-semibold">Source</h3>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  The tracker item that created the intent.
-                </p>
-              </div>
-              <div className="flex items-center gap-3 rounded-md border bg-muted/20 p-3">
-                <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-background text-sm font-semibold">
-                  #
-                </span>
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm font-semibold">{formatTrackerSourceLabel(intent.source)}</p>
-                  <p className="truncate text-xs text-muted-foreground">
-                    {intent.title || intent.source.provider}
+            <section className="px-6 py-4" aria-label="Source">
+              <div className="flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="flex items-center gap-2 text-sm font-semibold">
+                    {sourceProvider?.icon({ className: 'h-4 w-4 shrink-0' })}
+                    <span>Source: {formatSourceReference(intent.source)}</span>
+                  </p>
+                  <p className="mt-1 truncate text-xs text-muted-foreground">
+                    {intent.title || sourceProvider?.displayName || intent.source.provider}
                   </p>
                 </div>
                 {intent.source.resourceUrl && (
@@ -145,6 +140,75 @@ export function IntentConfigurationDialog({ open, onOpenChange }: IntentConfigur
             <div className="flex items-start justify-between gap-4">
               <div>
                 <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+                  <Workflow className="h-4 w-4" />
+                  Execution
+                </h3>
+              </div>
+              <Badge
+                variant="outline"
+                className={cn(
+                  'shrink-0 gap-1.5 text-[10px]',
+                  waiting && 'border-agent-waiting/30 bg-agent-waiting/10 text-agent-waiting',
+                  running && 'border-agent-running/30 bg-agent-running/10 text-agent-running',
+                  succeeded && 'border-agent-success/30 bg-agent-success/10 text-agent-success',
+                  failed && 'border-destructive/30 bg-destructive/10 text-destructive',
+                )}
+              >
+                {(waiting || running) && <LoaderCircle className="h-3 w-3 animate-spin" />}
+                {succeeded && <Check className="h-3 w-3" />}
+                {failed && <XCircle className="h-3 w-3" />}
+                {intent.status}
+              </Badge>
+            </div>
+            <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2">
+              <Definition label="Scope" value={intent.scope ?? 'Default'} />
+              <div className="min-w-0 space-y-1">
+                <dt className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Selected stages
+                </dt>
+                <dd className="flex items-center gap-2">
+                  <span className="text-sm font-medium">
+                    {selection
+                      ? `${selection.selected.length} of ${selection.available.length}`
+                      : 'Unavailable'}
+                  </span>
+                  {onOpenReshape && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7 gap-1.5 px-2.5 text-xs"
+                      onClick={() => {
+                        onOpenChange(false);
+                        onOpenReshape();
+                      }}
+                    >
+                      <GitBranch className="h-3.5 w-3.5" />
+                      Reshape
+                    </Button>
+                  )}
+                </dd>
+              </div>
+              <Definition
+                label="Agent"
+                value={intent.agentCli ? AGENT_CLI_METADATA[intent.agentCli].label : 'Default'}
+                secondaryValue={intentModel ?? 'CLI default'}
+              />
+              <Definition
+                label="Credentials"
+                value={
+                  intent.credentialSource
+                    ? `${AGENT_CREDENTIAL_SOURCE_LABELS[intent.credentialSource]} key`
+                    : 'Default'
+                }
+              />
+            </dl>
+          </section>
+
+          <section className="space-y-4 px-6 py-5">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="flex items-center gap-1.5 text-sm font-semibold">
                   <Boxes className="h-4 w-4" />
                   Environment
                 </h3>
@@ -153,11 +217,12 @@ export function IntentConfigurationDialog({ open, onOpenChange }: IntentConfigur
                 <Badge
                   variant="outline"
                   className={cn(
-                    'shrink-0 font-mono text-[10px]',
+                    'shrink-0 gap-1.5 font-mono text-[10px]',
                     verification === 'PASSED' &&
                       'border-agent-success/30 bg-agent-success/10 text-agent-success',
                   )}
                 >
+                  {verification === 'PASSED' && <Check className="h-3 w-3" />}
                   {verification}
                 </Badge>
               )}
@@ -180,7 +245,6 @@ export function IntentConfigurationDialog({ open, onOpenChange }: IntentConfigur
                 />
                 <Definition label="Runtime" value={environment.runtimeVersion ?? 'Legacy'} code />
                 <Definition label="Compatibility" value={environment.compatibilityVersion} code />
-                <Definition label="Verification" value={verification} code />
               </dl>
             ) : (
               <p className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">

--- a/frontend/src/components/intent/IntentConfigurationDialog.tsx
+++ b/frontend/src/components/intent/IntentConfigurationDialog.tsx
@@ -1,0 +1,201 @@
+import { Boxes, ExternalLink } from 'lucide-react';
+import { useIntent } from '@/contexts/IntentContext';
+import { AGENT_CLI_METADATA, AGENT_CREDENTIAL_SOURCE_LABELS } from '@/lib/agentCli';
+import { getIntentStageSelection } from '@/lib/intentStageSelection';
+import { formatTrackerSourceLabel } from '@/lib/trackerSourceLabel';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+interface IntentConfigurationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function Definition({
+  label,
+  value,
+  code = false,
+  wide = false,
+  secondaryValue,
+}: {
+  label: string;
+  value: string;
+  code?: boolean;
+  wide?: boolean;
+  secondaryValue?: string;
+}) {
+  return (
+    <div className={cn('min-w-0 space-y-1', wide && 'sm:col-span-2')}>
+      <dt className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className={cn('break-words text-sm font-medium', code && 'break-all font-mono text-xs')}>
+        <span className="block">{value}</span>
+        {secondaryValue && (
+          <span className="mt-1 block break-all font-mono text-xs font-normal text-muted-foreground">
+            {secondaryValue}
+          </span>
+        )}
+      </dd>
+    </div>
+  );
+}
+
+export function IntentConfigurationDialog({ open, onOpenChange }: IntentConfigurationDialogProps) {
+  const { detail, compiled, initializationPhasePaths } = useIntent();
+  if (!detail) return null;
+
+  const intent = detail.intent;
+  const environment = intent.environment;
+  const selection = compiled
+    ? getIntentStageSelection(intent, compiled, initializationPhasePaths)
+    : null;
+  const verification =
+    typeof environment?.verification?.status === 'string'
+      ? environment.verification.status
+      : 'UNKNOWN';
+  const intentModel =
+    intent.agentCli && intent.cliModels ? intent.cliModels[intent.agentCli] : undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] gap-0 overflow-y-auto p-0 sm:max-w-2xl">
+        <DialogHeader className="border-b px-6 py-5">
+          <DialogTitle>Intent configuration</DialogTitle>
+          <DialogDescription>Configuration captured when this intent started.</DialogDescription>
+        </DialogHeader>
+
+        <div className="divide-y">
+          <section className="space-y-4 px-6 py-5">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-sm font-semibold">Execution</h3>
+              </div>
+              <Badge variant="outline" className="shrink-0 text-[10px]">
+                {intent.status}
+              </Badge>
+            </div>
+            <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2">
+              <Definition label="Scope" value={intent.scope ?? 'Default'} />
+              <Definition
+                label="Selected steps"
+                value={
+                  selection
+                    ? `${selection.selected.length} of ${selection.available.length}`
+                    : 'Unavailable'
+                }
+              />
+              <Definition
+                label="Agent"
+                value={intent.agentCli ? AGENT_CLI_METADATA[intent.agentCli].label : 'Default'}
+                secondaryValue={intentModel ?? 'CLI default'}
+              />
+              <Definition
+                label="Credentials"
+                value={
+                  intent.credentialSource
+                    ? `${AGENT_CREDENTIAL_SOURCE_LABELS[intent.credentialSource]} key`
+                    : 'Default'
+                }
+              />
+            </dl>
+          </section>
+
+          {intent.source && (
+            <section className="space-y-4 px-6 py-5">
+              <div>
+                <h3 className="text-sm font-semibold">Source</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  The tracker item that created the intent.
+                </p>
+              </div>
+              <div className="flex items-center gap-3 rounded-md border bg-muted/20 p-3">
+                <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-background text-sm font-semibold">
+                  #
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-semibold">{formatTrackerSourceLabel(intent.source)}</p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {intent.title || intent.source.provider}
+                  </p>
+                </div>
+                {intent.source.resourceUrl && (
+                  <Button variant="outline" size="sm" className="shrink-0 gap-1.5" asChild>
+                    <a href={intent.source.resourceUrl} target="_blank" rel="noopener noreferrer">
+                      Open
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </a>
+                  </Button>
+                )}
+              </div>
+            </section>
+          )}
+
+          <section className="space-y-4 px-6 py-5">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="flex items-center gap-1.5 text-sm font-semibold">
+                  <Boxes className="h-4 w-4" />
+                  Environment
+                </h3>
+              </div>
+              {environment && (
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    'shrink-0 font-mono text-[10px]',
+                    verification === 'PASSED' &&
+                      'border-agent-success/30 bg-agent-success/10 text-agent-success',
+                  )}
+                >
+                  {verification}
+                </Badge>
+              )}
+            </div>
+
+            {environment ? (
+              <dl className="grid gap-x-6 gap-y-4 sm:grid-cols-2">
+                <Definition label="Name" value={environment.name} />
+                <Definition label="Revision" value={environment.revisionId} code />
+                <Definition
+                  label="Image"
+                  value={environment.imageDigest ?? 'Unavailable'}
+                  code
+                  wide
+                />
+                <Definition
+                  label="Endpoint"
+                  value={environment.runtimeEndpoint ?? 'Default'}
+                  code
+                />
+                <Definition label="Runtime" value={environment.runtimeVersion ?? 'Legacy'} code />
+                <Definition label="Compatibility" value={environment.compatibilityVersion} code />
+                <Definition label="Verification" value={verification} code />
+              </dl>
+            ) : (
+              <p className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
+                No environment snapshot was captured for this run.
+              </p>
+            )}
+          </section>
+        </div>
+
+        <DialogFooter className="border-t px-6 py-4">
+          <DialogClose asChild>
+            <Button variant="outline">Close</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/intent/IntentConfigurationDialog.tsx
+++ b/frontend/src/components/intent/IntentConfigurationDialog.tsx
@@ -1,6 +1,7 @@
 import {
   Boxes,
   Check,
+  CirclePause,
   ExternalLink,
   GitBranch,
   LoaderCircle,
@@ -11,6 +12,7 @@ import { useIntent } from '@/contexts/IntentContext';
 import { AGENT_CLI_METADATA, AGENT_CREDENTIAL_SOURCE_LABELS } from '@/lib/agentCli';
 import { getIntentStageSelection } from '@/lib/intentStageSelection';
 import { getTrackerProvider } from '@/lib/trackerProviders';
+import { formatTrackerSourceLabel } from '@/lib/trackerSourceLabel';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -23,7 +25,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
-import type { IntentSource } from '@/services/intents';
 
 interface IntentConfigurationDialogProps {
   open: boolean;
@@ -36,14 +37,6 @@ function trackerProviderId(provider: string) {
   if (provider === 'gitlab') return 'gitlab-issues';
   if (provider === 'bitbucket') return 'bitbucket-issues';
   return provider;
-}
-
-function formatSourceReference(source: IntentSource) {
-  const resourceType = (source.resourceType || 'issue').toLowerCase();
-  const resourceId = source.resourceId.startsWith('#')
-    ? source.resourceId
-    : `#${source.resourceId}`;
-  return `${resourceType} ${resourceId}`;
 }
 
 function Definition({
@@ -98,6 +91,13 @@ export function IntentConfigurationDialog({
   const sourceProvider = intent.source
     ? getTrackerProvider(trackerProviderId(intent.source.provider))
     : null;
+  const sourceLabel = intent.source
+    ? formatTrackerSourceLabel({
+        provider: intent.source.provider,
+        resourceId: intent.source.resourceId,
+        entityType: intent.source.resourceType,
+      })
+    : null;
   const waiting = intent.status === 'WAITING';
   const running = intent.status === 'RUNNING' || intent.status === 'CREATED';
   const succeeded = intent.status === 'SUCCEEDED';
@@ -118,7 +118,7 @@ export function IntentConfigurationDialog({
                 <div className="min-w-0">
                   <p className="flex items-center gap-2 text-sm font-semibold">
                     {sourceProvider?.icon({ className: 'h-4 w-4 shrink-0' })}
-                    <span>Source: {formatSourceReference(intent.source)}</span>
+                    <span>Source: {sourceLabel}</span>
                   </p>
                   <p className="mt-1 truncate text-xs text-muted-foreground">
                     {intent.title || sourceProvider?.displayName || intent.source.provider}
@@ -154,7 +154,8 @@ export function IntentConfigurationDialog({
                   failed && 'border-destructive/30 bg-destructive/10 text-destructive',
                 )}
               >
-                {(waiting || running) && <LoaderCircle className="h-3 w-3 animate-spin" />}
+                {waiting && <CirclePause className="h-3 w-3" />}
+                {running && <LoaderCircle className="h-3 w-3 animate-spin" />}
                 {succeeded && <Check className="h-3 w-3" />}
                 {failed && <XCircle className="h-3 w-3" />}
                 {intent.status}

--- a/frontend/src/components/intent/RecomposePanel.test.tsx
+++ b/frontend/src/components/intent/RecomposePanel.test.tsx
@@ -46,6 +46,8 @@ const stageRow = (stageId: string, state: string): IntentStage =>
 const renderPanel = (over: Partial<Parameters<typeof RecomposePanel>[0]> = {}) =>
   render(
     <RecomposePanel
+      open
+      onOpenChange={vi.fn()}
       projectId="p1"
       intentId="i1"
       intent={intent()}
@@ -63,15 +65,22 @@ describe('RecomposePanel', () => {
     recompose.mockReset().mockResolvedValue({});
     compiled.mockReset().mockResolvedValue({
       scopeGrid: {
-        feature: { init: 'EXECUTE', analyze: 'EXECUTE', optional: 'EXECUTE', build: 'EXECUTE' },
+        feature: {
+          init: 'EXECUTE',
+          ideation: 'SKIP',
+          analyze: 'EXECUTE',
+          optional: 'EXECUTE',
+          build: 'EXECUTE',
+        },
       },
       autonomy: { perStage: {}, rollup: { selfHalting: 0, mixed: 0, humanGated: 0, total: 0 } },
       graph: {
         nodes: [
           { stageId: 'init', phasePath: '01', order: 0 },
-          { stageId: 'analyze', phasePath: '03', order: 1 },
-          { stageId: 'optional', phasePath: '03', order: 2 },
-          { stageId: 'build', phasePath: '04', order: 3 },
+          { stageId: 'ideation', phasePath: '02', order: 1 },
+          { stageId: 'analyze', phasePath: '03', order: 2 },
+          { stageId: 'optional', phasePath: '03', order: 3 },
+          { stageId: 'build', phasePath: '04', order: 4 },
         ],
         edges: [],
         cycles: [],
@@ -93,6 +102,14 @@ describe('RecomposePanel', () => {
           order: 0,
         },
         {
+          phaseId: 'ideation',
+          name: 'Ideation',
+          kind: 'phase',
+          path: '02',
+          parentPath: null,
+          order: 1,
+        },
+        {
           phaseId: 'inception',
           name: 'Inception',
           kind: 'phase',
@@ -112,18 +129,31 @@ describe('RecomposePanel', () => {
     });
   });
 
-  it('is collapsed by default and fetches the workflow only when opened', async () => {
-    renderPanel();
+  it('fetches the workflow only when the dialog opens', async () => {
+    const onOpenChange = vi.fn();
+    const view = renderPanel({ open: false, onOpenChange });
     expect(compiled).not.toHaveBeenCalled();
-    await userEvent.setup().click(screen.getByTestId('recompose-toggle'));
+    view.rerender(
+      <RecomposePanel
+        open
+        onOpenChange={onOpenChange}
+        projectId="p1"
+        intentId="i1"
+        intent={intent()}
+        stageRows={[stageRow('analyze', 'SUCCEEDED'), stageRow('optional', 'WAITING_FOR_HUMAN')]}
+        workflowVersion={4}
+        onRelaunched={vi.fn()}
+      />,
+    );
     await waitFor(() => expect(compiled).toHaveBeenCalled());
+    expect(screen.getByRole('heading', { name: 'Reshape remaining stages' })).toBeInTheDocument();
     expect(await screen.findByTestId('stage-grid-editor')).toBeInTheDocument();
   });
 
   it('locks frozen (ran) stages and initialization; a manual flip applies via /recompose', async () => {
     const user = userEvent.setup();
-    renderPanel();
-    await user.click(screen.getByTestId('recompose-toggle'));
+    const onOpenChange = vi.fn();
+    renderPanel({ onOpenChange });
     await screen.findByTestId('stage-grid-editor');
     // analyze ran, init is initialization — both locked.
     expect(screen.getByTestId('grid-stage-analyze').querySelector('input')!.disabled).toBe(true);
@@ -142,13 +172,28 @@ describe('RecomposePanel', () => {
         scope: 'feature-recomposed',
       }),
     );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('locks earlier phases while preserving their skipped values', async () => {
+    renderPanel({
+      intent: intent({ currentPhase: 'inception', currentStage: null }),
+      stageRows: [],
+    });
+    await screen.findByTestId('stage-grid-editor');
+
+    const earlierStage = screen.getByTestId('grid-stage-ideation').querySelector('input')!;
+    const currentStage = screen.getByTestId('grid-stage-analyze').querySelector('input')!;
+
+    expect(earlierStage.disabled).toBe(true);
+    expect(earlierStage.checked).toBe(false);
+    expect(currentStage.disabled).toBe(false);
   });
 
   it('asks the composer in inflight mode and applies its proposal', async () => {
     const user = userEvent.setup();
     listComposes.mockResolvedValue({ composes: [] });
     renderPanel();
-    await user.click(screen.getByTestId('recompose-toggle'));
     await user.type(screen.getByTestId('recompose-instructions'), 'trim it');
     await user.click(screen.getByTestId('recompose-ask-composer'));
     await waitFor(() =>

--- a/frontend/src/components/intent/RecomposePanel.test.tsx
+++ b/frontend/src/components/intent/RecomposePanel.test.tsx
@@ -213,7 +213,13 @@ describe('RecomposePanel', () => {
           proposal: {
             mode: 'custom',
             scope: 'trimmed',
-            grid: { init: 'EXECUTE', analyze: 'EXECUTE', optional: 'EXECUTE', build: 'SKIP' },
+            grid: {
+              init: 'EXECUTE',
+              ideation: 'EXECUTE',
+              analyze: 'EXECUTE',
+              optional: 'EXECUTE',
+              build: 'SKIP',
+            },
             rationale: ['tail not needed'],
             confidence: 0.9,
           },
@@ -241,7 +247,13 @@ describe('RecomposePanel', () => {
     await user.click(screen.getByTestId('recompose-apply-proposal'));
     await waitFor(() =>
       expect(recompose).toHaveBeenCalledWith('p1', 'i1', {
-        composedGrid: { init: 'EXECUTE', analyze: 'EXECUTE', optional: 'EXECUTE', build: 'SKIP' },
+        composedGrid: {
+          init: 'EXECUTE',
+          ideation: 'SKIP',
+          analyze: 'EXECUTE',
+          optional: 'EXECUTE',
+          build: 'SKIP',
+        },
         scope: 'trimmed',
       }),
     );

--- a/frontend/src/components/intent/RecomposePanel.tsx
+++ b/frontend/src/components/intent/RecomposePanel.tsx
@@ -180,6 +180,14 @@ export function RecomposePanel({
 
   const effectiveGrid = grid ?? baseline;
 
+  const preserveLockedStages = (candidate: Record<string, 'EXECUTE' | 'SKIP'>) => {
+    const next = { ...candidate };
+    for (const stageId of lockedStageIds) {
+      next[stageId] = baseline[stageId] === 'EXECUTE' ? 'EXECUTE' : 'SKIP';
+    }
+    return next;
+  };
+
   const toggleStage = (stageId: string) => {
     if (lockedStageIds.has(stageId)) return;
     const next = { ...effectiveGrid };
@@ -212,7 +220,7 @@ export function RecomposePanel({
     setError(null);
     try {
       await intentsService.recompose(projectId, intentId, {
-        composedGrid: applyGrid,
+        composedGrid: preserveLockedStages(applyGrid),
         scope: scopeLabel,
       });
       await onRelaunched();

--- a/frontend/src/components/intent/RecomposePanel.tsx
+++ b/frontend/src/components/intent/RecomposePanel.tsx
@@ -235,7 +235,7 @@ export function RecomposePanel({
         <DialogHeader className="border-b px-6 py-5">
           <DialogTitle>Reshape remaining stages</DialogTitle>
           <DialogDescription>
-            Completed and running steps stay locked. Pending steps can be added or removed.
+            Completed and running stages stay locked. Pending stages can be added or removed.
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/src/components/intent/RecomposePanel.tsx
+++ b/frontend/src/components/intent/RecomposePanel.tsx
@@ -16,10 +16,19 @@ import {
 import { workflowsService, type CompiledWorkflow, type PhaseNode } from '@/services/workflows';
 import { StageGridEditor } from '@/components/intent/StageGridEditor';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { AlertCircle, ChevronDown, ChevronRight, Loader2, Sparkles } from 'lucide-react';
+import { AlertCircle, Loader2, Sparkles } from 'lucide-react';
 
 interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   projectId: string;
   intentId: string;
   intent: Intent;
@@ -33,6 +42,8 @@ const POLL_MS = 2500;
 const RAN_STATES = new Set(['SUCCEEDED', 'RUNNING', 'WAITING_FOR_HUMAN', 'FAILED']);
 
 export function RecomposePanel({
+  open,
+  onOpenChange,
   projectId,
   intentId,
   intent,
@@ -40,7 +51,6 @@ export function RecomposePanel({
   workflowVersion,
   onRelaunched,
 }: Props) {
-  const [open, setOpen] = useState(false);
   const [compiled, setCompiled] = useState<CompiledWorkflow | null>(null);
   const [phases, setPhases] = useState<PhaseNode[]>([]);
   const [grid, setGrid] = useState<Record<string, 'EXECUTE' | 'SKIP'> | null>(null);
@@ -110,6 +120,37 @@ export function RecomposePanel({
       })),
     [compiled],
   );
+  const orderedNodes = useMemo(
+    () =>
+      (compiled?.graph.nodes ?? []).toSorted(
+        (a, b) =>
+          (a.phasePath ?? '').localeCompare(b.phasePath ?? '') ||
+          a.order - b.order ||
+          a.stageId.localeCompare(b.stageId),
+      ),
+    [compiled],
+  );
+  const progressBoundaryIndex = useMemo(() => {
+    const currentStageIndex = intent.currentStage
+      ? orderedNodes.findIndex((node) => node.stageId === intent.currentStage)
+      : -1;
+    if (currentStageIndex >= 0) return currentStageIndex;
+
+    const currentPhasePath =
+      phases.find(
+        (phase) => phase.phaseId === intent.currentPhase || phase.path === intent.currentPhase,
+      )?.path ?? null;
+    const currentPhaseIndex = currentPhasePath
+      ? orderedNodes.findIndex((node) => node.phasePath === currentPhasePath)
+      : -1;
+    if (currentPhaseIndex >= 0) return currentPhaseIndex;
+
+    let latestRanIndex = -1;
+    orderedNodes.forEach((node, index) => {
+      if (frozen.get(node.stageId) === 'EXECUTE') latestRanIndex = index;
+    });
+    return latestRanIndex;
+  }, [frozen, intent.currentPhase, intent.currentStage, orderedNodes, phases]);
   const lockedStageIds = useMemo(
     () =>
       new Set([
@@ -117,8 +158,9 @@ export function RecomposePanel({
           .filter((n) => initPhasePath != null && n.phasePath === initPhasePath)
           .map((n) => n.stageId),
         ...frozen.keys(),
+        ...orderedNodes.slice(0, Math.max(0, progressBoundaryIndex)).map((n) => n.stageId),
       ]),
-    [compiled, initPhasePath, frozen],
+    [compiled, frozen, initPhasePath, orderedNodes, progressBoundaryIndex],
   );
 
   // Baseline: the intent's composed grid, else the run scope's projection,
@@ -174,6 +216,7 @@ export function RecomposePanel({
         scope: scopeLabel,
       });
       await onRelaunched();
+      onOpenChange(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Recompose failed');
     } finally {
@@ -184,24 +227,22 @@ export function RecomposePanel({
   const dirty = grid != null;
 
   return (
-    <div className="rounded border" data-testid="recompose-panel">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center gap-1.5 px-3 py-2 text-sm font-medium"
-        data-testid="recompose-toggle"
+    <Dialog open={open} onOpenChange={(next) => !applying && onOpenChange(next)}>
+      <DialogContent
+        className="max-h-[85vh] gap-0 overflow-y-auto p-0 sm:max-w-3xl"
+        data-testid="recompose-dialog"
       >
-        {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-        Reshape remaining stages
-        <span className="text-xs text-muted-foreground font-normal">
-          skip or add pending stages — completed work stays frozen
-        </span>
-      </button>
-      {open && (
-        <div className="px-3 pb-3 space-y-3">
+        <DialogHeader className="border-b px-6 py-5">
+          <DialogTitle>Reshape remaining stages</DialogTitle>
+          <DialogDescription>
+            Completed and running steps stay locked. Pending steps can be added or removed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 px-6 py-5">
           {error && (
             <p className="flex items-start gap-1.5 text-xs text-destructive">
-              <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
               {error}
             </p>
           )}
@@ -223,9 +264,9 @@ export function RecomposePanel({
               data-testid="recompose-ask-composer"
             >
               {composing || pending ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
               ) : (
-                <Sparkles className="h-3.5 w-3.5 mr-1.5" />
+                <Sparkles className="mr-1.5 h-3.5 w-3.5" />
               )}
               {pending ? 'Composing…' : 'Ask composer'}
             </Button>
@@ -239,7 +280,7 @@ export function RecomposePanel({
 
           {latestInflight?.state === 'COMPLETED' && latestInflight.proposal?.grid && (
             <div
-              className="rounded-md border bg-muted/30 px-3 py-2.5 space-y-2"
+              className="space-y-2 rounded-md border bg-muted/30 px-3 py-2.5"
               data-testid="recompose-proposal"
             >
               <p className="text-sm font-medium">
@@ -268,7 +309,7 @@ export function RecomposePanel({
                 disabled={applying}
                 data-testid="recompose-apply-proposal"
               >
-                {applying && <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />}
+                {applying && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
                 Apply &amp; relaunch
               </Button>
             </div>
@@ -293,7 +334,7 @@ export function RecomposePanel({
                     disabled={applying}
                     data-testid="recompose-apply-manual"
                   >
-                    {applying && <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />}
+                    {applying && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
                     Apply changes &amp; relaunch
                   </Button>
                   <Button
@@ -315,7 +356,7 @@ export function RecomposePanel({
             <p className="text-xs text-muted-foreground">Loading the workflow grid…</p>
           )}
         </div>
-      )}
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/intent/StageGridEditor.tsx
+++ b/frontend/src/components/intent/StageGridEditor.tsx
@@ -21,7 +21,7 @@ interface Props {
   phaseNames: Record<string, string>;
   /** The effective grid (composed grid, or the selected scope's projection). */
   grid: Record<string, 'EXECUTE' | 'SKIP'>;
-  /** Stage ids locked to EXECUTE (initialization). */
+  /** Stage ids whose current EXECUTE/SKIP value cannot be changed. */
   lockedStageIds: Set<string>;
   disabled?: boolean;
   onToggle: (stageId: string) => void;
@@ -57,7 +57,7 @@ export function StageGridEditor({
           <div className="mt-1 grid gap-1.5 sm:grid-cols-2">
             {phaseStages.map((s) => {
               const locked = lockedStageIds.has(s.stageId);
-              const executed = locked || grid[s.stageId] === 'EXECUTE';
+              const executed = grid[s.stageId] === 'EXECUTE';
               return (
                 <label
                   key={s.stageId}
@@ -77,7 +77,7 @@ export function StageGridEditor({
                     {s.stageId}
                   </span>
                   {locked && (
-                    <span title="Initialization stages always run">
+                    <span title="This stage can no longer be changed">
                       <Lock className="ml-auto h-3 w-3 text-muted-foreground" />
                     </span>
                   )}

--- a/frontend/src/components/layout/AppShell.test.tsx
+++ b/frontend/src/components/layout/AppShell.test.tsx
@@ -76,7 +76,6 @@ vi.mock('@/components/layout/AppHeader', () => ({
   ),
 }));
 vi.mock('@/components/layout/SprintPipelineBar', () => ({ SprintPipelineBar: () => null }));
-vi.mock('@/components/layout/IntentPipelineBar', () => ({ IntentPipelineBar: () => null }));
 vi.mock('@/components/layout/ActivityPanel', () => ({
   ActivityPanel: () => <div data-testid="activity-panel" />,
 }));

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -4,7 +4,6 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { AppSidebar } from '@/components/layout/AppSidebar';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { SprintPipelineBar } from '@/components/layout/SprintPipelineBar';
-import { IntentPipelineBar } from '@/components/layout/IntentPipelineBar';
 // Lazy: the activity panels pull react-markdown (+ transitively heavy deps)
 // that don't belong in the eager main chunk — they only render when a side
 // panel is open on sprint/intent routes.
@@ -24,6 +23,7 @@ import { useProjectSprintsCache } from '@/hooks/useProjectsCache';
 import { useState, useCallback, useMemo, useEffect, useRef, lazy, Suspense } from 'react';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useResizablePanel } from '@/hooks/useResizablePanel';
+import { setLastIntentSection, type IntentSection } from '@/lib/intentSectionPreference';
 
 // ---------------------------------------------------------------------------
 // Route classification: determines whether the activity panel should default
@@ -32,6 +32,12 @@ import { useResizablePanel } from '@/hooks/useResizablePanel';
 // ---------------------------------------------------------------------------
 
 const NON_WORK_SUFFIXES = ['/graph', '/audit', '/compose', '/observability'];
+
+function intentSection(pathname: string): IntentSection {
+  if (pathname.endsWith('/graph')) return 'graph';
+  if (pathname.endsWith('/observability') || pathname.endsWith('/audit')) return 'overview';
+  return 'work';
+}
 
 /** True when the given pathname represents a "work" route where the panel opens. */
 export function shouldDefaultOpen(pathname: string): boolean {
@@ -79,17 +85,13 @@ export function AppShell() {
   // mounted in the same slots as the sprint one and backed by IntentProvider.
   const inIntent = !!intentId;
   const onProjectPage = !!projectId && !inSprint && !inIntent;
-  const onComposePage = location.pathname.endsWith('/compose');
-  const onWorkSection =
-    inIntent &&
-    !onComposePage &&
-    !location.pathname.endsWith('/observability') &&
-    !location.pathname.endsWith('/graph') &&
-    !location.pathname.endsWith('/audit');
-  const showPipelineBar = onWorkSection;
   // Graph pages render a full-bleed canvas with their own toolbar: the shell's
   // content padding would float that toolbar mid-pane, so drop it there.
   const onGraphPage = location.pathname.endsWith('/graph');
+
+  useEffect(() => {
+    if (intentId) setLastIntentSection(intentId, intentSection(location.pathname));
+  }, [intentId, location.pathname]);
 
   // Breakpoint (Tailwind lg): below it BOTH side panels render as NON-modal
   // overlays above the content instead of grid columns, so they stay usable
@@ -194,7 +196,6 @@ export function AppShell() {
               {/* Main content */}
               <main className="h-full overflow-hidden min-w-0 flex flex-col">
                 {inSprint && <SprintPipelineBar />}
-                {showPipelineBar && <IntentPipelineBar />}
                 <div
                   className={cn(
                     'flex-1 overflow-y-auto min-w-0',

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { AppSidebar } from '@/components/layout/AppSidebar';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { SprintPipelineBar } from '@/components/layout/SprintPipelineBar';
+import { detectSection } from '@/components/layout/IntentPipelineBar';
 // Lazy: the activity panels pull react-markdown (+ transitively heavy deps)
 // that don't belong in the eager main chunk — they only render when a side
 // panel is open on sprint/intent routes.
@@ -23,7 +24,7 @@ import { useProjectSprintsCache } from '@/hooks/useProjectsCache';
 import { useState, useCallback, useMemo, useEffect, useRef, lazy, Suspense } from 'react';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useResizablePanel } from '@/hooks/useResizablePanel';
-import { setLastIntentSection, type IntentSection } from '@/lib/intentSectionPreference';
+import { setLastIntentSection } from '@/lib/intentSectionPreference';
 
 // ---------------------------------------------------------------------------
 // Route classification: determines whether the activity panel should default
@@ -32,12 +33,6 @@ import { setLastIntentSection, type IntentSection } from '@/lib/intentSectionPre
 // ---------------------------------------------------------------------------
 
 const NON_WORK_SUFFIXES = ['/graph', '/audit', '/compose', '/observability'];
-
-function intentSection(pathname: string): IntentSection {
-  if (pathname.endsWith('/graph')) return 'graph';
-  if (pathname.endsWith('/observability') || pathname.endsWith('/audit')) return 'overview';
-  return 'work';
-}
 
 /** True when the given pathname represents a "work" route where the panel opens. */
 export function shouldDefaultOpen(pathname: string): boolean {
@@ -90,7 +85,7 @@ export function AppShell() {
   const onGraphPage = location.pathname.endsWith('/graph');
 
   useEffect(() => {
-    if (intentId) setLastIntentSection(intentId, intentSection(location.pathname));
+    if (intentId) setLastIntentSection(intentId, detectSection(location.pathname));
   }, [intentId, location.pathname]);
 
   // Breakpoint (Tailwind lg): below it BOTH side panels render as NON-modal

--- a/frontend/src/components/layout/IntentPipelineBar.test.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.test.tsx
@@ -56,6 +56,9 @@ describe('IntentPhaseBreadcrumb', () => {
     expect(screen.getByText('1/1 selected stages')).toBeInTheDocument();
     expect(screen.getByText('0/1 selected stages')).toBeInTheDocument();
     expect(screen.queryByText('Operation')).not.toBeInTheDocument();
+    const scroller = screen.getByTestId('intent-phase-breadcrumb-scroll');
+    expect(scroller).toHaveClass('flex', 'w-full', 'overflow-x-auto');
+    expect(scroller).not.toHaveClass('min-w-max');
   });
 
   it('reserves the breadcrumb space while workflow metadata loads', () => {

--- a/frontend/src/components/layout/IntentPipelineBar.test.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.test.tsx
@@ -16,7 +16,12 @@ const readyContext = {
   detail: {
     intent: {
       scope: 'feature',
-      composedGrid: { requirements: 'EXECUTE', design: 'SKIP', build: 'EXECUTE' },
+      composedGrid: {
+        requirements: 'EXECUTE',
+        design: 'SKIP',
+        build: 'EXECUTE',
+        release: 'SKIP',
+      },
       skipStageIds: [],
     },
     stages: [
@@ -32,12 +37,14 @@ const readyContext = {
         { stageId: 'requirements', phasePath: '01', order: 1 },
         { stageId: 'design', phasePath: '01', order: 2 },
         { stageId: 'build', phasePath: '02', order: 3 },
+        { stageId: 'release', phasePath: '03', order: 4 },
       ],
     },
   },
-  phaseNameOf: (phase: string) => (phase === '01' ? 'Inception' : 'Construction'),
+  phaseNameOf: (phase: string) =>
+    phase === '01' ? 'Inception' : phase === '02' ? 'Construction' : 'Operation',
   initializationPhasePaths: new Set<string>(),
-  workflowPhases: [{ path: '01' }, { path: '02' }],
+  workflowPhases: [{ path: '01' }, { path: '02' }, { path: '03' }],
   currentPhasePath: '02',
 };
 
@@ -46,8 +53,9 @@ describe('IntentPhaseBreadcrumb', () => {
     mockUseIntent.mockReturnValue(readyContext);
     render(<IntentPhaseBreadcrumb />);
     expect(screen.getByLabelText('Scope: feature')).toBeInTheDocument();
-    expect(screen.getByText('1/1 selected steps')).toBeInTheDocument();
-    expect(screen.getByText('0/1 selected steps')).toBeInTheDocument();
+    expect(screen.getByText('1/1 selected stages')).toBeInTheDocument();
+    expect(screen.getByText('0/1 selected stages')).toBeInTheDocument();
+    expect(screen.queryByText('Operation')).not.toBeInTheDocument();
   });
 
   it('reserves the breadcrumb space while workflow metadata loads', () => {
@@ -65,17 +73,38 @@ describe('IntentPhaseBreadcrumb', () => {
     expect(screen.queryByTestId('intent-phase-breadcrumb')).not.toBeInTheDocument();
   });
 
-  it('opens the run configuration from a phase with excluded steps', async () => {
+  it('opens the scope definition from a phase with excluded stages', async () => {
     const user = userEvent.setup();
-    const onOpenConfiguration = vi.fn();
+    const onOpenScopeDefinition = vi.fn();
     mockUseIntent.mockReturnValue(readyContext);
 
-    render(<IntentPhaseBreadcrumb onOpenConfiguration={onOpenConfiguration} />);
+    render(<IntentPhaseBreadcrumb onOpenScopeDefinition={onOpenScopeDefinition} />);
 
     await user.click(screen.getByRole('button', { name: /Inception/ }));
-    await user.click(screen.getByRole('button', { name: 'View configuration' }));
+    await user.click(screen.getByRole('button', { name: 'Scope definition' }));
 
-    expect(onOpenConfiguration).toHaveBeenCalledOnce();
+    expect(onOpenScopeDefinition).toHaveBeenCalledOnce();
+  });
+
+  it('renders failed stages as failures instead of running work', async () => {
+    const user = userEvent.setup();
+    mockUseIntent.mockReturnValue({
+      ...readyContext,
+      detail: {
+        ...readyContext.detail,
+        stages: [{ stageInstanceId: 'r1', stageId: 'requirements', state: 'FAILED' }],
+      },
+      currentPhasePath: '01',
+    });
+
+    render(<IntentPhaseBreadcrumb />);
+
+    const inception = screen.getByRole('button', { name: /Inception/ });
+    expect(inception).toHaveClass('text-destructive');
+    await user.click(inception);
+
+    expect(screen.getByText(/1 failed/)).toBeInTheDocument();
+    expect(screen.getByText('failed')).toHaveClass('text-destructive');
   });
 });
 

--- a/frontend/src/components/layout/IntentPipelineBar.test.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 const { mockUseIntent } = vi.hoisted(() => ({
   mockUseIntent: vi.fn(),
@@ -62,6 +63,19 @@ describe('IntentPhaseBreadcrumb', () => {
     expect(placeholder).toHaveClass('space-y-2');
     expect(placeholder.children).toHaveLength(2);
     expect(screen.queryByTestId('intent-phase-breadcrumb')).not.toBeInTheDocument();
+  });
+
+  it('opens the run configuration from a phase with excluded steps', async () => {
+    const user = userEvent.setup();
+    const onOpenConfiguration = vi.fn();
+    mockUseIntent.mockReturnValue(readyContext);
+
+    render(<IntentPhaseBreadcrumb onOpenConfiguration={onOpenConfiguration} />);
+
+    await user.click(screen.getByRole('button', { name: /Inception/ }));
+    await user.click(screen.getByRole('button', { name: 'View configuration' }));
+
+    expect(onOpenConfiguration).toHaveBeenCalledOnce();
   });
 });
 

--- a/frontend/src/components/layout/IntentPipelineBar.test.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.test.tsx
@@ -1,94 +1,74 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
-import { TooltipProvider } from '@/components/ui/tooltip';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
 
-vi.mock('react-router', async () => {
-  const actual = await vi.importActual('react-router');
-  return { ...actual, useNavigate: () => vi.fn() };
-});
+const { mockUseIntent } = vi.hoisted(() => ({
+  mockUseIntent: vi.fn(),
+}));
 
 vi.mock('@/contexts/IntentContext', () => ({
-  useIntent: () => ({
-    projectId: 'p1',
-    intentId: 'i1',
-    detail: { intent: { id: 'i1', status: 'RUNNING' } },
-    compiled: { graph: { nodes: [{ stageId: 's1', phasePath: '01' }], edges: [] } },
-    stageRows: [{ stageId: 's1', phase: '01', state: 'RUNNING', done: 0, total: 1 }],
-    loading: false,
-    phaseNameOf: () => 'Build',
-    initializationPhasePaths: new Set(),
-    workflowPhases: [{ path: '01', name: 'Build' }],
-    currentPhasePath: '01',
-  }),
+  useIntent: mockUseIntent,
 }));
 
-vi.mock('@/lib/intentPhases', () => ({
-  groupByPhase: (rows: unknown[]) => (rows.length > 0 ? [{ phase: '01', done: 0, total: 1 }] : []),
-  derivePhaseState: () => 'active',
-}));
+import { IntentPhaseBreadcrumb, detectSection } from './IntentPipelineBar';
 
-import { IntentPipelineBar, detectSection } from './IntentPipelineBar';
-import { getLastIntentSection } from '@/lib/intentSectionPreference';
+const readyContext = {
+  detail: {
+    intent: {
+      scope: 'feature',
+      composedGrid: { requirements: 'EXECUTE', design: 'SKIP', build: 'EXECUTE' },
+      skipStageIds: [],
+    },
+    stages: [
+      { stageInstanceId: 'r1', stageId: 'requirements', state: 'SUCCEEDED' },
+      { stageInstanceId: 'b1', stageId: 'build', state: 'SUCCEEDED', unitSlug: 'one' },
+      { stageInstanceId: 'b2', stageId: 'build', state: 'RUNNING', unitSlug: 'two' },
+    ],
+  },
+  compiled: {
+    scopeGrid: {},
+    graph: {
+      nodes: [
+        { stageId: 'requirements', phasePath: '01', order: 1 },
+        { stageId: 'design', phasePath: '01', order: 2 },
+        { stageId: 'build', phasePath: '02', order: 3 },
+      ],
+    },
+  },
+  phaseNameOf: (phase: string) => (phase === '01' ? 'Inception' : 'Construction'),
+  initializationPhasePaths: new Set<string>(),
+  workflowPhases: [{ path: '01' }, { path: '02' }],
+  currentPhasePath: '02',
+};
 
-const renderAt = (path: string) =>
-  render(
-    <MemoryRouter initialEntries={[path]}>
-      <TooltipProvider>
-        <IntentPipelineBar />
-      </TooltipProvider>
-    </MemoryRouter>,
-  );
-
-describe('IntentPipelineBar', () => {
-  beforeEach(() => {
-    localStorage.clear();
+describe('IntentPhaseBreadcrumb', () => {
+  it('uses selected stage definitions and collapses parallel instances', () => {
+    mockUseIntent.mockReturnValue(readyContext);
+    render(<IntentPhaseBreadcrumb />);
+    expect(screen.getByLabelText('Scope: feature')).toBeInTheDocument();
+    expect(screen.getByText('1/1 selected steps')).toBeInTheDocument();
+    expect(screen.getByText('0/1 selected steps')).toBeInTheDocument();
   });
 
-  it('renders phase progress chips on the work route', () => {
-    const { container } = renderAt('/space/p1/intent/i1');
-    expect(container.textContent).toContain('Build');
-  });
+  it('reserves the breadcrumb space while workflow metadata loads', () => {
+    mockUseIntent.mockReturnValue({
+      ...readyContext,
+      compiled: null,
+      workflowPhases: null,
+    });
 
-  it('persists work when on the root intent route', () => {
-    renderAt('/space/p1/intent/i1');
-    expect(getLastIntentSection('i1')).toBe('work');
-  });
+    render(<IntentPhaseBreadcrumb />);
 
-  it('persists overview when on the observability route', () => {
-    renderAt('/space/p1/intent/i1/observability');
-    expect(getLastIntentSection('i1')).toBe('overview');
-  });
-
-  it('persists overview when on the audit route', () => {
-    renderAt('/space/p1/intent/i1/audit');
-    expect(getLastIntentSection('i1')).toBe('overview');
-  });
-
-  it('persists graph when on the graph route', () => {
-    renderAt('/space/p1/intent/i1/graph');
-    expect(getLastIntentSection('i1')).toBe('graph');
+    const placeholder = screen.getByTestId('intent-phase-breadcrumb-placeholder');
+    expect(placeholder).toHaveClass('space-y-2');
+    expect(placeholder.children).toHaveLength(2);
+    expect(screen.queryByTestId('intent-phase-breadcrumb')).not.toBeInTheDocument();
   });
 });
 
 describe('detectSection', () => {
-  it('maps root intent path to work', () => {
-    expect(detectSection('/space/p1/intent/i1')).toBe('work');
-  });
-
-  it('maps review subroute to work', () => {
-    expect(detectSection('/space/p1/intent/i1/review/h1')).toBe('work');
-  });
-
-  it('maps /observability to overview', () => {
-    expect(detectSection('/space/p1/intent/i1/observability')).toBe('overview');
-  });
-
-  it('maps /audit to overview', () => {
-    expect(detectSection('/space/p1/intent/i1/audit')).toBe('overview');
-  });
-
-  it('maps /graph to graph', () => {
-    expect(detectSection('/space/p1/intent/i1/graph')).toBe('graph');
+  it('maps intent routes', () => {
+    expect(detectSection('/space/p/intent/i')).toBe('work');
+    expect(detectSection('/space/p/intent/i/observability')).toBe('overview');
+    expect(detectSection('/space/p/intent/i/graph')).toBe('graph');
   });
 });

--- a/frontend/src/components/layout/IntentPipelineBar.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Check, Circle, LoaderCircle } from 'lucide-react';
+import { Check, Circle, LoaderCircle, XCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -10,7 +10,7 @@ import { getIntentStageSelection } from '@/lib/intentStageSelection';
 import type { IntentSection } from '@/lib/intentSectionPreference';
 import type { IntentStage } from '@/services/intents';
 
-function detectSection(pathname: string): IntentSection {
+export function detectSection(pathname: string): IntentSection {
   if (pathname.endsWith('/graph')) return 'graph';
   if (pathname.endsWith('/observability') || pathname.endsWith('/audit')) return 'overview';
   return 'work';
@@ -29,9 +29,9 @@ function stepState(rows: IntentStage[]): StepState {
 }
 
 export function IntentPhaseBreadcrumb({
-  onOpenConfiguration,
+  onOpenScopeDefinition,
 }: {
-  onOpenConfiguration?: () => void;
+  onOpenScopeDefinition?: () => void;
 }) {
   const {
     detail,
@@ -56,7 +56,6 @@ export function IntentPhaseBreadcrumb({
 
     const selection = getIntentStageSelection(intent, compiled, initializationPhasePaths);
     const selected = selection.selected.toSorted((a, b) => a.order - b.order);
-
     const allByPhase = new Map<string, number>();
     for (const node of selection.available) {
       const phase = node.phasePath ?? '(ungrouped)';
@@ -114,9 +113,12 @@ export function IntentPhaseBreadcrumb({
       <div className="flex w-full min-w-max overflow-x-auto pr-4">
         {phases.map((group, index) => {
           const done = group.steps.filter((step) => step.state === 'done').length;
+          const running = group.steps.filter((step) => step.state === 'running').length;
+          const failed = group.steps.filter((step) => step.state === 'failed').length;
+          const pending = group.steps.filter((step) => step.state === 'pending').length;
           const active =
-            group.phase === currentPhasePath ||
-            group.steps.some((step) => step.state === 'running' || step.state === 'failed');
+            group.steps.length > 0 &&
+            (group.phase === currentPhasePath || running > 0 || failed > 0);
           const complete = done === group.steps.length && group.steps.length > 0;
           const open = openPhase === group.phase;
 
@@ -133,7 +135,8 @@ export function IntentPhaseBreadcrumb({
                     'group relative flex min-h-12 min-w-48 flex-1 items-center gap-2.5 px-8 py-2 text-left transition-[filter] focus-visible:outline-none',
                     index > 0 && '-ml-4',
                     complete && 'bg-agent-success/10 text-agent-success',
-                    active && !complete && 'bg-agent-running/10 text-agent-running',
+                    failed > 0 && !complete && 'bg-destructive/10 text-destructive',
+                    active && failed === 0 && !complete && 'bg-agent-running/10 text-agent-running',
                     !active && !complete && 'bg-muted text-muted-foreground',
                     open && 'brightness-[0.97]',
                   )}
@@ -153,6 +156,8 @@ export function IntentPhaseBreadcrumb({
                   >
                     {complete ? (
                       <Check className="h-3.5 w-3.5" />
+                    ) : failed > 0 ? (
+                      <XCircle className="h-3.5 w-3.5" />
                     ) : active ? (
                       <span className="h-2 w-2 rounded-full bg-current" />
                     ) : (
@@ -164,7 +169,7 @@ export function IntentPhaseBreadcrumb({
                       {phaseNameOf(group.phase)}
                     </span>
                     <span className="block text-[10px] font-medium opacity-80">
-                      {done}/{group.steps.length} selected steps
+                      {done}/{group.steps.length} selected stages
                     </span>
                   </span>
                 </button>
@@ -173,9 +178,8 @@ export function IntentPhaseBreadcrumb({
                 <div className="border-b px-4 py-3">
                   <h3 className="text-sm font-semibold">{phaseNameOf(group.phase)}</h3>
                   <p className="mt-1 text-xs text-muted-foreground">
-                    {done} resolved ·{' '}
-                    {group.steps.filter((step) => step.state === 'running').length} running ·{' '}
-                    {group.steps.filter((step) => step.state === 'pending').length} pending
+                    {done} resolved · {running} running
+                    {failed > 0 && ` · ${failed} failed`} · {pending} pending
                   </p>
                 </div>
                 <div className="space-y-1 bg-muted/30 p-2">
@@ -188,32 +192,41 @@ export function IntentPhaseBreadcrumb({
                         <Check className="h-3.5 w-3.5 text-agent-success" />
                       ) : step.state === 'running' ? (
                         <LoaderCircle className="h-3.5 w-3.5 animate-spin text-agent-running" />
+                      ) : step.state === 'failed' ? (
+                        <XCircle className="h-3.5 w-3.5 text-destructive" />
                       ) : (
                         <Circle className="h-3.5 w-3.5 text-muted-foreground" />
                       )}
                       <span className="min-w-0 flex-1 truncate font-medium">
                         {humanizeStageId(step.stageId)}
                       </span>
-                      <span className="capitalize text-muted-foreground">{step.state}</span>
+                      <span
+                        className={cn(
+                          'capitalize text-muted-foreground',
+                          step.state === 'failed' && 'text-destructive',
+                        )}
+                      >
+                        {step.state}
+                      </span>
                     </div>
                   ))}
                 </div>
                 <div className="flex items-center justify-between gap-3 px-4 py-2.5 text-[11px] text-muted-foreground">
                   <span>
                     {group.excluded > 0
-                      ? `${group.excluded} ${group.excluded === 1 ? 'step is' : 'steps are'} outside this selection.`
-                      : 'All workflow steps in this phase are selected.'}
+                      ? `${group.excluded} ${group.excluded === 1 ? 'stage is' : 'stages are'} outside this selection.`
+                      : 'All workflow stages in this phase are selected.'}
                   </span>
-                  {group.excluded > 0 && onOpenConfiguration && (
+                  {group.excluded > 0 && onOpenScopeDefinition && (
                     <button
                       type="button"
                       className="shrink-0 font-medium text-foreground underline-offset-4 hover:underline"
                       onClick={() => {
                         setOpenPhase(null);
-                        onOpenConfiguration();
+                        onOpenScopeDefinition();
                       }}
                     >
-                      View configuration
+                      Scope definition
                     </button>
                   )}
                 </div>
@@ -225,6 +238,3 @@ export function IntentPhaseBreadcrumb({
     </div>
   );
 }
-
-export const IntentPipelineBar = IntentPhaseBreadcrumb;
-export { detectSection };

--- a/frontend/src/components/layout/IntentPipelineBar.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useMemo } from 'react';
-import { useLocation } from 'react-router';
-import { CheckCircle2, ChevronRight } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Check, Circle, LoaderCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { Progress } from '@/components/ui/progress';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useIntent } from '@/contexts/IntentContext';
-import { groupByPhase, derivePhaseState } from '@/lib/intentPhases';
-import { setLastIntentSection, type IntentSection } from '@/lib/intentSectionPreference';
+import { ScopeBadge } from '@/components/intent/ScopeBadge';
+import { humanizeStageId } from '@/components/intent/documentHelpers';
+import { getIntentStageSelection } from '@/lib/intentStageSelection';
+import type { IntentSection } from '@/lib/intentSectionPreference';
+import type { IntentStage } from '@/services/intents';
 
 function detectSection(pathname: string): IntentSection {
   if (pathname.endsWith('/graph')) return 'graph';
@@ -14,103 +16,191 @@ function detectSection(pathname: string): IntentSection {
   return 'work';
 }
 
-export function IntentPipelineBar() {
-  const location = useLocation();
+type StepState = 'done' | 'running' | 'failed' | 'pending';
+
+function stepState(rows: IntentStage[]): StepState {
+  if (rows.length === 0) return 'pending';
+  if (rows.some((row) => row.state === 'RUNNING' || row.state === 'WAITING_FOR_HUMAN')) {
+    return 'running';
+  }
+  if (rows.some((row) => row.state === 'FAILED')) return 'failed';
+  if (rows.every((row) => row.state === 'SUCCEEDED' || row.state === 'SKIPPED')) return 'done';
+  return 'pending';
+}
+
+export function IntentPhaseBreadcrumb() {
   const {
-    projectId,
-    intentId,
     detail,
     compiled,
-    stageRows,
-    loading,
     phaseNameOf,
     initializationPhasePaths,
     workflowPhases,
     currentPhasePath,
   } = useIntent();
+  const [openPhase, setOpenPhase] = useState<string | null>(null);
 
-  const planReady = !!compiled && !!workflowPhases;
+  const phases = useMemo(() => {
+    if (!detail || !compiled || !workflowPhases) return [];
+    const intent = detail.intent;
+    const rowsByStage = new Map<string, IntentStage[]>();
+    for (const row of detail.stages) {
+      if (!row.stageId) continue;
+      const rows = rowsByStage.get(row.stageId) ?? [];
+      rows.push(row);
+      rowsByStage.set(row.stageId, rows);
+    }
 
-  const phases = useMemo(
-    () =>
-      planReady
-        ? groupByPhase(stageRows).filter((g) => !initializationPhasePaths.has(g.phase))
-        : [],
-    [planReady, stageRows, initializationPhasePaths],
-  );
+    const selection = getIntentStageSelection(intent, compiled, initializationPhasePaths);
+    const selected = selection.selected.toSorted((a, b) => a.order - b.order);
 
-  const activeIndex = useMemo(() => {
-    const idx = phases.findIndex((g) => derivePhaseState(g, currentPhasePath) === 'active');
-    return idx >= 0 ? idx : phases.length - 1;
-  }, [phases, currentPhasePath]);
+    const allByPhase = new Map<string, number>();
+    for (const node of selection.available) {
+      const phase = node.phasePath ?? '(ungrouped)';
+      allByPhase.set(phase, (allByPhase.get(phase) ?? 0) + 1);
+    }
 
-  const currentSection = detectSection(location.pathname);
+    const groups = new Map<
+      string,
+      {
+        phase: string;
+        steps: { stageId: string; state: StepState }[];
+        excluded: number;
+      }
+    >();
+    for (const node of selected) {
+      const phase = node.phasePath ?? '(ungrouped)';
+      const group = groups.get(phase) ?? { phase, steps: [], excluded: 0 };
+      group.steps.push({
+        stageId: node.stageId,
+        state: stepState(rowsByStage.get(node.stageId) ?? []),
+      });
+      groups.set(phase, group);
+    }
+    for (const group of groups.values()) {
+      group.excluded = Math.max(
+        0,
+        (allByPhase.get(group.phase) ?? group.steps.length) - group.steps.length,
+      );
+    }
+    return [...groups.values()];
+  }, [compiled, detail, initializationPhasePaths, workflowPhases]);
 
-  useEffect(() => {
-    if (intentId) setLastIntentSection(intentId, currentSection);
-  }, [intentId, currentSection]);
-
-  if (!detail && loading) return null;
-  if (!projectId || !intentId) return null;
-  if (phases.length === 0) return null;
+  const intent = detail?.intent;
+  if (intent && (!compiled || !workflowPhases)) {
+    return (
+      <div
+        className="space-y-2"
+        data-testid="intent-phase-breadcrumb-placeholder"
+        aria-hidden="true"
+      >
+        {intent.scope && <Skeleton className="h-4 w-24 rounded-full" />}
+        <Skeleton className="h-12 w-full rounded-none" />
+      </div>
+    );
+  }
+  if (!intent || phases.length === 0) return null;
 
   return (
-    <div className="h-11 border-b bg-background flex items-center px-3 gap-1 overflow-x-auto md:overflow-visible">
-      <div className="flex items-center gap-0.5 shrink-0">
+    <div className="space-y-2" data-testid="intent-phase-breadcrumb">
+      {intent.scope && (
+        <div className="flex items-center">
+          <ScopeBadge scope={intent.scope} className="px-2 py-0 text-[10px]" />
+        </div>
+      )}
+      <div className="flex w-full min-w-max overflow-x-auto pr-4">
         {phases.map((group, index) => {
-          const state = derivePhaseState(group, currentPhasePath);
-          const progress = group.total > 0 ? Math.round((group.done / group.total) * 100) : null;
-          const distance = Math.abs(index - activeIndex);
-          const isNear = distance <= 1;
+          const done = group.steps.filter((step) => step.state === 'done').length;
+          const active =
+            group.phase === currentPhasePath ||
+            group.steps.some((step) => step.state === 'running' || step.state === 'failed');
+          const complete = done === group.steps.length && group.steps.length > 0;
+          const open = openPhase === group.phase;
 
           return (
-            <div key={group.phase} className="flex items-center">
-              {index > 0 && (
-                <ChevronRight className="h-3 w-3 text-muted-foreground/50 mx-0.5 shrink-0" />
-              )}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
+            <Popover
+              key={group.phase}
+              open={open}
+              onOpenChange={(next) => setOpenPhase(next ? group.phase : null)}
+            >
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    'group relative flex min-h-12 min-w-48 flex-1 items-center gap-2.5 px-8 py-2 text-left transition-[filter] focus-visible:outline-none',
+                    index > 0 && '-ml-4',
+                    complete && 'bg-agent-success/10 text-agent-success',
+                    active && !complete && 'bg-agent-running/10 text-agent-running',
+                    !active && !complete && 'bg-muted text-muted-foreground',
+                    open && 'brightness-[0.97]',
+                  )}
+                  style={{
+                    clipPath:
+                      index === 0
+                        ? 'polygon(0 0, calc(100% - 18px) 0, 100% 50%, calc(100% - 18px) 100%, 0 100%)'
+                        : 'polygon(0 0, calc(100% - 18px) 0, 100% 50%, calc(100% - 18px) 100%, 0 100%, 18px 50%)',
+                  }}
+                >
+                  <span
                     className={cn(
-                      'flex flex-col gap-1 rounded-md font-medium whitespace-nowrap transition-all',
-                      isNear ? 'px-3 py-1.5 text-xs' : 'px-1.5 py-1 text-[10px] opacity-60',
-                      state === 'active' && 'bg-sidebar-accent text-foreground',
-                      state === 'done' && 'text-muted-foreground',
-                      state === 'pending' && 'text-muted-foreground/40',
+                      'grid h-6 w-6 shrink-0 place-items-center rounded-full bg-background/80',
+                      'group-focus-visible:ring-2 group-focus-visible:ring-current group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-transparent',
+                      open && 'ring-2 ring-current ring-offset-2 ring-offset-transparent',
                     )}
                   >
-                    <span className="flex items-center gap-1.5">
-                      {state === 'done' ? (
-                        <CheckCircle2 className="h-3.5 w-3.5 text-agent-success shrink-0" />
-                      ) : state === 'active' ? (
-                        <span className="h-2 w-2 rounded-full bg-agent-running animate-pulse shrink-0" />
-                      ) : (
-                        <span className="h-2 w-2 rounded-full bg-muted-foreground/40 shrink-0" />
-                      )}
-                      <span>{phaseNameOf(group.phase)}</span>
-                      {isNear && (
-                        <span className="hidden xl:inline text-[10px] text-muted-foreground font-normal">
-                          {group.done}/{group.total}
-                        </span>
-                      )}
-                    </span>
-                    {isNear && progress !== null && (
-                      <Progress
-                        value={progress}
-                        className={cn(
-                          'h-1 w-full',
-                          state === 'done' && '[&>div]:bg-agent-success',
-                          state === 'active' && '[&>div]:bg-agent-running',
-                        )}
-                      />
+                    {complete ? (
+                      <Check className="h-3.5 w-3.5" />
+                    ) : active ? (
+                      <span className="h-2 w-2 rounded-full bg-current" />
+                    ) : (
+                      <Circle className="h-3.5 w-3.5" />
                     )}
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {phaseNameOf(group.phase)} — {group.done}/{group.total}
-                </TooltipContent>
-              </Tooltip>
-            </div>
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate text-xs font-bold">
+                      {phaseNameOf(group.phase)}
+                    </span>
+                    <span className="block text-[10px] font-medium opacity-80">
+                      {done}/{group.steps.length} selected steps
+                    </span>
+                  </span>
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="start" className="w-[min(26rem,calc(100vw-2rem))] p-0">
+                <div className="border-b px-4 py-3">
+                  <h3 className="text-sm font-semibold">{phaseNameOf(group.phase)}</h3>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {done} resolved ·{' '}
+                    {group.steps.filter((step) => step.state === 'running').length} running ·{' '}
+                    {group.steps.filter((step) => step.state === 'pending').length} pending
+                  </p>
+                </div>
+                <div className="space-y-1 bg-muted/30 p-2">
+                  {group.steps.map((step) => (
+                    <div
+                      key={step.stageId}
+                      className="flex items-center gap-2 rounded-md bg-background px-2.5 py-2 text-xs"
+                    >
+                      {step.state === 'done' ? (
+                        <Check className="h-3.5 w-3.5 text-agent-success" />
+                      ) : step.state === 'running' ? (
+                        <LoaderCircle className="h-3.5 w-3.5 animate-spin text-agent-running" />
+                      ) : (
+                        <Circle className="h-3.5 w-3.5 text-muted-foreground" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate font-medium">
+                        {humanizeStageId(step.stageId)}
+                      </span>
+                      <span className="capitalize text-muted-foreground">{step.state}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="px-4 py-2.5 text-[11px] text-muted-foreground">
+                  {group.excluded > 0
+                    ? `${group.excluded} ${group.excluded === 1 ? 'step is' : 'steps are'} outside this selection.`
+                    : 'All workflow steps in this phase are selected.'}
+                </div>
+              </PopoverContent>
+            </Popover>
           );
         })}
       </div>
@@ -118,4 +208,5 @@ export function IntentPipelineBar() {
   );
 }
 
+export const IntentPipelineBar = IntentPhaseBreadcrumb;
 export { detectSection };

--- a/frontend/src/components/layout/IntentPipelineBar.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.tsx
@@ -110,7 +110,10 @@ export function IntentPhaseBreadcrumb({
           <ScopeBadge scope={intent.scope} className="px-2 py-0 text-[10px]" />
         </div>
       )}
-      <div className="flex w-full min-w-max overflow-x-auto pr-4">
+      <div
+        className="flex w-full overflow-x-auto pr-4"
+        data-testid="intent-phase-breadcrumb-scroll"
+      >
         {phases.map((group, index) => {
           const done = group.steps.filter((step) => step.state === 'done').length;
           const running = group.steps.filter((step) => step.state === 'running').length;

--- a/frontend/src/components/layout/IntentPipelineBar.tsx
+++ b/frontend/src/components/layout/IntentPipelineBar.tsx
@@ -28,7 +28,11 @@ function stepState(rows: IntentStage[]): StepState {
   return 'pending';
 }
 
-export function IntentPhaseBreadcrumb() {
+export function IntentPhaseBreadcrumb({
+  onOpenConfiguration,
+}: {
+  onOpenConfiguration?: () => void;
+}) {
   const {
     detail,
     compiled,
@@ -194,10 +198,24 @@ export function IntentPhaseBreadcrumb() {
                     </div>
                   ))}
                 </div>
-                <div className="px-4 py-2.5 text-[11px] text-muted-foreground">
-                  {group.excluded > 0
-                    ? `${group.excluded} ${group.excluded === 1 ? 'step is' : 'steps are'} outside this selection.`
-                    : 'All workflow steps in this phase are selected.'}
+                <div className="flex items-center justify-between gap-3 px-4 py-2.5 text-[11px] text-muted-foreground">
+                  <span>
+                    {group.excluded > 0
+                      ? `${group.excluded} ${group.excluded === 1 ? 'step is' : 'steps are'} outside this selection.`
+                      : 'All workflow steps in this phase are selected.'}
+                  </span>
+                  {group.excluded > 0 && onOpenConfiguration && (
+                    <button
+                      type="button"
+                      className="shrink-0 font-medium text-foreground underline-offset-4 hover:underline"
+                      onClick={() => {
+                        setOpenPhase(null);
+                        onOpenConfiguration();
+                      }}
+                    >
+                      View configuration
+                    </button>
+                  )}
                 </div>
               </PopoverContent>
             </Popover>

--- a/frontend/src/lib/intentStageSelection.test.ts
+++ b/frontend/src/lib/intentStageSelection.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { Intent } from '@/services/intents';
+import type { CompiledWorkflow } from '@/services/workflows';
+import { getIntentStageSelection } from './intentStageSelection';
+
+const compiled = {
+  scopeGrid: {
+    feature: {
+      requirements: 'EXECUTE',
+      design: 'EXECUTE',
+      build: 'SKIP',
+    },
+  },
+  graph: {
+    nodes: [
+      { stageId: 'initialize', phasePath: '00', order: 0 },
+      { stageId: 'requirements', phasePath: '01', order: 1 },
+      { stageId: 'design', phasePath: '01', order: 2 },
+      { stageId: 'build', phasePath: '02', order: 3 },
+    ],
+  },
+} as unknown as CompiledWorkflow;
+
+describe('getIntentStageSelection', () => {
+  it('prefers the composed projection and applies initialization and skip overlays', () => {
+    const intent = {
+      scope: 'feature',
+      composedGrid: {
+        requirements: 'SKIP',
+        design: 'EXECUTE',
+        build: 'EXECUTE',
+      },
+      skipStageIds: ['build'],
+    } as unknown as Intent;
+
+    const selection = getIntentStageSelection(intent, compiled, new Set(['00']));
+
+    expect(selection.available.map((node) => node.stageId)).toEqual([
+      'requirements',
+      'design',
+      'build',
+    ]);
+    expect(selection.selected.map((node) => node.stageId)).toEqual(['design']);
+  });
+
+  it('falls back to the named scope when no composed projection exists', () => {
+    const intent = {
+      scope: 'feature',
+      composedGrid: null,
+      skipStageIds: [],
+    } as unknown as Intent;
+
+    const selection = getIntentStageSelection(intent, compiled, new Set(['00']));
+
+    expect(selection.selected.map((node) => node.stageId)).toEqual(['requirements', 'design']);
+  });
+});

--- a/frontend/src/lib/intentStageSelection.ts
+++ b/frontend/src/lib/intentStageSelection.ts
@@ -1,0 +1,28 @@
+import type { Intent } from '@/services/intents';
+import type { CompiledWorkflow } from '@/services/workflows';
+
+type CompiledStageNode = CompiledWorkflow['graph']['nodes'][number];
+
+export interface IntentStageSelection {
+  available: CompiledStageNode[];
+  selected: CompiledStageNode[];
+}
+
+export function getIntentStageSelection(
+  intent: Intent,
+  compiled: CompiledWorkflow,
+  initializationPhasePaths: Set<string>,
+): IntentStageSelection {
+  const projection =
+    intent.composedGrid ?? (intent.scope ? compiled.scopeGrid?.[intent.scope] : undefined);
+  const explicitSkips = new Set(intent.skipStageIds ?? []);
+  const available = compiled.graph.nodes.filter(
+    (node) => !initializationPhasePaths.has(node.phasePath ?? ''),
+  );
+  const selected = available.filter(
+    (node) =>
+      (!projection || projection[node.stageId] === 'EXECUTE') && !explicitSkips.has(node.stageId),
+  );
+
+  return { available, selected };
+}

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -390,6 +390,28 @@ describe('IntentView', () => {
     expect(screen.getAllByText('PASSED')).toHaveLength(2);
   });
 
+  it('opens the reshape controls from the intent actions menu', async () => {
+    const user = userEvent.setup();
+    get.mockResolvedValue(
+      baseDetail({
+        status: 'WAITING',
+        constructionAutonomyMode: 'gated',
+      }),
+    );
+    renderAt();
+
+    expect(await screen.findByText('My intent')).toBeInTheDocument();
+    expect(screen.queryByTestId('recompose-dialog')).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Intent actions'));
+    await user.click(screen.getByText('Reshape remaining stages'));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Reshape remaining stages' }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('recompose-dialog')).toBeInTheDocument();
+  });
+
   it('shows resume progress after a gate is answered but before the stage is running again', async () => {
     get.mockResolvedValue({
       ...baseDetail({ status: 'WAITING', pendingHumanTaskId: 'h1' }),

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -383,7 +383,7 @@ describe('IntentView', () => {
     expect(await screen.findByText('My intent')).toBeInTheDocument();
     expect(screen.queryByText('Polyglot')).not.toBeInTheDocument();
     expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
-    expect(screen.queryByText('Source: issue #3')).not.toBeInTheDocument();
+    expect(screen.queryByText('Source: Issue #3')).not.toBeInTheDocument();
 
     await user.click(screen.getByLabelText('Intent actions'));
     await user.click(screen.getByText('Intent configuration'));
@@ -394,7 +394,7 @@ describe('IntentView', () => {
     expect(screen.getByText('Polyglot')).toBeInTheDocument();
     expect(screen.getByText('Claude Code')).toBeInTheDocument();
     expect(screen.getByText(/us\.anthropic\.claude-sonnet-4-6/)).toBeInTheDocument();
-    const sourceLabel = screen.getByText('Source: issue #3');
+    const sourceLabel = screen.getByText('Source: Issue #3');
     expect(sourceLabel).toBeInTheDocument();
     expect(screen.getByRole('img', { name: 'GitHub' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute(
@@ -413,6 +413,32 @@ describe('IntentView', () => {
       .find((element) => element.classList.contains('text-agent-success'));
     expect(passedBadge).toBeDefined();
     expect(passedBadge?.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('preserves Jira source keys in the intent configuration dialog', async () => {
+    const user = userEvent.setup();
+    get.mockResolvedValue(
+      baseDetail({
+        status: 'RUNNING',
+        source: {
+          bindingId: 'jira',
+          provider: 'jira-cloud',
+          instance: 'cloud',
+          resourceType: 'task',
+          resourceId: 'TAS-01',
+          resourceUrl: 'https://example.atlassian.net/browse/TAS-01',
+        },
+      }),
+    );
+    renderAt();
+
+    await screen.findByText('My intent');
+    await user.click(screen.getByLabelText('Intent actions'));
+    await user.click(screen.getByText('Intent configuration'));
+
+    expect(await screen.findByText('Source: task TAS-01')).toBeInTheDocument();
+    expect(screen.queryByText(/#TAS-01/)).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Jira' })).toBeInTheDocument();
   });
 
   it('opens the reshape controls from the intent actions menu', async () => {
@@ -455,7 +481,8 @@ describe('IntentView', () => {
     ).toBeInTheDocument();
     const waitingBadge = screen.getByText('WAITING');
     expect(waitingBadge).toHaveClass('text-agent-waiting');
-    expect(waitingBadge.querySelector('.animate-spin')).not.toBeNull();
+    expect(waitingBadge.querySelector('svg')).not.toBeNull();
+    expect(waitingBadge.querySelector('.animate-spin')).toBeNull();
 
     await user.click(screen.getByRole('button', { name: 'Reshape' }));
 

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -349,10 +349,14 @@ describe('IntentView', () => {
     expect(editors[0].getAttribute('data-gate')).toBe('h1');
   });
 
-  it('renders the immutable environment revision and verification result', async () => {
+  it('moves the immutable environment snapshot into the run configuration dialog', async () => {
+    const user = userEvent.setup();
     get.mockResolvedValue(
       baseDetail({
         status: 'RUNNING',
+        agentCli: 'claude',
+        credentialSource: 'space',
+        cliModels: { claude: 'us.anthropic.claude-sonnet-4-6' },
         environment: {
           environmentId: 'polyglot',
           name: 'Polyglot',
@@ -367,10 +371,23 @@ describe('IntentView', () => {
       }),
     );
     renderAt();
-    expect(await screen.findByText('Polyglot')).toBeInTheDocument();
+
+    expect(await screen.findByText('My intent')).toBeInTheDocument();
+    expect(screen.queryByText('Polyglot')).not.toBeInTheDocument();
+    expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Intent actions'));
+    await user.click(screen.getByText('Intent configuration'));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Intent configuration' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Polyglot')).toBeInTheDocument();
+    expect(screen.getByText('Claude Code')).toBeInTheDocument();
+    expect(screen.getByText(/us\.anthropic\.claude-sonnet-4-6/)).toBeInTheDocument();
     expect(screen.getByText('r-7')).toBeInTheDocument();
     expect(screen.getByText('revision_r_7')).toBeInTheDocument();
-    expect(screen.getByText('verification PASSED')).toBeInTheDocument();
+    expect(screen.getAllByText('PASSED')).toHaveLength(2);
   });
 
   it('shows resume progress after a gate is answered but before the stage is running again', async () => {

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -973,7 +973,7 @@ describe('IntentView', () => {
 
     renderAt();
     // Phases and stages render expanded by default, in workflow order.
-    expect(await screen.findByText('Construction')).toBeInTheDocument();
+    expect((await screen.findAllByText('Construction')).length).toBeGreaterThan(0);
     expect(await screen.findByText('Code Gen Doc')).toBeInTheDocument();
 
     // Collect phase headers + document titles in DOM order and assert the full
@@ -987,7 +987,10 @@ describe('IntentView', () => {
       'Requirements Doc Old',
       'Requirements Doc New',
     ];
-    const positions = labels.map((t) => ({ t, el: screen.getByText(t) }));
+    const positions = labels.map((t) => {
+      const matches = screen.getAllByText(t);
+      return { t, el: matches[matches.length - 1] };
+    });
     const domOrder = positions
       .toSorted((a, b) =>
         a.el.compareDocumentPosition(b.el) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1,

--- a/frontend/src/pages/IntentView.test.tsx
+++ b/frontend/src/pages/IntentView.test.tsx
@@ -357,6 +357,14 @@ describe('IntentView', () => {
         agentCli: 'claude',
         credentialSource: 'space',
         cliModels: { claude: 'us.anthropic.claude-sonnet-4-6' },
+        source: {
+          bindingId: 'github',
+          provider: 'github',
+          instance: null,
+          resourceType: 'issue',
+          resourceId: '3',
+          resourceUrl: 'https://github.com/example/repository/issues/3',
+        },
         environment: {
           environmentId: 'polyglot',
           name: 'Polyglot',
@@ -375,6 +383,7 @@ describe('IntentView', () => {
     expect(await screen.findByText('My intent')).toBeInTheDocument();
     expect(screen.queryByText('Polyglot')).not.toBeInTheDocument();
     expect(screen.queryByText('Claude Code')).not.toBeInTheDocument();
+    expect(screen.queryByText('Source: issue #3')).not.toBeInTheDocument();
 
     await user.click(screen.getByLabelText('Intent actions'));
     await user.click(screen.getByText('Intent configuration'));
@@ -385,9 +394,25 @@ describe('IntentView', () => {
     expect(screen.getByText('Polyglot')).toBeInTheDocument();
     expect(screen.getByText('Claude Code')).toBeInTheDocument();
     expect(screen.getByText(/us\.anthropic\.claude-sonnet-4-6/)).toBeInTheDocument();
+    const sourceLabel = screen.getByText('Source: issue #3');
+    expect(sourceLabel).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'GitHub' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open' })).toHaveAttribute(
+      'href',
+      'https://github.com/example/repository/issues/3',
+    );
+    const executionHeading = screen.getByRole('heading', { name: 'Execution' });
+    expect(
+      sourceLabel.compareDocumentPosition(executionHeading) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
     expect(screen.getByText('r-7')).toBeInTheDocument();
     expect(screen.getByText('revision_r_7')).toBeInTheDocument();
-    expect(screen.getAllByText('PASSED')).toHaveLength(2);
+    expect(screen.getAllByText('PASSED')).toHaveLength(1);
+    const passedBadge = screen
+      .getAllByText('PASSED')
+      .find((element) => element.classList.contains('text-agent-success'));
+    expect(passedBadge).toBeDefined();
+    expect(passedBadge?.querySelector('svg')).toBeInTheDocument();
   });
 
   it('opens the reshape controls from the intent actions menu', async () => {
@@ -410,6 +435,80 @@ describe('IntentView', () => {
       await screen.findByRole('heading', { name: 'Reshape remaining stages' }),
     ).toBeInTheDocument();
     expect(screen.getByTestId('recompose-dialog')).toBeInTheDocument();
+  });
+
+  it('switches from intent configuration to reshape', async () => {
+    const user = userEvent.setup();
+    get.mockResolvedValue(
+      baseDetail({
+        status: 'WAITING',
+        constructionAutonomyMode: 'gated',
+      }),
+    );
+    renderAt();
+
+    await screen.findByText('My intent');
+    await user.click(screen.getByLabelText('Intent actions'));
+    await user.click(screen.getByText('Intent configuration'));
+    expect(
+      await screen.findByRole('heading', { name: 'Intent configuration' }),
+    ).toBeInTheDocument();
+    const waitingBadge = screen.getByText('WAITING');
+    expect(waitingBadge).toHaveClass('text-agent-waiting');
+    expect(waitingBadge.querySelector('.animate-spin')).not.toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Reshape' }));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Reshape remaining stages' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Intent configuration' })).not.toBeInTheDocument();
+  });
+
+  it('opens reshape from the scope definition link', async () => {
+    const user = userEvent.setup();
+    compiled.mockResolvedValue({
+      scopeGrid: {
+        feature: {
+          requirements: 'EXECUTE',
+          optional: 'SKIP',
+        },
+      },
+      graph: {
+        nodes: [
+          { stageId: 'requirements', phasePath: '01', order: 1 },
+          { stageId: 'optional', phasePath: '01', order: 2 },
+        ],
+        edges: [],
+      },
+    });
+    workflowGet.mockResolvedValue({
+      phases: [
+        {
+          phaseId: 'inception',
+          name: 'Inception',
+          kind: 'phase',
+          path: '01',
+          parentPath: null,
+          order: 1,
+        },
+      ],
+    });
+    get.mockResolvedValue(
+      baseDetail({
+        status: 'WAITING',
+        currentPhase: 'inception',
+        constructionAutonomyMode: 'gated',
+      }),
+    );
+    renderAt();
+
+    await user.click(await screen.findByRole('button', { name: /Inception/ }));
+    await user.click(screen.getByRole('button', { name: 'Scope definition' }));
+
+    expect(
+      await screen.findByRole('heading', { name: 'Reshape remaining stages' }),
+    ).toBeInTheDocument();
   });
 
   it('shows resume progress after a gate is answered but before the stage is running again', async () => {

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -11,7 +11,7 @@ import { deriveLaneWaits } from '@/lib/intentRecovery';
 import { formatTrackerSourceLabel } from '@/lib/trackerSourceLabel';
 import { AGENT_CLI_METADATA, AGENT_CREDENTIAL_SOURCE_LABELS } from '@/lib/agentCli';
 import { PendingQuestionsTabs } from '@/components/intent/PendingQuestionsTabs';
-import { ScopeBadge } from '@/components/intent/ScopeBadge';
+import { IntentPhaseBreadcrumb } from '@/components/layout/IntentPipelineBar';
 import { QuorumEditPanel } from '@/components/intent/QuorumEditPanel';
 import { UnitLaneBoard, isFanoutActive } from '@/components/intent/UnitLaneBoard';
 import { AgentProgressCard } from '@/components/intent/AgentProgressCard';
@@ -253,7 +253,6 @@ export default function IntentView() {
           <h1 className="text-lg font-bold tracking-tight truncate min-w-0">
             {intent.title || 'Intent'}
           </h1>
-          {intent.scope && <ScopeBadge scope={intent.scope} className="shrink-0" />}
           {intent.agentCli && (
             <Badge variant="outline" className="gap-1 text-[10px] shrink-0">
               <Bot className="h-3 w-3" />
@@ -322,6 +321,8 @@ export default function IntentView() {
           )}
         </div>
       </div>
+
+      <IntentPhaseBreadcrumb />
 
       {intent.environment && (
         <div className="grid gap-3 border-y py-3 text-[11px] sm:grid-cols-2 lg:grid-cols-[auto_1fr_1fr_1fr_auto] lg:items-center">

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -5,11 +5,11 @@ import { useIntent } from '@/contexts/IntentContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useProjectCache } from '@/hooks/useProjectsCache';
 import { RecomposePanel } from '@/components/intent/RecomposePanel';
+import { IntentConfigurationDialog } from '@/components/intent/IntentConfigurationDialog';
 import { DiscussButton } from '@/components/discussion/DiscussButton';
 import { humanizeStageId } from '@/components/intent/documentHelpers';
 import { deriveLaneWaits } from '@/lib/intentRecovery';
 import { formatTrackerSourceLabel } from '@/lib/trackerSourceLabel';
-import { AGENT_CLI_METADATA, AGENT_CREDENTIAL_SOURCE_LABELS } from '@/lib/agentCli';
 import { PendingQuestionsTabs } from '@/components/intent/PendingQuestionsTabs';
 import { IntentPhaseBreadcrumb } from '@/components/layout/IntentPipelineBar';
 import { QuorumEditPanel } from '@/components/intent/QuorumEditPanel';
@@ -36,16 +36,16 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import {
-  Bot,
-  Boxes,
   KeyRound,
   Loader2,
   MoreHorizontal,
   Play,
   RotateCcw,
+  Settings2,
   Trash2,
   TriangleAlert,
   Wrench,
@@ -93,6 +93,7 @@ export default function IntentView() {
   const [deleting, setDeleting] = useState(false);
   const [confirmRepair, setConfirmRepair] = useState(false);
   const [repairing, setRepairing] = useState(false);
+  const [configurationOpen, setConfigurationOpen] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
   // A stage failure retries from the earliest failed stage, preserving all
@@ -196,10 +197,6 @@ export default function IntentView() {
   }
 
   const intent = detail.intent;
-  const environmentVerification =
-    typeof intent.environment?.verification?.status === 'string'
-      ? intent.environment.verification.status
-      : 'UNKNOWN';
   const laneWaits = deriveLaneWaits(detail.stages, gates);
   const recoveryWaits = Object.values(laneWaits).filter((wait) => wait.kind === 'recovery');
   const needsLaneRepair =
@@ -253,15 +250,6 @@ export default function IntentView() {
           <h1 className="text-lg font-bold tracking-tight truncate min-w-0">
             {intent.title || 'Intent'}
           </h1>
-          {intent.agentCli && (
-            <Badge variant="outline" className="gap-1 text-[10px] shrink-0">
-              <Bot className="h-3 w-3" />
-              {AGENT_CLI_METADATA[intent.agentCli].label}
-              {intent.credentialSource
-                ? ` · ${AGENT_CREDENTIAL_SOURCE_LABELS[intent.credentialSource]} key`
-                : ''}
-            </Badge>
-          )}
           {TERMINAL_STATUSES.has(intent.status) && (
             <Badge variant="outline" className="text-[10px] shrink-0">
               {intent.status}
@@ -292,73 +280,40 @@ export default function IntentView() {
               )}
             </span>
           )}
-          {(isCancellable || isDeletable) && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Intent actions">
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {isCancellable && (
-                  <DropdownMenuItem disabled={cancelling} onClick={handleCancel}>
-                    <XCircle className="mr-2 h-4 w-4" />
-                    {cancelling ? 'Cancelling…' : 'Cancel run'}
-                  </DropdownMenuItem>
-                )}
-                {isDeletable && (
-                  <DropdownMenuItem
-                    disabled={deleting}
-                    onClick={() => setConfirmDelete(true)}
-                    className="text-destructive"
-                  >
-                    <Trash2 className="mr-2 h-4 w-4" />
-                    {deleting ? 'Deleting…' : 'Delete'}
-                  </DropdownMenuItem>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Intent actions">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => setConfigurationOpen(true)}>
+                <Settings2 className="mr-2 h-4 w-4" />
+                Intent configuration
+              </DropdownMenuItem>
+              {(isCancellable || isDeletable) && <DropdownMenuSeparator />}
+              {isCancellable && (
+                <DropdownMenuItem disabled={cancelling} onClick={handleCancel}>
+                  <XCircle className="mr-2 h-4 w-4" />
+                  {cancelling ? 'Cancelling…' : 'Cancel run'}
+                </DropdownMenuItem>
+              )}
+              {isDeletable && (
+                <DropdownMenuItem
+                  disabled={deleting}
+                  onClick={() => setConfirmDelete(true)}
+                  className="text-destructive"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  {deleting ? 'Deleting…' : 'Delete'}
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
 
-      <IntentPhaseBreadcrumb />
-
-      {intent.environment && (
-        <div className="grid gap-3 border-y py-3 text-[11px] sm:grid-cols-2 lg:grid-cols-[auto_1fr_1fr_1fr_auto] lg:items-center">
-          <div className="flex items-center gap-1.5 font-medium">
-            <Boxes className="h-3.5 w-3.5" />
-            {intent.environment.name}
-          </div>
-          <div>
-            <span className="text-muted-foreground">Revision </span>
-            <span className="break-all font-mono">{intent.environment.revisionId}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">Image </span>
-            <span className="break-all font-mono">
-              {intent.environment.imageDigest ?? 'Unavailable'}
-            </span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">Endpoint </span>
-            <span className="break-all font-mono">
-              {intent.environment.runtimeEndpoint ?? 'Default'}
-            </span>
-          </div>
-          <div className="flex flex-wrap items-center gap-1.5 lg:justify-end">
-            <Badge variant="outline" className="font-mono text-[10px]">
-              runtime {intent.environment.runtimeVersion ?? 'legacy'}
-            </Badge>
-            <Badge variant="outline" className="font-mono text-[10px]">
-              compatibility {intent.environment.compatibilityVersion}
-            </Badge>
-            <Badge variant="outline" className="font-mono text-[10px]">
-              verification {environmentVerification}
-            </Badge>
-          </div>
-        </div>
-      )}
+      <IntentPhaseBreadcrumb onOpenConfiguration={() => setConfigurationOpen(true)} />
 
       {error && (
         <div className="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -620,6 +575,8 @@ export default function IntentView() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <IntentConfigurationDialog open={configurationOpen} onOpenChange={setConfigurationOpen} />
     </div>
   );
 }

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -9,7 +9,6 @@ import { IntentConfigurationDialog } from '@/components/intent/IntentConfigurati
 import { DiscussButton } from '@/components/discussion/DiscussButton';
 import { humanizeStageId } from '@/components/intent/documentHelpers';
 import { deriveLaneWaits } from '@/lib/intentRecovery';
-import { formatTrackerSourceLabel } from '@/lib/trackerSourceLabel';
 import { PendingQuestionsTabs } from '@/components/intent/PendingQuestionsTabs';
 import { IntentPhaseBreadcrumb } from '@/components/layout/IntentPipelineBar';
 import { QuorumEditPanel } from '@/components/intent/QuorumEditPanel';
@@ -265,25 +264,9 @@ export default function IntentView() {
               aria-label="live"
             />
           )}
-          <DiscussButton entityType="intent" entityTitle={intent.title || 'Intent'} />
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          {intent.source && (
-            <span className="text-xs text-muted-foreground">
-              {intent.source.resourceUrl ? (
-                <a
-                  href={intent.source.resourceUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline hover:no-underline"
-                >
-                  from {formatTrackerSourceLabel(intent.source)}
-                </a>
-              ) : (
-                <>from {formatTrackerSourceLabel(intent.source)}</>
-              )}
-            </span>
-          )}
+          <DiscussButton entityType="intent" entityTitle={intent.title || 'Intent'} />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Intent actions">
@@ -323,7 +306,9 @@ export default function IntentView() {
         </div>
       </div>
 
-      <IntentPhaseBreadcrumb onOpenConfiguration={() => setConfigurationOpen(true)} />
+      <IntentPhaseBreadcrumb
+        onOpenScopeDefinition={canReshape ? () => setReshapeOpen(true) : undefined}
+      />
 
       {error && (
         <div className="rounded border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -568,7 +553,11 @@ export default function IntentView() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <IntentConfigurationDialog open={configurationOpen} onOpenChange={setConfigurationOpen} />
+      <IntentConfigurationDialog
+        open={configurationOpen}
+        onOpenChange={setConfigurationOpen}
+        onOpenReshape={canReshape ? () => setReshapeOpen(true) : undefined}
+      />
 
       {canReshape && (
         <RecomposePanel

--- a/frontend/src/pages/IntentView.tsx
+++ b/frontend/src/pages/IntentView.tsx
@@ -40,6 +40,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import {
+  GitBranch,
   KeyRound,
   Loader2,
   MoreHorizontal,
@@ -94,6 +95,7 @@ export default function IntentView() {
   const [confirmRepair, setConfirmRepair] = useState(false);
   const [repairing, setRepairing] = useState(false);
   const [configurationOpen, setConfigurationOpen] = useState(false);
+  const [reshapeOpen, setReshapeOpen] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
   // A stage failure retries from the earliest failed stage, preserving all
@@ -210,6 +212,8 @@ export default function IntentView() {
   }
   const isActive = intent.status === 'RUNNING' || intent.status === 'WAITING';
   const isFailed = intent.status === 'FAILED';
+  const canReshape =
+    (intent.status === 'WAITING' || isFailed) && intent.constructionAutonomyMode !== 'autonomous';
   // Cancellable (steering): parked, stranded, or failed — never mid-RUNNING.
   const isCancellable = ['WAITING', 'CREATED', 'FAILED'].includes(intent.status);
   // Deletable (destructive): owner/admin, any status except mid-RUNNING.
@@ -291,6 +295,12 @@ export default function IntentView() {
                 <Settings2 className="mr-2 h-4 w-4" />
                 Intent configuration
               </DropdownMenuItem>
+              {canReshape && (
+                <DropdownMenuItem onSelect={() => setReshapeOpen(true)}>
+                  <GitBranch className="mr-2 h-4 w-4" />
+                  Reshape remaining stages
+                </DropdownMenuItem>
+              )}
               {(isCancellable || isDeletable) && <DropdownMenuSeparator />}
               {isCancellable && (
                 <DropdownMenuItem disabled={cancelling} onClick={handleCancel}>
@@ -414,24 +424,6 @@ export default function IntentView() {
           </div>
         </div>
       )}
-
-      {/* In-flight reshape (Adaptive Workflows): skip/add PENDING stages on a
-          parked or failed run — composer-assisted or manual, always applied
-          through the validated recompose relaunch. Hidden mid-RUN and while
-          construction runs autonomously (the endpoint rejects both anyway). */}
-      {(intent.status === 'WAITING' || isFailed) &&
-        intent.constructionAutonomyMode !== 'autonomous' &&
-        projectId &&
-        intentId && (
-          <RecomposePanel
-            projectId={projectId}
-            intentId={intentId}
-            intent={intent}
-            stageRows={detail.stages}
-            workflowVersion={intent.workflowVersion ?? undefined}
-            onRelaunched={reload}
-          />
-        )}
 
       {/* DRAFT never renders here — it redirects to the compose page above. */}
       {reviewGate ? (
@@ -577,6 +569,19 @@ export default function IntentView() {
       </AlertDialog>
 
       <IntentConfigurationDialog open={configurationOpen} onOpenChange={setConfigurationOpen} />
+
+      {canReshape && (
+        <RecomposePanel
+          open={reshapeOpen}
+          onOpenChange={setReshapeOpen}
+          projectId={projectId}
+          intentId={intentId}
+          intent={intent}
+          stageRows={detail.stages}
+          workflowVersion={intent.workflowVersion ?? undefined}
+          onRelaunched={reload}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
*Issue #, if available:*  #433

This PR simplifies the intent workspace header and moves secondary configuration controls into focused dialogs.

### Changes

  - Moved scope progress below the intent title as an interactive phase breadcrumb.
  - Progress counts now reflect the stages selected by the effective scope.
  - Phases without selected stages are omitted.
  - Phase details show resolved, running, failed, and pending stages.
  - Moved environment, execution, agent, model, credentials, and source details into the **Intent configuration** dialog.
  - Added tracker source links and provider icons.
  - Added direct access from configuration to **Reshape**.
  - Moved scope reshaping into a dedicated dialog.
  - Completed, running, skipped, and earlier stages remain locked during reshaping.
  - Updated status colors and icons for waiting, running, successful, and failed states.
  - Kept the Discuss action as an icon beside the actions menu.

  This is a frontend-only change and requires no backend update.

### Screenshots

<img width="842" height="158" alt="image" src="https://github.com/user-attachments/assets/9bb9f76b-7d7a-4957-bdbb-822ed2693973" />

<img width="835" height="312" alt="image" src="https://github.com/user-attachments/assets/987c59e2-9275-4f63-b922-7ed15174920c" />

<img width="261" height="198" alt="image" src="https://github.com/user-attachments/assets/4deca54f-2438-4c36-9040-7009facfbf5b" />

<img width="691" height="677" alt="image" src="https://github.com/user-attachments/assets/31aa50ed-c38d-4efd-933b-3aab87912dbd" />

<img width="802" height="759" alt="image" src="https://github.com/user-attachments/assets/1d6e9540-6616-424f-a64c-5883719b7eae" />

Closes #433 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
