### PR TITLE
fix: simplify managed tool and environment UX

### DIFF
--- a/docs/using-the-platform/managed-environments.md
+++ b/docs/using-the-platform/managed-environments.md
@@ -97,18 +97,24 @@ environments by themselves.
 
 ### Tool-version lifecycle
 
-The version selector in **Tools** shows every version and its status:
+The **Tools** workspace shows a visual path for every selected version:
 
-| Status            | Meaning                                                                                                 | Available action                                  |
-| ----------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `DRAFT`           | Definition is editable and no build is active.                                                          | **Edit** or **Build**                             |
-| `QUEUED`          | CodeBuild has been requested.                                                                           | Wait or refresh                                   |
-| `BUILDING`        | Source import, installation, normalization, and functional checks are running.                          | Open **Build logs**                               |
-| `SCANNING`        | The immutable OCI artifact exists and ECR scan results are being evaluated.                             | Wait or refresh                                   |
-| `SECURITY_REVIEW` | Critical or High findings, or an unsupported artifact scan, require an explicit administrator decision. | **Accept Findings** or **Accept Scan Limitation** |
-| `READY`           | Source, artifact, scan decision, and verification evidence are complete.                                | **Publish**                                       |
-| `PUBLISHED`       | The immutable version can be selected by environments.                                                  | **Recommend** when it is not already recommended  |
-| `FAILED`          | Import, installation, scan processing, or verification failed.                                          | Inspect evidence, **Edit**, or **Retry**          |
+**Define -> Build -> Check -> Publish -> Recommend**
+
+The active step includes a waiting indicator while CodeBuild or ECR is still
+working. **CodeBuild logs** are available as soon as the build supplies a log
+URL, and **Open ECR** is available after the image exists.
+
+| Status            | Meaning                                                                                      | Available action                                   |
+| ----------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `DRAFT`           | Definition is editable and no build is active.                                               | Edit or start the build                            |
+| `QUEUED`          | CodeBuild has been requested.                                                                | Wait or open **CodeBuild logs**                    |
+| `BUILDING`        | Source import, installation, normalization, and functional checks are running.               | Open **CodeBuild logs**                            |
+| `SCANNING`        | The immutable OCI artifact exists and ECR scan results are being evaluated.                  | Wait or open **ECR**                               |
+| `SECURITY_REVIEW` | Critical or High findings, or a scan limitation, require an explicit administrator decision. | Review the findings or scan limitation             |
+| `READY`           | Source, artifact, scan decision, and verification evidence are complete.                     | **Publish**                                        |
+| `PUBLISHED`       | The immutable version can be selected by environments.                                       | **Make recommended** when it should be the default |
+| `FAILED`          | Import, installation, scan processing, or verification failed.                               | Inspect the error, edit, or retry                  |
 
 Refreshing the browser is not required while a build is active; the view polls
 the version until it reaches a reviewable or terminal status.
@@ -121,14 +127,21 @@ Before opening the form, identify:
 
 - An exact version.
 - An official Linux ARM64 archive URL.
-- The executable paths inside the installed tool.
-- A command that prints the version and a stable expected substring.
-- A representative functional check.
-- Any exact Debian package prerequisites.
-- Any dependency on another tool family.
-- An optional publisher checksum and public checksum-evidence URL.
+- The distribution and publisher, for example **Amazon Corretto** and
+  **Amazon Web Services**.
+- The tool type, such as **Java JDK**, **Go SDK**, or **Other CLI**.
 
-The normal import path accepts public HTTPS archives ending in:
+For the normal case, that is all the version form requires. The tool type
+supplies the executable paths, environment variables, dependencies, version
+command, and functional check. Open **Advanced options** only for an unusual
+archive layout, installer, dependency, package prerequisite, or verification
+command.
+
+The optional advanced checksum fields can record a publisher-provided checksum
+and public checksum-evidence URL. The platform always pins the downloaded
+artifact to its calculated SHA-256 even when those fields are empty.
+
+The import path accepts public HTTPS archives ending in:
 
 - `.tar.gz`
 - `.tgz`
@@ -157,29 +170,29 @@ Current import limits are:
 #### Create the family and first version
 
 1. Open **Admin -> Environments -> Tools**.
-2. Choose **Add Tool**.
+2. Choose **New tool family**.
 3. Enter a human-readable **Name**, for example `.NET SDK`.
 4. Enter or accept the stable lowercase **ID**, for example `dotnet-sdk`.
 5. Enter the **Publisher**, **Category**, and **Description**.
 6. Enter the **Exact version**.
-7. Select a **Verification** preset.
-8. Enter the **Official ARM64 archive** URL.
-9. Review the generated installation and verification defaults.
-10. Choose **Create and Build**.
+7. Select the **Tool type**.
+8. Enter the **Linux ARM64 download URL**.
+9. Choose **Create and start build**.
 
 Creating the family and creating its first version happen together. A tool
-family can later contain multiple published versions.
+family can later contain multiple published versions. For the first version,
+the family name and publisher are also used as the distribution identity.
 
 The tool ID is a durable catalog key. Do not include the version in it. Use
 `dotnet-sdk`, not `dotnet-sdk-8`. The version belongs to the tool-version
 record.
 
-#### Choose a verification preset
+#### Choose a tool type
 
-Presets fill in executable paths, environment variables, dependencies, the
-version command, and a representative build:
+Tool types fill in executable paths, environment variables, dependencies, the
+version command, and a representative functional check:
 
-| Preset          | Functional verification                                                                                |
+| Tool type       | Functional verification                                                                                |
 | --------------- | ------------------------------------------------------------------------------------------------------ |
 | **Java**        | Runs `java -version`, compiles a class with `javac`, and runs it.                                      |
 | **Go**          | Runs `go version`, builds a small Go program, and runs it.                                             |
@@ -189,7 +202,7 @@ version command, and a representative build:
 | **.NET**        | Runs `dotnet --version`, creates a console project, builds it, and runs it.                            |
 | **Generic CLI** | Runs the configured version command. Add a custom verifier when a version check alone is insufficient. |
 
-Selecting a preset is a starting point, not a bypass. Review the generated
+Selecting a tool type is a starting point, not a bypass. Review the generated
 executable paths and expected version before building.
 
 #### Publisher checksum and source trust
@@ -293,19 +306,16 @@ output. Do not include credentials or production data.
 
 #### Example: add a .NET SDK
 
-1. Choose **Add Tool**.
+1. Choose **New tool family**.
 2. Set **Name** to `.NET SDK` and **ID** to `dotnet-sdk`.
 3. Set **Publisher** to `Microsoft` and **Category** to `Language SDK`.
 4. Enter the exact SDK version.
-5. Select the **.NET** preset.
+5. Select the **.NET SDK** tool type.
 6. Enter Microsoft's official Linux ARM64 SDK archive URL.
-7. Add publisher checksum evidence when available.
-8. Confirm the preset exposes `dotnet`, sets
-   `DOTNET_ROOT=${TOOL_ROOT}`, and expects the exact SDK version.
-9. Choose **Create and Build**.
-10. Review the source, OCI artifact, scan, and console-project verification.
-11. Publish the version.
-12. Recommend it if it should be the default .NET SDK for new environment
+7. Choose **Create and start build**.
+8. Review the source, artifact, package inspection, and functional check.
+9. Publish the version.
+10. Make it recommended if it should be the default .NET SDK for new environment
     drafts.
 
 This adds .NET as a selectable tool. It does not create or publish a .NET
@@ -345,11 +355,12 @@ identity, failure detail, and CodeBuild logs.
 
 For a `FAILED` version:
 
-1. Open **Build logs** and read the failure detail shown in the version.
+1. Open **CodeBuild logs** and read the field-specific failure detail shown in
+   the version.
 2. Choose **Edit** when the archive layout, executable path, installer,
    package, variable, version command, or verifier is wrong.
-3. Choose **Save and Build** to store the corrected definition and queue a new
-   build.
+3. Choose **Save and rebuild** to store the corrected definition and queue a
+   new build.
 4. Choose **Retry** only when the definition is already correct and the failure
    was transient.
 
@@ -367,11 +378,12 @@ limitation retained as evidence.
 The administrator can:
 
 - Leave the version unpublished and remediate its source or dependencies.
-- Choose **Accept Findings** to record the identity and timestamp and move the
+- Choose **Review package findings** when Critical or High package findings
+  were detected, then explicitly continue to record the decision and move the
   version to `READY`.
-- Choose **Accept Scan Limitation** when ECR reports the artifact as
-  unsupported, after reviewing the publisher checksum, generated SBOM, and
-  networkless functional verification.
+- Choose **Continue without scan** when ECR cannot inspect the artifact format.
+  The dialog explains that this is a scanner limitation, not a detected
+  vulnerability.
 
 Acceptance does not publish the version. The findings and acceptance record
 remain visible after publication and in every environment revision that
@@ -381,10 +393,10 @@ snapshots that tool version.
 
 Publishing and recommending are separate decisions:
 
-| Action        | Effect                                                                                |
-| ------------- | ------------------------------------------------------------------------------------- |
-| **Publish**   | Makes one exact immutable version available for explicit environment selection.       |
-| **Recommend** | Makes one published version the default for new selections and dependency resolution. |
+| Action               | Effect                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| **Publish**          | Makes one exact immutable version available for explicit environment selection.       |
+| **Make recommended** | Makes one published version the default for new selections and dependency resolution. |
 
 Multiple versions of the same tool can remain published. Only one version is
 recommended.
@@ -400,23 +412,34 @@ new version:
 - Does not change an existing environment revision.
 - Does not change an active or completed intent.
 
+Choosing **Replace recommendation** directly replaces the current recommended
+version within that tool family. The existing recommendation does not need to
+be removed first.
+
 For shipped tools, publish and recommend Java before building Maven or Gradle.
 
 ### Add or update a tool version
 
-To add a newer version:
+To add a newer version or another distribution:
 
 1. Open the tool family in **Admin -> Environments -> Tools**.
-2. Choose **Add Version**.
-3. Enter the new exact version, official ARM64 archive, and verification
-   definition.
-4. Choose **Create and Build**.
-5. Review the complete evidence.
+2. Choose **Add distribution or version**.
+3. Enter the distribution, publisher, exact version, and Linux ARM64 download
+   URL. The existing family supplies the tool type.
+4. Choose **Create and start build**.
+5. Review the lifecycle and evidence.
 6. Publish the version.
-7. Choose **Recommend** only when the new version should become the default.
+7. Choose **Make recommended** or **Replace recommendation** only when the new
+   version should become the default.
 
 The prior published version remains selectable. Environments pinned to it
 remain valid.
+
+For example, add **Amazon Corretto** as another version in the existing
+**Java JDK** family. Set **Distribution** to `Amazon Corretto`, **Publisher** to
+`Amazon Web Services`, choose the exact Corretto version and archive, then
+publish and replace the Eclipse Temurin recommendation if Corretto should
+become the default. Both distributions remain selectable.
 
 To correct an unpublished version, use **Edit** while its status is `DRAFT` or
 `FAILED`. Published versions cannot be edited; create another version instead.
@@ -433,9 +456,9 @@ Tool versions are selected on an environment revision, not globally:
 6. Choose **Create Draft** or **Save as New Revision**.
 7. Build, review, and publish that environment revision.
 
-When a tool has only one published version, the editor shows its version badge
-and an include switch; there is no redundant version selector. A selector
-appears when:
+When a tool has only one published version, the editor shows its version and an
+**Add** action; there is no redundant version selector. The tool can be removed
+again before the revision is saved. A selector appears when:
 
 - More than one published version is available.
 - The base already includes the tool and a published version can override the
@@ -446,26 +469,27 @@ not a restriction. Any published version shown by the selector can be chosen.
 
 ### Create an environment
 
-Open **Admin -> Environments -> Environments** and choose **New Environment**.
+Open **Admin -> Environments -> Environments** and choose **New environment**.
 
-1. Enter a stable environment ID, name, and description.
+1. Enter a name and description. Optionally provide a stable environment ID;
+   otherwise one is generated from the name.
 2. Select a published **Base environment**. Use Standard unless the new
    environment intentionally extends another published custom environment.
 3. Review the protected Node.js and Python versions and any tools inherited
    from the base.
-4. Enable catalog tools. The initial toggle selects the recommended published
-   version.
+4. Search or browse the tool catalog and choose **Add** for each capability.
+   The recommended published version is selected initially.
 5. Use the version selector when multiple published versions exist or when
    overriding a tool inherited from the base.
-6. Review dependencies marked **Required**. They are added at their recommended
-   published versions.
-7. Add exact apt packages, non-secret environment variables, or restricted
-   single-line build commands only when the catalog tools do not cover the
-   need.
-8. Review the projected compressed size. AgentCore runtime images must remain
-   at or below `2048 MiB`.
-9. Choose **Create Draft**.
-10. Select the draft revision and choose **Build**.
+6. Review dependencies marked **Required** or **Automatic**. They are added at
+   their recommended published versions.
+7. Expand **Advanced settings** only when catalog tools do not cover the need.
+   Add exact apt packages, non-secret environment variables, or restricted
+   single-line build commands as structured rows.
+8. Review the live **Composition** summary and projected compressed size.
+   AgentCore runtime images must remain at or below `2048 MiB`.
+9. Choose **Create draft**.
+10. Open **Revisions**, select the draft revision, and choose **Build**.
 
 Environment variables and build commands cannot replace protected runtime
 behavior, inject secrets, change the runtime user, entrypoint, command, port,
@@ -501,13 +525,21 @@ and AgentCore runtime validation succeed.
 
 ### Environment-revision lifecycle
 
+The revision workspace shows the process as a visual path:
+
+**Define -> Build -> Check -> Verify -> Publish**
+
+The active Build, Check, or Verify step displays a waiting indicator.
+CodeBuild logs are shown when available, and the ECR repository is linked after
+the image has been created.
+
 | Status            | Meaning                                                          | Available action                                |
 | ----------------- | ---------------------------------------------------------------- | ----------------------------------------------- |
 | `DRAFT`           | Editable recipe snapshot, not yet built.                         | **Build**                                       |
 | `QUEUED`          | CodeBuild has been requested.                                    | Wait or refresh                                 |
-| `BUILDING`        | The composed image and local checks are running.                 | Open **Build logs**                             |
-| `SCANNING`        | ECR scan results are being evaluated.                            | Wait or refresh                                 |
-| `SECURITY_REVIEW` | Critical or High findings require a recorded decision.           | **Accept Findings & Continue**                  |
+| `BUILDING`        | The composed image and local checks are running.                 | Open **CodeBuild logs**                         |
+| `SCANNING`        | ECR scan results are being evaluated.                            | Wait or open **ECR**                            |
+| `SECURITY_REVIEW` | Critical or High findings require a recorded decision.           | **Review findings**                             |
 | `VERIFYING`       | AgentCore runtime and endpoint validation are running.           | Wait or refresh                                 |
 | `READY`           | All required checks passed or findings were explicitly accepted. | **Publish**                                     |
 | `PUBLISHED`       | This is, or was, a published immutable revision.                 | Create another revision for changes             |
@@ -547,9 +579,9 @@ revision.
 2. Recommend it when it should become the default. Affected environments show
    a recommended-tool update warning.
 3. Open the environment.
-4. Select the desired exact version in the catalog-tool list.
-5. Choose **Save as New Revision**.
-6. Build, review, and publish the new revision.
+4. Open **Definition** and select the desired exact version in the tool list.
+5. Review the composition summary and choose **Save as new revision**.
+6. Open **Revisions**, then build, review, and publish the new revision.
 
 The warning is informational. No revision changes until the administrator
 selects versions and saves a new revision.

--- a/frontend/src/components/admin/tabs/EnvironmentRegistry.tsx
+++ b/frontend/src/components/admin/tabs/EnvironmentRegistry.tsx
@@ -1,24 +1,18 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Archive, Boxes, Plus, RotateCw, Search, TriangleAlert } from 'lucide-react';
 import {
-  Archive,
-  Boxes,
-  CircleCheck,
-  ExternalLink,
-  Hammer,
-  Loader2,
-  Plus,
-  RefreshCw,
-  Rocket,
-  RotateCw,
-  Save,
-  ShieldAlert,
-  ShieldCheck,
-  TriangleAlert,
-} from 'lucide-react';
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -27,641 +21,60 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { SettingsCard } from '@/components/settings/SettingsCard';
 import {
   environmentsService,
   toolsService,
   type EnvironmentDetail,
-  type EnvironmentRecipeInput,
   type EnvironmentRevision,
-  type EnvironmentToolSnapshot,
   type ManagedEnvironment,
-  type CatalogEnvironmentRecipe,
   type ManagedTool,
-  type ManagedToolVersion,
 } from '@/services/environments';
 import { cn } from '@/lib/utils';
+import { EnvironmentBuilder } from './environment-builder/EnvironmentBuilder';
+import {
+  EnvironmentRevisionWorkspace,
+  isActiveRevision,
+} from './environment-builder/EnvironmentRevisionWorkspace';
+import {
+  emptyEnvironmentForm,
+  formFingerprint,
+  formFromRevision,
+  isCatalogRecipe,
+  recipeFromForm,
+  type EnvironmentForm,
+} from './environment-builder/model';
+import { StatusBadge, statusClass } from './environment-builder/ui';
 
-const ACTIVE_REVISION_STATUSES = new Set(['QUEUED', 'BUILDING', 'SCANNING', 'VERIFYING']);
-const RUNTIME_IMAGE_LIMIT_BYTES = 2048 * 1024 * 1024;
+type Workspace = 'definition' | 'revisions';
+type EnvironmentFilter = 'all' | 'attention' | 'drafts' | 'published' | 'retired';
 
-interface EnvironmentForm {
-  environmentId: string;
-  name: string;
+interface Confirmation {
+  title: string;
   description: string;
-  baseEnvironmentId: string;
-  toolVersionIds: string[];
-  aptPackages: string;
-  environmentVariables: string;
-  buildCommands: string;
+  actionLabel: string;
+  destructive?: boolean;
+  onConfirm: () => void;
 }
 
-const emptyForm = (): EnvironmentForm => ({
-  environmentId: '',
-  name: '',
-  description: '',
-  baseEnvironmentId: 'standard',
-  toolVersionIds: [],
-  aptPackages: '',
-  environmentVariables: '',
-  buildCommands: '',
-});
-
-const isCatalogRecipe = (
-  recipe: EnvironmentRevision['recipe'] | undefined,
-): recipe is CatalogEnvironmentRecipe => recipe?.schemaVersion === 2;
-
-const resolvedTools = (revision: EnvironmentRevision | null): EnvironmentToolSnapshot[] => {
-  const recipe = revision?.flattenedRecipe;
-  if (!isCatalogRecipe(recipe)) return [];
-  return recipe.resolvedTools ?? recipe.tools;
-};
-
-const directToolVersionIds = (revision: EnvironmentRevision | null) =>
-  isCatalogRecipe(revision?.recipe) ? revision.recipe.toolVersionIds : [];
-
-const protectedRuntimeVersions = (revision: EnvironmentRevision | null) => {
-  const recipe = revision?.flattenedRecipe;
-  if (!recipe || recipe.schemaVersion !== 1) return { node: null, python: null };
-  return {
-    node: recipe.tools.node?.version ?? null,
-    python: recipe.tools.python?.version ?? null,
-  };
-};
-
-const formFromRevision = (
-  environment: ManagedEnvironment,
-  revision: EnvironmentRevision | null,
-): EnvironmentForm => {
-  const recipe = revision?.recipe;
-  return {
-    environmentId: environment.environmentId,
-    name: environment.name,
-    description: environment.description ?? '',
-    baseEnvironmentId:
-      environment.environmentId === 'standard'
-        ? ''
-        : (recipe?.base?.environmentId ?? environment.baseEnvironmentId ?? 'standard'),
-    toolVersionIds: directToolVersionIds(revision),
-    aptPackages: (recipe?.aptPackages ?? []).map((pkg) => `${pkg.name}=${pkg.version}`).join('\n'),
-    environmentVariables: Object.entries(recipe?.environmentVariables ?? {})
-      .map(([name, value]) => `${name}=${value}`)
-      .join('\n'),
-    buildCommands: (recipe?.buildCommands ?? []).join('\n'),
-  };
-};
-
-const parsePairs = (value: string) =>
-  value
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const separator = line.indexOf('=');
-      return separator > 0
-        ? [line.slice(0, separator).trim(), line.slice(separator + 1).trim()]
-        : [line, ''];
-    });
-
-const recipeFromForm = (form: EnvironmentForm): EnvironmentRecipeInput => ({
-  schemaVersion: 2,
-  toolVersionIds: form.toolVersionIds,
-  aptPackages: parsePairs(form.aptPackages).map(([name, version]) => ({ name, version })),
-  environmentVariables: Object.fromEntries(parsePairs(form.environmentVariables)),
-  buildCommands: form.buildCommands
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean),
-});
-
-const statusClass = (status: string) => {
-  if (status === 'FAILED') return 'border-destructive/30 bg-destructive/10 text-destructive';
-  if (status === 'PUBLISHED' || status === 'READY')
-    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300';
-  if (status === 'SECURITY_REVIEW' || status === 'UPDATE_AVAILABLE')
-    return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300';
-  if (ACTIVE_REVISION_STATUSES.has(status))
-    return 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300';
-  return 'bg-muted/50 text-muted-foreground';
-};
-
-const severityClass = (severity: string) => {
-  if (severity === 'CRITICAL') return 'border-destructive/40 bg-destructive/10 text-destructive';
-  if (severity === 'HIGH')
-    return 'border-orange-500/40 bg-orange-500/10 text-orange-700 dark:text-orange-300';
-  if (severity === 'MEDIUM')
-    return 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300';
-  return 'bg-muted/50 text-muted-foreground';
-};
-
-function StatusBadge({ status }: { status: string }) {
-  return (
-    <Badge variant="outline" className={cn('font-mono text-[10px]', statusClass(status))}>
-      {status.replaceAll('_', ' ')}
-    </Badge>
-  );
-}
-
-const publishedVersions = (tool: ManagedTool) =>
-  tool.versions.filter((version) => version.status === 'PUBLISHED');
-
-const recommendedVersion = (tool: ManagedTool) =>
-  publishedVersions(tool).find((version) => version.versionId === tool.recommendedVersionId) ??
-  publishedVersions(tool)[0] ??
-  null;
-
-function RecipeEditor({
-  form,
-  onChange,
-  baseOptions,
-  baseEnvironment,
-  baseRevision,
-  baseLoading,
-  tools,
-  disabled,
-  showId,
-}: {
-  form: EnvironmentForm;
-  onChange: (next: EnvironmentForm) => void;
-  baseOptions: ManagedEnvironment[];
-  baseEnvironment: ManagedEnvironment | null;
-  baseRevision: EnvironmentRevision | null;
-  baseLoading: boolean;
-  tools: ManagedTool[];
-  disabled: boolean;
-  showId: boolean;
-}) {
-  const inherited = resolvedTools(baseRevision);
-  const protectedVersions = protectedRuntimeVersions(baseRevision);
-  const inheritedById = new Map(inherited.map((tool) => [tool.toolId, tool]));
-  const selectedVersions = new Map<string, ManagedToolVersion>();
-  for (const tool of tools) {
-    const selected = tool.versions.find((version) =>
-      form.toolVersionIds.includes(version.versionId),
+const filterEnvironment = (environment: ManagedEnvironment, filter: EnvironmentFilter) => {
+  if (filter === 'all') return true;
+  if (filter === 'attention') {
+    return (
+      environment.updateAvailable ||
+      environment.status === 'FAILED' ||
+      environment.status === 'SECURITY_REVIEW'
     );
-    if (selected) selectedVersions.set(tool.toolId, selected);
   }
-  const toolById = new Map(tools.map((tool) => [tool.toolId, tool]));
-  const effectiveSelectedVersions = new Map(selectedVersions);
-  const requiredBy = new Map<string, Set<string>>();
-  const resolving = new Set<string>();
-  const includeDependencies = (version: ManagedToolVersion) => {
-    if (resolving.has(version.toolId)) return;
-    resolving.add(version.toolId);
-    for (const dependencyId of version.definition.dependencies) {
-      if (inheritedById.has(dependencyId)) continue;
-      const owners = requiredBy.get(dependencyId) ?? new Set<string>();
-      owners.add(toolById.get(version.toolId)?.name ?? version.toolId);
-      requiredBy.set(dependencyId, owners);
-      let dependency = effectiveSelectedVersions.get(dependencyId);
-      if (!dependency) {
-        const family = toolById.get(dependencyId);
-        dependency = family ? (recommendedVersion(family) ?? undefined) : undefined;
-        if (dependency) effectiveSelectedVersions.set(dependencyId, dependency);
-      }
-      if (dependency) includeDependencies(dependency);
-    }
-    resolving.delete(version.toolId);
-  };
-  for (const version of selectedVersions.values()) includeDependencies(version);
-
-  const selectedSize = [...effectiveSelectedVersions.values()].reduce(
-    (total, version) => total + Number(version.imageSizeBytes ?? 0),
-    0,
-  );
-  const sizesKnown =
-    Number(baseRevision?.imageSizeBytes ?? 0) > 0 &&
-    [...effectiveSelectedVersions.values()].every(
-      (version) => Number(version.imageSizeBytes ?? 0) > 0,
+  if (filter === 'drafts') {
+    return ['DRAFT', 'BUILDING', 'SECURITY_REVIEW', 'VERIFYING', 'READY', 'FAILED'].includes(
+      environment.status,
     );
-  const projectedSize = sizesKnown
-    ? Number(baseRevision?.imageSizeBytes ?? 0) + selectedSize
-    : null;
-
-  const setVersion = (tool: ManagedTool, versionId: string | null) => {
-    const familyVersionIds = new Set(tool.versions.map((version) => version.versionId));
-    const remaining = form.toolVersionIds.filter((id) => !familyVersionIds.has(id));
-    onChange({
-      ...form,
-      toolVersionIds: versionId ? [...remaining, versionId] : remaining,
-    });
-  };
-
-  return (
-    <div className="space-y-5">
-      <div className="grid gap-3 sm:grid-cols-2">
-        {showId && (
-          <div className="space-y-1.5">
-            <Label htmlFor="environment-id" className="text-xs">
-              ID
-            </Label>
-            <Input
-              id="environment-id"
-              value={form.environmentId}
-              onChange={(event) => onChange({ ...form, environmentId: event.target.value })}
-              placeholder="generated-from-name"
-              disabled={disabled}
-              className="h-9 font-mono text-sm"
-            />
-          </div>
-        )}
-        <div className="space-y-1.5">
-          <Label htmlFor="environment-name" className="text-xs">
-            Name
-          </Label>
-          <Input
-            id="environment-name"
-            value={form.name}
-            onChange={(event) => onChange({ ...form, name: event.target.value })}
-            disabled={disabled}
-            className="h-9 text-sm"
-          />
-        </div>
-        <div className="space-y-1.5 sm:col-span-2">
-          <Label htmlFor="environment-description" className="text-xs">
-            Description
-          </Label>
-          <Input
-            id="environment-description"
-            value={form.description}
-            onChange={(event) => onChange({ ...form, description: event.target.value })}
-            disabled={disabled}
-            className="h-9 text-sm"
-          />
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="environment-base" className="text-xs">
-          Base environment
-        </Label>
-        <Select
-          value={form.baseEnvironmentId}
-          onValueChange={(baseEnvironmentId) =>
-            onChange({ ...form, baseEnvironmentId, toolVersionIds: [] })
-          }
-          disabled={disabled}
-        >
-          <SelectTrigger id="environment-base" className="h-9 text-sm">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {baseOptions.map((environment) => (
-              <SelectItem key={environment.environmentId} value={environment.environmentId}>
-                {environment.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {baseLoading ? (
-          <Skeleton className="h-14" />
-        ) : baseRevision ? (
-          <div className="border-l-2 border-primary/30 pl-3">
-            <p className="text-[11px] text-muted-foreground">
-              Inherits protected Node.js and Python plus tools in{' '}
-              <span className="font-medium text-foreground">
-                {baseEnvironment?.name ?? 'the base'}
-              </span>
-              .
-            </p>
-            <div className="mt-1.5 flex flex-wrap gap-1.5">
-              <Badge variant="outline" className="text-[10px]">
-                Node.js{protectedVersions.node ? ` ${protectedVersions.node}` : ''}
-              </Badge>
-              <Badge variant="outline" className="text-[10px]">
-                Python{protectedVersions.python ? ` ${protectedVersions.python}` : ''}
-              </Badge>
-              {inherited.map((tool) => (
-                <Badge key={tool.toolId} variant="outline" className="text-[10px]">
-                  {tool.name} {tool.version}
-                </Badge>
-              ))}
-            </div>
-          </div>
-        ) : (
-          <p className="text-[11px] text-destructive">Published base revision unavailable</p>
-        )}
-      </div>
-
-      <div className="space-y-2">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <h4 className="text-xs font-medium">Catalog tools</h4>
-          {projectedSize ? (
-            <Badge
-              variant="outline"
-              className={cn(
-                'font-mono text-[10px]',
-                projectedSize > RUNTIME_IMAGE_LIMIT_BYTES && statusClass('FAILED'),
-              )}
-            >
-              Projected {(projectedSize / 1024 / 1024).toFixed(0)} / 2048 MiB
-            </Badge>
-          ) : (
-            <span className="text-[11px] text-muted-foreground">
-              Size available after artifacts are built
-            </span>
-          )}
-        </div>
-        <div className="divide-y rounded border">
-          {tools.map((tool) => {
-            const versions = publishedVersions(tool);
-            const inheritedTool = inheritedById.get(tool.toolId) ?? null;
-            const selected = selectedVersions.get(tool.toolId) ?? null;
-            const effective = effectiveSelectedVersions.get(tool.toolId) ?? null;
-            const required = requiredBy.has(tool.toolId) && !inheritedTool;
-            const enabled = Boolean(effective);
-            const recommended = recommendedVersion(tool);
-            const showVersionSelect =
-              Boolean(inheritedTool && versions.length) ||
-              Boolean(effective && versions.length > 1);
-            return (
-              <div
-                key={tool.toolId}
-                className="grid min-h-20 gap-3 p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
-              >
-                <div className="min-w-0 space-y-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-xs font-medium">{tool.name}</span>
-                    <Badge variant="outline" className="font-mono text-[10px]">
-                      {effective?.definition.version ??
-                        inheritedTool?.version ??
-                        recommended?.definition.version ??
-                        'Unavailable'}
-                    </Badge>
-                    {effective?.versionId === tool.recommendedVersionId && (
-                      <Badge variant="secondary" className="text-[10px]">
-                        Recommended
-                      </Badge>
-                    )}
-                  </div>
-                  <p className="text-[11px] text-muted-foreground">
-                    {selected
-                      ? `Added by this environment · ${selected.source?.trustLevel === 'PUBLISHER_VERIFIED' ? 'publisher verified' : 'platform pinned'}`
-                      : required
-                        ? `Added automatically for ${[...(requiredBy.get(tool.toolId) ?? [])].join(', ')}`
-                        : inheritedTool
-                          ? `Inherited from ${baseEnvironment?.name ?? 'base environment'}`
-                          : versions.length
-                            ? tool.description
-                            : 'No published version'}
-                  </p>
-                  {(effective?.definition.dependencies.length ?? 0) > 0 && (
-                    <p className="text-[11px] text-muted-foreground">
-                      Requires {effective?.definition.dependencies.join(', ')}; missing dependencies
-                      are added at their recommended version.
-                    </p>
-                  )}
-                </div>
-                <div className="flex items-center justify-end gap-2">
-                  {showVersionSelect && (
-                    <Select
-                      value={effective?.versionId ?? 'inherit'}
-                      disabled={disabled}
-                      onValueChange={(value) =>
-                        setVersion(tool, value === 'inherit' ? null : value)
-                      }
-                    >
-                      <SelectTrigger
-                        aria-label={`${tool.name} version`}
-                        className="h-8 w-52 text-xs"
-                      >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {inheritedTool && (
-                          <SelectItem value="inherit">Base · {inheritedTool.version}</SelectItem>
-                        )}
-                        {versions.map((version) => (
-                          <SelectItem key={version.versionId} value={version.versionId}>
-                            {version.definition.version}
-                            {version.versionId === tool.recommendedVersionId
-                              ? ' · recommended'
-                              : ''}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  )}
-                  {!inheritedTool && !required && (
-                    <Switch
-                      aria-label={`Include ${tool.name}`}
-                      checked={enabled}
-                      disabled={disabled || !recommended}
-                      onCheckedChange={(checked) =>
-                        setVersion(tool, checked ? (recommended?.versionId ?? null) : null)
-                      }
-                    />
-                  )}
-                  {required && (
-                    <Badge variant="secondary" className="text-[10px]">
-                      Required
-                    </Badge>
-                  )}
-                  {inheritedTool && !showVersionSelect && (
-                    <Badge variant="secondary" className="text-[10px]">
-                      Included
-                    </Badge>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-          {tools.length === 0 && (
-            <div className="p-3 text-xs text-muted-foreground">
-              Publish a tool version before composing an environment.
-            </div>
-          )}
-        </div>
-        {projectedSize && projectedSize > RUNTIME_IMAGE_LIMIT_BYTES && (
-          <p className="flex items-start gap-1.5 text-xs text-destructive">
-            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            This composition exceeds the AgentCore runtime image limit.
-          </p>
-        )}
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-3">
-        <div className="space-y-1.5">
-          <Label htmlFor="environment-apt" className="text-xs">
-            Additional apt packages
-          </Label>
-          <Textarea
-            id="environment-apt"
-            value={form.aptPackages}
-            onChange={(event) => onChange({ ...form, aptPackages: event.target.value })}
-            placeholder="package=exact-version"
-            disabled={disabled}
-            className="min-h-28 font-mono text-xs"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="environment-variables" className="text-xs">
-            Environment variables
-          </Label>
-          <Textarea
-            id="environment-variables"
-            value={form.environmentVariables}
-            onChange={(event) => onChange({ ...form, environmentVariables: event.target.value })}
-            placeholder="NAME=value"
-            disabled={disabled}
-            className="min-h-28 font-mono text-xs"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="environment-commands" className="text-xs">
-            Build commands
-          </Label>
-          <Textarea
-            id="environment-commands"
-            value={form.buildCommands}
-            onChange={(event) => onChange({ ...form, buildCommands: event.target.value })}
-            placeholder="command"
-            disabled={disabled}
-            className="min-h-28 font-mono text-xs"
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const securityFindingsAcceptedAt = (revision: EnvironmentRevision) =>
-  revision.securityFindingsAcceptedAt ?? revision.highFindingsAcknowledgedAt ?? null;
-const securityFindingsAcceptedBy = (revision: EnvironmentRevision) =>
-  revision.securityFindingsAcceptedBy ?? revision.highFindingsAcknowledgedBy ?? null;
-const isActiveRevision = (revision: EnvironmentRevision) =>
-  ACTIVE_REVISION_STATUSES.has(revision.status) ||
-  (revision.status === 'SECURITY_REVIEW' && Boolean(securityFindingsAcceptedAt(revision)));
-
-function Evidence({ revision }: { revision: EnvironmentRevision }) {
-  const findings = revision.scanFindings?.findings ?? [];
-  const acceptedAt = securityFindingsAcceptedAt(revision);
-  const acceptedBy = securityFindingsAcceptedBy(revision);
-  const critical = Number(revision.scanFindings?.severityCounts?.CRITICAL ?? 0);
-  const high = Number(revision.scanFindings?.severityCounts?.HIGH ?? 0);
-  const securityOnlyFailure =
-    revision.failure?.reason === 'critical_vulnerability_findings' && Boolean(revision.imageDigest);
-  return (
-    <div className="space-y-4 border-t pt-4">
-      <div className="grid gap-4 lg:grid-cols-3">
-        <div className="space-y-2">
-          <h4 className="text-xs font-medium">Image</h4>
-          {revision.imageDigest ? (
-            <Badge
-              variant="outline"
-              className="gap-1 border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-            >
-              <CircleCheck className="h-3 w-3" />
-              Build passed
-            </Badge>
-          ) : (
-            <span className="text-[11px] text-muted-foreground">Not built</span>
-          )}
-          <p className="break-all font-mono text-[11px] text-muted-foreground">
-            {revision.imageDigest ?? 'No image digest'}
-          </p>
-          {revision.imageSizeBytes && (
-            <p className="font-mono text-[11px] text-muted-foreground">
-              {(revision.imageSizeBytes / 1024 / 1024).toFixed(1)} MiB
-            </p>
-          )}
-          {revision.buildLogUrl && (
-            <a
-              href={revision.buildLogUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
-            >
-              Build logs <ExternalLink className="h-3 w-3" />
-            </a>
-          )}
-        </div>
-        <div className="space-y-2">
-          <h4 className="text-xs font-medium">Security scan</h4>
-          <Badge
-            variant="outline"
-            className={cn(
-              acceptedAt || critical + high > 0
-                ? statusClass('SECURITY_REVIEW')
-                : revision.scanFindings
-                  ? statusClass('READY')
-                  : '',
-            )}
-          >
-            {acceptedAt
-              ? 'Findings accepted'
-              : critical + high > 0
-                ? 'Review required'
-                : revision.scanFindings
-                  ? 'Passed'
-                  : 'Pending'}
-          </Badge>
-          {acceptedAt && (
-            <p className="text-[11px] text-muted-foreground">
-              Accepted{acceptedBy ? ` by ${acceptedBy}` : ''}{' '}
-              <time dateTime={acceptedAt}>{new Date(acceptedAt).toLocaleString()}</time>
-            </p>
-          )}
-        </div>
-        <div className="space-y-2">
-          <h4 className="text-xs font-medium">Runtime validation</h4>
-          <p className="text-[11px] text-muted-foreground">
-            {revision.verification ? 'Recorded with this revision' : 'Not completed'}
-          </p>
-        </div>
-      </div>
-      {findings.length > 0 && (
-        <div className="divide-y overflow-hidden rounded border">
-          {findings.map((finding, index) => (
-            <div
-              key={`${finding.id}-${index}`}
-              className="grid gap-2 px-3 py-2 sm:grid-cols-[90px_minmax(0,1fr)_auto]"
-            >
-              <Badge
-                variant="outline"
-                className={cn('w-fit font-mono text-[10px]', severityClass(finding.severity))}
-              >
-                {finding.severity}
-              </Badge>
-              {finding.uri ? (
-                <a
-                  href={finding.uri}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="truncate font-mono text-[11px] text-primary hover:underline"
-                >
-                  {finding.id}
-                </a>
-              ) : (
-                <span className="truncate font-mono text-[11px]">{finding.id}</span>
-              )}
-              <span className="font-mono text-[11px] text-muted-foreground">
-                {finding.packageName ?? 'Unknown package'}
-                {finding.packageVersion ? ` ${finding.packageVersion}` : ''}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
-      {revision.failure && !securityOnlyFailure && (
-        <div className="border-l-2 border-destructive/60 pl-3 text-xs text-destructive">
-          <div className="font-medium">{revision.failure.reason ?? 'Build failed'}</div>
-          {revision.failure.detail && <div className="mt-1">{revision.failure.detail}</div>}
-        </div>
-      )}
-      {revision.generatedDockerfile && (
-        <div className="space-y-2">
-          <h4 className="text-xs font-medium">Generated Dockerfile</h4>
-          <pre className="max-h-96 overflow-auto rounded border bg-muted/30 p-3 font-mono text-[11px] leading-relaxed">
-            {revision.generatedDockerfile}
-          </pre>
-        </div>
-      )}
-    </div>
-  );
-}
+  }
+  if (filter === 'published') return environment.status === 'PUBLISHED';
+  return environment.status === 'RETIRED';
+};
 
 export function EnvironmentRegistry() {
   const [environments, setEnvironments] = useState<ManagedEnvironment[]>([]);
@@ -670,13 +83,26 @@ export function EnvironmentRegistry() {
   const [detail, setDetail] = useState<EnvironmentDetail | null>(null);
   const [baseDetail, setBaseDetail] = useState<EnvironmentDetail | null>(null);
   const [selectedRevisionId, setSelectedRevisionId] = useState<string | null>(null);
-  const [form, setForm] = useState<EnvironmentForm>(emptyForm);
+  const [form, setForm] = useState<EnvironmentForm>(emptyEnvironmentForm);
+  const [savedFormFingerprint, setSavedFormFingerprint] = useState(() =>
+    formFingerprint(emptyEnvironmentForm()),
+  );
   const [creating, setCreating] = useState(false);
+  const [workspace, setWorkspace] = useState<Workspace>('definition');
   const [loading, setLoading] = useState(true);
   const [detailLoading, setDetailLoading] = useState(false);
   const [baseLoading, setBaseLoading] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState<EnvironmentFilter>('all');
+  const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
+  const loadedEnvironmentId = useRef<string | null>(null);
+
+  const setFormAndBaseline = useCallback((next: EnvironmentForm) => {
+    setForm(next);
+    setSavedFormFingerprint(formFingerprint(next));
+  }, []);
 
   const loadList = useCallback(async (preferredId?: string) => {
     const values = await environmentsService.list();
@@ -690,29 +116,48 @@ export function EnvironmentRegistry() {
     return values;
   }, []);
 
-  const loadDetail = useCallback(async (environmentId: string, showLoading = true) => {
-    if (showLoading) setDetailLoading(true);
-    try {
-      const value = await environmentsService.get(environmentId);
-      setDetail(value);
-      const current =
-        value.revisions.find(
-          (revision) => revision.revisionId === value.environment.currentRevisionId,
-        ) ??
-        value.publishedRevision ??
-        value.revisions[0] ??
-        null;
-      setSelectedRevisionId((selected) =>
-        selected && value.revisions.some((revision) => revision.revisionId === selected)
-          ? selected
-          : (current?.revisionId ?? null),
-      );
-      setForm(formFromRevision(value.environment, current));
-      return value;
-    } finally {
-      if (showLoading) setDetailLoading(false);
-    }
-  }, []);
+  const loadDetail = useCallback(
+    async (
+      environmentId: string,
+      options: { showLoading?: boolean; preferCurrent?: boolean; preserveForm?: boolean } = {},
+    ) => {
+      const { showLoading = true, preferCurrent = false, preserveForm = false } = options;
+      if (showLoading) setDetailLoading(true);
+      try {
+        const value = await environmentsService.get(environmentId);
+        const current =
+          value.revisions.find(
+            (revision) => revision.revisionId === value.environment.currentRevisionId,
+          ) ??
+          value.publishedRevision ??
+          value.revisions[0] ??
+          null;
+        if (loadedEnvironmentId.current !== value.environment.environmentId) {
+          const definitionAvailable =
+            value.environment.environmentId !== 'standard' &&
+            Boolean(current) &&
+            isCatalogRecipe(current?.recipe);
+          setWorkspace(
+            definitionAvailable && current?.status === 'DRAFT' ? 'definition' : 'revisions',
+          );
+          loadedEnvironmentId.current = value.environment.environmentId;
+        }
+        setDetail(value);
+        setSelectedRevisionId((selected) =>
+          preferCurrent
+            ? (current?.revisionId ?? null)
+            : selected && value.revisions.some((revision) => revision.revisionId === selected)
+              ? selected
+              : (current?.revisionId ?? null),
+        );
+        if (!preserveForm) setFormAndBaseline(formFromRevision(value.environment, current));
+        return value;
+      } finally {
+        if (showLoading) setDetailLoading(false);
+      }
+    },
+    [setFormAndBaseline],
+  );
 
   useEffect(() => {
     Promise.all([loadList(), toolsService.list(true)])
@@ -761,6 +206,22 @@ export function EnvironmentRegistry() {
     () => detail?.revisions.find((revision) => revision.revisionId === selectedRevisionId) ?? null,
     [detail, selectedRevisionId],
   );
+  const isDirty = formFingerprint(form) !== savedFormFingerprint;
+
+  useEffect(() => {
+    if (!selectedId || !selectedRevision || !isActiveRevision(selectedRevision)) return;
+    const timer = window.setInterval(() => {
+      void Promise.all([
+        loadDetail(selectedId, {
+          showLoading: false,
+          preserveForm: isDirty,
+        }),
+        loadList(selectedId),
+      ]).catch(() => undefined);
+    }, 8000);
+    return () => window.clearInterval(timer);
+  }, [isDirty, loadDetail, loadList, selectedId, selectedRevision]);
+
   const currentRevision =
     detail?.revisions.find(
       (revision) => revision.revisionId === detail.environment.currentRevisionId,
@@ -769,16 +230,8 @@ export function EnvironmentRegistry() {
     detail?.environment.environmentId !== 'standard' &&
     Boolean(currentRevision) &&
     !isCatalogRecipe(currentRevision?.recipe);
-
-  useEffect(() => {
-    if (!selectedId || !selectedRevision || !isActiveRevision(selectedRevision)) return;
-    const timer = window.setInterval(() => {
-      void Promise.all([loadDetail(selectedId, false), loadList(selectedId)]).catch(
-        () => undefined,
-      );
-    }, 8000);
-    return () => window.clearInterval(timer);
-  }, [loadDetail, loadList, selectedId, selectedRevision]);
+  const definitionAvailable =
+    detail?.environment.environmentId !== 'standard' && !fixedToolEnvironment;
 
   const baseOptions = environments.filter(
     (environment) =>
@@ -795,13 +248,30 @@ export function EnvironmentRegistry() {
     null;
   const baseRevision = activeBaseDetail?.publishedRevision ?? null;
 
-  const run = async (name: string, action: () => Promise<unknown>, preferredId = selectedId) => {
+  const filteredEnvironments = environments.filter((environment) => {
+    const query = search.trim().toLowerCase();
+    return (
+      filterEnvironment(environment, filter) &&
+      (!query ||
+        environment.name.toLowerCase().includes(query) ||
+        environment.environmentId.toLowerCase().includes(query) ||
+        environment.description.toLowerCase().includes(query))
+    );
+  });
+
+  const run = async (
+    name: string,
+    action: () => Promise<unknown>,
+    preferredId = selectedId,
+    preferCurrent = false,
+    preserveForm = false,
+  ) => {
     setBusy(name);
     setError(null);
     try {
       await action();
       await loadList(preferredId ?? undefined);
-      if (preferredId) await loadDetail(preferredId);
+      if (preferredId) await loadDetail(preferredId, { preferCurrent, preserveForm });
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : 'Environment action failed');
     } finally {
@@ -823,7 +293,8 @@ export function EnvironmentRegistry() {
       setCreating(false);
       setSelectedId(result.environment.environmentId);
       await loadList(result.environment.environmentId);
-      await loadDetail(result.environment.environmentId);
+      await loadDetail(result.environment.environmentId, { preferCurrent: true });
+      setWorkspace('revisions');
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : 'Environment action failed');
     } finally {
@@ -831,351 +302,439 @@ export function EnvironmentRegistry() {
     }
   };
 
+  const requestDiscard = (action: () => void) => {
+    if (!isDirty) {
+      action();
+      return;
+    }
+    setConfirmation({
+      title: 'Discard unsaved changes?',
+      description:
+        'The environment definition has changes that have not been saved as a new revision.',
+      actionLabel: 'Discard changes',
+      destructive: true,
+      onConfirm: action,
+    });
+  };
+
+  const startCreating = () => {
+    const next = emptyEnvironmentForm();
+    setCreating(true);
+    setDetail(null);
+    loadedEnvironmentId.current = null;
+    setWorkspace('definition');
+    setFormAndBaseline(next);
+    setError(null);
+  };
+
+  const selectEnvironment = (environmentId: string) => {
+    if (!creating && selectedId === environmentId) return;
+    requestDiscard(() => {
+      setCreating(false);
+      setDetail(null);
+      setSelectedId(environmentId);
+      setError(null);
+    });
+  };
+
+  const requestRetire = (environment: ManagedEnvironment) =>
+    setConfirmation({
+      title: `Retire ${environment.name}?`,
+      description:
+        'Retired environments cannot be changed or assigned to new spaces. Existing intent snapshots remain available.',
+      actionLabel: 'Retire environment',
+      destructive: true,
+      onConfirm: () =>
+        void run('retire', () => environmentsService.retire(environment.environmentId)),
+    });
+
+  const requestAcceptFindings = (
+    environment: ManagedEnvironment,
+    revision: EnvironmentRevision,
+    critical: number,
+    high: number,
+  ) =>
+    setConfirmation({
+      title: 'Accept security findings?',
+      description: `Accept ${critical} Critical and ${high} High security findings and continue to runtime validation? The findings remain visible after publication.`,
+      actionLabel: 'Accept and continue',
+      onConfirm: () =>
+        void run(
+          'accept-findings',
+          () => environmentsService.acceptFindings(environment.environmentId, revision.revisionId),
+          environment.environmentId,
+          false,
+          isDirty,
+        ),
+    });
+
   const environment = detail?.environment ?? null;
-  const findingsAcceptedAt = selectedRevision ? securityFindingsAcceptedAt(selectedRevision) : null;
-  const legacySecurityFailure =
-    selectedRevision?.status === 'FAILED' &&
-    selectedRevision.failure?.reason === 'critical_vulnerability_findings' &&
-    Boolean(selectedRevision.imageDigest);
-  const requiresSecurityAcceptance =
-    Boolean(selectedRevision) &&
-    !findingsAcceptedAt &&
-    (selectedRevision?.status === 'SECURITY_REVIEW' || legacySecurityFailure);
-  const selectedCriticalFindings = Number(
-    selectedRevision?.scanFindings?.severityCounts?.CRITICAL ?? 0,
-  );
-  const selectedHighFindings = Number(selectedRevision?.scanFindings?.severityCounts?.HIGH ?? 0);
+  const revisionWorkspace =
+    environment && detail ? (
+      <EnvironmentRevisionWorkspace
+        environment={environment}
+        detail={detail}
+        selectedRevisionId={selectedRevisionId}
+        onSelectRevision={setSelectedRevisionId}
+        busy={busy}
+        onRefresh={() => void loadDetail(environment.environmentId, { preserveForm: isDirty })}
+        onRun={(name, action) => void run(name, action, environment.environmentId, false, isDirty)}
+        onRequestAccept={(revision, critical, high) =>
+          requestAcceptFindings(environment, revision, critical, high)
+        }
+      />
+    ) : null;
 
   return (
-    <SettingsCard
-      icon={<Boxes />}
-      title="Managed Environments"
-      badge={
-        updates.length ? (
-          <Badge variant="outline" className={statusClass('UPDATE_AVAILABLE')}>
-            {updates.length} update{updates.length === 1 ? '' : 's'}
-          </Badge>
-        ) : null
-      }
-      description="Compose published tools into versioned AgentCore runtimes."
-      headerAction={
-        <Button
-          size="sm"
-          className="gap-1.5"
-          disabled={Boolean(busy)}
-          onClick={() => {
-            setCreating(true);
-            setDetail(null);
-            setForm(emptyForm());
-            setError(null);
-          }}
-        >
-          <Plus className="h-3.5 w-3.5" />
-          New
-        </Button>
-      }
-    >
-      {loading ? (
-        <div className="grid gap-4 lg:grid-cols-[230px_minmax(0,1fr)]">
-          <Skeleton className="h-72" />
-          <Skeleton className="h-96" />
-        </div>
-      ) : (
-        <div className="grid min-w-0 gap-5 lg:grid-cols-[230px_minmax(0,1fr)]">
-          <div className="space-y-1 border-r pr-4">
-            {environments.map((item) => (
-              <button
-                key={item.environmentId}
-                type="button"
-                className={cn(
-                  'flex w-full items-start justify-between gap-2 rounded px-2.5 py-2 text-left hover:bg-muted/60',
-                  !creating && selectedId === item.environmentId && 'bg-muted',
-                )}
-                onClick={() => {
-                  setCreating(false);
-                  setSelectedId(item.environmentId);
-                }}
-              >
-                <span className="min-w-0">
-                  <span className="block truncate text-xs font-medium">{item.name}</span>
-                  <span className="block truncate font-mono text-[10px] text-muted-foreground">
-                    {item.environmentId}
-                  </span>
-                </span>
-                {item.updateAvailable ? (
-                  <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600" />
-                ) : (
-                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
-                )}
-              </button>
-            ))}
+    <>
+      <SettingsCard
+        icon={<Boxes />}
+        title="Managed Environments"
+        badge={
+          updates.length ? (
+            <Badge variant="outline" className={statusClass('UPDATE_AVAILABLE')}>
+              {updates.length} update{updates.length === 1 ? '' : 's'}
+            </Badge>
+          ) : null
+        }
+        description="Define reusable toolchains, then build and publish immutable runtime revisions."
+        headerAction={
+          <Button
+            size="sm"
+            className="gap-1.5"
+            disabled={Boolean(busy)}
+            onClick={() => requestDiscard(startCreating)}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New environment
+          </Button>
+        }
+      >
+        {error && (
+          <div className="mb-4 flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+            <TriangleAlert className="mt-px h-3.5 w-3.5 shrink-0" />
+            <span>{error}</span>
           </div>
+        )}
 
-          <div className="min-w-0 space-y-5">
-            {creating ? (
-              <>
-                <div className="flex items-center justify-between gap-3">
-                  <h3 className="text-sm font-semibold">New Environment</h3>
-                  <Button variant="ghost" size="sm" onClick={() => setCreating(false)}>
-                    Cancel
-                  </Button>
+        {loading ? (
+          <div className="grid gap-4 lg:grid-cols-[250px_minmax(0,1fr)]">
+            <Skeleton className="h-[520px]" />
+            <Skeleton className="h-[620px]" />
+          </div>
+        ) : (
+          <div className="grid min-w-0 gap-5 lg:grid-cols-[250px_minmax(0,1fr)]">
+            <aside className="self-start rounded-xl border bg-muted/10 p-2 lg:sticky lg:top-0">
+              <div className="space-y-2 p-1">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                  <Input
+                    aria-label="Search environments"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search environments"
+                    className="h-9 bg-background pl-8 text-xs"
+                  />
                 </div>
-                <RecipeEditor
-                  form={form}
-                  onChange={setForm}
-                  baseOptions={baseOptions}
-                  baseEnvironment={baseEnvironment}
-                  baseRevision={baseRevision}
-                  baseLoading={baseLoading}
-                  tools={tools}
-                  disabled={Boolean(busy)}
-                  showId
-                />
-                <Button
-                  size="sm"
-                  className="gap-1.5"
-                  disabled={
-                    Boolean(busy) ||
-                    baseLoading ||
-                    !baseRevision ||
-                    !form.name.trim() ||
-                    !form.baseEnvironmentId
-                  }
-                  onClick={() => void createEnvironment()}
+                <Select
+                  value={filter}
+                  onValueChange={(value) => setFilter(value as EnvironmentFilter)}
                 >
-                  {busy === 'create' ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Save className="h-3.5 w-3.5" />
-                  )}
-                  Create Draft
-                </Button>
-              </>
-            ) : detailLoading || !environment ? (
-              <Skeleton className="h-96" />
-            ) : (
-              <>
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-sm font-semibold">{environment.name}</h3>
-                      <StatusBadge status={environment.status} />
+                  <SelectTrigger
+                    aria-label="Filter environments"
+                    className="h-8 bg-background text-xs"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All environments</SelectItem>
+                    <SelectItem value="attention">Needs attention</SelectItem>
+                    <SelectItem value="drafts">In progress</SelectItem>
+                    <SelectItem value="published">Published</SelectItem>
+                    <SelectItem value="retired">Retired</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="mt-1 max-h-[680px] space-y-1 overflow-y-auto">
+                {creating && (
+                  <div className="rounded-lg border border-primary/30 bg-primary/5 px-3 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <Plus className="h-3.5 w-3.5 text-primary" />
+                      <span className="text-xs font-semibold">New environment</span>
                     </div>
-                    <p className="mt-1 font-mono text-[11px] text-muted-foreground">
-                      {environment.environmentId}
-                    </p>
-                    {(environment.toolUpdates?.length ?? 0) > 0 && (
-                      <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
-                        Recommended tool updates are available. Save a new revision to select them.
-                      </p>
-                    )}
-                    {fixedToolEnvironment && (
-                      <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
-                        This fixed-tool environment is read-only. Retire it, then create a new
-                        environment from published catalog tools.
-                      </p>
-                    )}
+                    <p className="mt-1 text-[10px] text-muted-foreground">Unsaved definition</p>
                   </div>
-                  <div className="flex flex-wrap gap-2">
-                    {environment.updateAvailable &&
-                      environment.baseEnvironmentId &&
-                      !(environment.toolUpdates?.length ?? 0) && (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="gap-1.5"
-                          disabled={Boolean(busy)}
-                          onClick={() =>
-                            void run('rebuild', () =>
-                              environmentsService.rebuild(environment.environmentId),
-                            )
-                          }
-                        >
-                          <RotateCw className="h-3.5 w-3.5" />
-                          Rebuild on Latest Base
-                        </Button>
-                      )}
-                    {environment.environmentId !== 'standard' && (
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        className="gap-1.5 text-destructive"
-                        disabled={Boolean(busy)}
-                        onClick={() => {
-                          if (window.confirm(`Retire ${environment.name}?`)) {
-                            void run('retire', () =>
-                              environmentsService.retire(environment.environmentId),
-                            );
-                          }
-                        }}
-                      >
-                        <Archive className="h-3.5 w-3.5" />
-                        Retire
-                      </Button>
+                )}
+                {filteredEnvironments.map((item) => (
+                  <button
+                    key={item.environmentId}
+                    type="button"
+                    className={cn(
+                      'w-full rounded-lg border border-transparent px-3 py-2.5 text-left transition-colors hover:bg-muted/60',
+                      !creating &&
+                        selectedId === item.environmentId &&
+                        'border-border bg-background shadow-sm',
                     )}
-                  </div>
-                </div>
-
-                <div className="flex flex-wrap items-center gap-2 border-y py-3">
-                  <Select
-                    value={selectedRevisionId ?? undefined}
-                    onValueChange={setSelectedRevisionId}
+                    aria-pressed={!creating && selectedId === item.environmentId}
+                    onClick={() => selectEnvironment(item.environmentId)}
                   >
-                    <SelectTrigger aria-label="Revision" className="h-8 w-64 font-mono text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {detail?.revisions.map((revision) => (
-                        <SelectItem key={revision.revisionId} value={revision.revisionId}>
-                          {revision.revisionId} · {revision.status}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {selectedRevision && <StatusBadge status={selectedRevision.status} />}
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8"
-                    title="Refresh"
-                    onClick={() => void loadDetail(environment.environmentId)}
-                  >
-                    <RefreshCw className="h-3.5 w-3.5" />
-                  </Button>
-                  <div className="ml-auto flex flex-wrap gap-2">
-                    {selectedRevision?.status === 'DRAFT' &&
-                      !environment.updateAvailable &&
-                      isCatalogRecipe(selectedRevision.recipe) && (
-                        <Button
-                          size="sm"
-                          onClick={() =>
-                            void run('build', () =>
-                              environmentsService.build(
-                                environment.environmentId,
-                                selectedRevision.revisionId,
-                              ),
-                            )
-                          }
-                        >
-                          <Hammer className="h-3.5 w-3.5" />
-                          Build
-                        </Button>
+                    <div className="flex items-start justify-between gap-2">
+                      <span className="min-w-0">
+                        <span className="block truncate text-xs font-semibold">{item.name}</span>
+                        <span className="mt-0.5 block truncate font-mono text-[9px] text-muted-foreground">
+                          {item.environmentId}
+                        </span>
+                      </span>
+                      {item.updateAvailable ? (
+                        <span className="mt-0.5 shrink-0 text-amber-600">
+                          <TriangleAlert className="h-3.5 w-3.5" />
+                          <span className="sr-only">Update available</span>
+                        </span>
+                      ) : (
+                        <StatusBadge
+                          status={item.status}
+                          className="shrink-0 px-1.5 py-0 text-[8px]"
+                        />
                       )}
-                    {selectedRevision?.status === 'FAILED' &&
-                      !environment.updateAvailable &&
-                      isCatalogRecipe(selectedRevision.recipe) && (
-                        <Button
-                          size="sm"
-                          onClick={() =>
-                            void run('retry', () =>
-                              environmentsService.retry(
-                                environment.environmentId,
-                                selectedRevision.revisionId,
-                              ),
-                            )
-                          }
-                        >
-                          <RotateCw className="h-3.5 w-3.5" />
-                          Retry
-                        </Button>
-                      )}
-                    {requiresSecurityAcceptance && selectedRevision && (
-                      <Button
-                        size="sm"
-                        onClick={() => {
-                          if (
-                            window.confirm(
-                              `Accept ${selectedCriticalFindings} Critical and ${selectedHighFindings} High security findings and continue to runtime validation? The findings will remain visible after publication.`,
-                            )
-                          ) {
-                            void run('accept-findings', () =>
-                              environmentsService.acceptFindings(
-                                environment.environmentId,
-                                selectedRevision.revisionId,
-                              ),
-                            );
-                          }
-                        }}
-                      >
-                        <ShieldAlert className="h-3.5 w-3.5" />
-                        Accept Findings & Continue
-                      </Button>
+                    </div>
+                    {(item.toolUpdates?.length ?? 0) > 0 && (
+                      <span className="mt-1.5 block text-[9px] font-medium text-amber-700 dark:text-amber-300">
+                        {item.toolUpdates?.length} recommended tool update
+                        {item.toolUpdates?.length === 1 ? '' : 's'}
+                      </span>
                     )}
-                    {selectedRevision?.status === 'SECURITY_REVIEW' && findingsAcceptedAt && (
-                      <Badge
-                        variant="outline"
-                        className={cn('gap-1.5', statusClass('SECURITY_REVIEW'))}
-                      >
-                        <ShieldCheck className="h-3.5 w-3.5" />
-                        Accepted · validation pending
-                      </Badge>
-                    )}
-                    {selectedRevision?.status === 'READY' &&
-                      (environment.environmentId === 'standard' ||
-                        isCatalogRecipe(selectedRevision.recipe)) && (
-                        <Button
-                          size="sm"
-                          onClick={() =>
-                            void run('publish', () =>
-                              environmentsService.publish(
-                                environment.environmentId,
-                                selectedRevision.revisionId,
-                              ),
-                            )
-                          }
-                        >
-                          <Rocket className="h-3.5 w-3.5" />
-                          Publish
-                        </Button>
-                      )}
+                  </button>
+                ))}
+                {filteredEnvironments.length === 0 && (
+                  <div className="px-3 py-8 text-center text-xs text-muted-foreground">
+                    No environments match this view.
                   </div>
-                </div>
+                )}
+              </div>
+            </aside>
 
-                {environment.environmentId !== 'standard' && !fixedToolEnvironment && (
-                  <>
-                    <RecipeEditor
-                      form={form}
-                      onChange={setForm}
-                      baseOptions={baseOptions}
-                      baseEnvironment={baseEnvironment}
-                      baseRevision={baseRevision}
-                      baseLoading={baseLoading}
-                      tools={tools}
-                      disabled={Boolean(busy)}
-                      showId={false}
-                    />
+            <div className="min-w-0">
+              {creating ? (
+                <div className="space-y-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-base font-semibold">Create an environment</h3>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Choose a base, add tools, and review the composition before creating a
+                        draft.
+                      </p>
+                    </div>
                     <Button
+                      variant="ghost"
                       size="sm"
-                      variant="outline"
-                      className="gap-1.5"
-                      disabled={Boolean(busy) || baseLoading || !baseRevision || !form.name.trim()}
                       onClick={() =>
-                        void run('save', () =>
-                          environmentsService.update(environment.environmentId, {
-                            name: form.name.trim(),
-                            description: form.description.trim(),
-                            baseEnvironmentId: form.baseEnvironmentId,
-                            recipe: recipeFromForm(form),
-                          }),
-                        )
+                        requestDiscard(() => {
+                          setCreating(false);
+                          if (selectedId) void loadDetail(selectedId);
+                        })
                       }
                     >
-                      {busy === 'save' ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <Save className="h-3.5 w-3.5" />
-                      )}
-                      Save as New Revision
+                      Cancel
                     </Button>
-                  </>
-                )}
-                {selectedRevision && <Evidence revision={selectedRevision} />}
-              </>
-            )}
-            {error && <p className="text-xs text-destructive">{error}</p>}
+                  </div>
+                  <EnvironmentBuilder
+                    key="new-environment"
+                    form={form}
+                    onChange={setForm}
+                    baseOptions={baseOptions}
+                    baseEnvironment={baseEnvironment}
+                    baseRevision={baseRevision}
+                    baseLoading={baseLoading}
+                    tools={tools}
+                    disabled={Boolean(busy)}
+                    showId
+                    actionLabel="Create draft"
+                    actionBusy={busy === 'create'}
+                    actionDisabled={Boolean(busy) || baseLoading || !baseRevision}
+                    onAction={() => void createEnvironment()}
+                  />
+                </div>
+              ) : detailLoading || !environment || !detail ? (
+                <Skeleton className="h-[620px]" />
+              ) : (
+                <div className="space-y-4">
+                  <div className="border-b pb-3">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="text-base font-semibold">{environment.name}</h3>
+                          <StatusBadge status={environment.status} />
+                        </div>
+                        <p className="mt-1 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                          <span className="font-mono text-[10px]">{environment.environmentId}</span>
+                          {environment.description && (
+                            <>
+                              <span aria-hidden="true">·</span>
+                              <span>{environment.description}</span>
+                            </>
+                          )}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {environment.updateAvailable &&
+                          environment.baseEnvironmentId &&
+                          !(environment.toolUpdates?.length ?? 0) && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="gap-1.5"
+                              disabled={Boolean(busy)}
+                              onClick={() =>
+                                requestDiscard(
+                                  () =>
+                                    void run(
+                                      'rebuild',
+                                      () => environmentsService.rebuild(environment.environmentId),
+                                      environment.environmentId,
+                                      true,
+                                    ),
+                                )
+                              }
+                            >
+                              <RotateCw className="h-3.5 w-3.5" />
+                              Rebuild on latest base
+                            </Button>
+                          )}
+                        {environment.environmentId !== 'standard' && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="gap-1.5 text-destructive"
+                            disabled={Boolean(busy)}
+                            onClick={() => requestRetire(environment)}
+                          >
+                            <Archive className="h-3.5 w-3.5" />
+                            Retire
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+
+                    {(environment.toolUpdates?.length ?? 0) > 0 && (
+                      <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-2.5 text-xs text-amber-800 dark:text-amber-200">
+                        <TriangleAlert className="mt-px h-3.5 w-3.5 shrink-0" />
+                        <span>
+                          Recommended tool updates are available. Review the definition and save a
+                          new revision to select them.
+                        </span>
+                      </div>
+                    )}
+                    {fixedToolEnvironment && (
+                      <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-2.5 text-xs text-amber-800 dark:text-amber-200">
+                        <TriangleAlert className="mt-px h-3.5 w-3.5 shrink-0" />
+                        <span>
+                          This fixed-tool environment is read-only. Retire it, then create a new
+                          environment from published catalog tools.
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  {definitionAvailable ? (
+                    <Tabs
+                      value={workspace}
+                      onValueChange={(value) => setWorkspace(value as Workspace)}
+                    >
+                      <TabsList>
+                        <TabsTrigger value="definition">
+                          Definition
+                          {isDirty && (
+                            <>
+                              <span className="ml-1 h-1.5 w-1.5 rounded-full bg-amber-500" />
+                              <span className="sr-only">Unsaved changes</span>
+                            </>
+                          )}
+                        </TabsTrigger>
+                        <TabsTrigger value="revisions">
+                          Revisions
+                          <Badge variant="secondary" className="ml-1.5 px-1.5 py-0 text-[9px]">
+                            {detail.revisions.length}
+                          </Badge>
+                        </TabsTrigger>
+                      </TabsList>
+
+                      <TabsContent value="definition" className="mt-4">
+                        <EnvironmentBuilder
+                          key={environment.environmentId}
+                          form={form}
+                          onChange={setForm}
+                          baseOptions={baseOptions}
+                          baseEnvironment={baseEnvironment}
+                          baseRevision={baseRevision}
+                          baseLoading={baseLoading}
+                          tools={tools}
+                          disabled={Boolean(busy)}
+                          showId={false}
+                          actionLabel="Save as new revision"
+                          actionBusy={busy === 'save'}
+                          actionDisabled={Boolean(busy) || baseLoading || !baseRevision || !isDirty}
+                          onAction={() =>
+                            void run(
+                              'save',
+                              () =>
+                                environmentsService.update(environment.environmentId, {
+                                  name: form.name.trim(),
+                                  description: form.description.trim(),
+                                  baseEnvironmentId: form.baseEnvironmentId,
+                                  recipe: recipeFromForm(form),
+                                }),
+                              environment.environmentId,
+                              true,
+                            )
+                          }
+                        />
+                      </TabsContent>
+
+                      <TabsContent value="revisions" className="mt-4">
+                        {revisionWorkspace}
+                      </TabsContent>
+                    </Tabs>
+                  ) : (
+                    revisionWorkspace
+                  )}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
-    </SettingsCard>
+        )}
+      </SettingsCard>
+
+      <AlertDialog
+        open={Boolean(confirmation)}
+        onOpenChange={(open) => {
+          if (!open) setConfirmation(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirmation?.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirmation?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={
+                confirmation?.destructive
+                  ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                  : undefined
+              }
+              onClick={() => {
+                const action = confirmation?.onConfirm;
+                setConfirmation(null);
+                action?.();
+              }}
+            >
+              {confirmation?.actionLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/frontend/src/components/admin/tabs/EnvironmentRegistry.tsx
+++ b/frontend/src/components/admin/tabs/EnvironmentRegistry.tsx
@@ -76,6 +76,27 @@ const filterEnvironment = (environment: ManagedEnvironment, filter: EnvironmentF
   return environment.status === 'RETIRED';
 };
 
+const environmentTask = (environment: ManagedEnvironment) => {
+  const toolUpdates = environment.toolUpdates?.length ?? 0;
+  if (toolUpdates > 0) {
+    return `${toolUpdates} recommended tool update${toolUpdates === 1 ? '' : 's'}`;
+  }
+  if (environment.updateAvailable) return 'Rebuild on the latest base';
+  const tasks: Record<string, string> = {
+    DRAFT: 'Build the first revision',
+    QUEUED: 'Waiting for the image build',
+    BUILDING: 'Building the environment image',
+    SCANNING: 'Scanning image packages',
+    SECURITY_REVIEW: 'Review security findings',
+    VERIFYING: 'Validating runtime behavior',
+    READY: 'Publish this revision',
+    PUBLISHED: 'Available to projects',
+    FAILED: 'Correct or retry the failed build',
+    RETIRED: 'Read-only environment',
+  };
+  return tasks[environment.status] ?? 'Review environment status';
+};
+
 export function EnvironmentRegistry() {
   const [environments, setEnvironments] = useState<ManagedEnvironment[]>([]);
   const [tools, setTools] = useState<ManagedTool[]>([]);
@@ -482,28 +503,29 @@ export function EnvironmentRegistry() {
                     <div className="flex items-start justify-between gap-2">
                       <span className="min-w-0">
                         <span className="block truncate text-xs font-semibold">{item.name}</span>
-                        <span className="mt-0.5 block truncate font-mono text-[9px] text-muted-foreground">
+                        <span className="mt-0.5 block truncate font-mono text-[10px] text-muted-foreground">
                           {item.environmentId}
                         </span>
                       </span>
-                      {item.updateAvailable ? (
-                        <span className="mt-0.5 shrink-0 text-amber-600">
-                          <TriangleAlert className="h-3.5 w-3.5" />
-                          <span className="sr-only">Update available</span>
-                        </span>
-                      ) : (
-                        <StatusBadge
-                          status={item.status}
-                          className="shrink-0 px-1.5 py-0 text-[8px]"
-                        />
-                      )}
+                      <StatusBadge
+                        status={item.updateAvailable ? 'UPDATE_AVAILABLE' : item.status}
+                        className="shrink-0 px-1.5 py-0"
+                      />
                     </div>
-                    {(item.toolUpdates?.length ?? 0) > 0 && (
-                      <span className="mt-1.5 block text-[9px] font-medium text-amber-700 dark:text-amber-300">
-                        {item.toolUpdates?.length} recommended tool update
-                        {item.toolUpdates?.length === 1 ? '' : 's'}
-                      </span>
-                    )}
+                    <span
+                      className={cn(
+                        'mt-1.5 flex items-center gap-1 text-[10px] font-medium text-muted-foreground',
+                        (item.updateAvailable ||
+                          item.status === 'SECURITY_REVIEW' ||
+                          item.status === 'FAILED') &&
+                          'text-amber-700 dark:text-amber-300',
+                      )}
+                    >
+                      {(item.updateAvailable ||
+                        item.status === 'SECURITY_REVIEW' ||
+                        item.status === 'FAILED') && <TriangleAlert className="h-3 w-3 shrink-0" />}
+                      {environmentTask(item)}
+                    </span>
                   </button>
                 ))}
                 {filteredEnvironments.length === 0 && (

--- a/frontend/src/components/admin/tabs/EnvironmentsTab.test.tsx
+++ b/frontend/src/components/admin/tabs/EnvironmentsTab.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const list = vi.fn();
@@ -83,6 +83,8 @@ const javaVersion = {
   definition: {
     schemaVersion: 1 as const,
     version: '21.0.8',
+    distribution: 'Eclipse Temurin',
+    publisher: 'Eclipse Adoptium',
     source: {
       type: 'https' as const,
       url: 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.8_9.tar.gz',
@@ -140,6 +142,8 @@ const mavenVersion = {
   definition: {
     ...javaVersion.definition,
     version: '3.9.11',
+    distribution: 'Apache Maven',
+    publisher: 'Apache Software Foundation',
     source: {
       type: 'https' as const,
       url: 'https://archive.apache.org/maven.tar.gz',
@@ -259,10 +263,27 @@ describe('EnvironmentsTab', () => {
   it('shows revision evidence and starts a draft build', async () => {
     const user = userEvent.setup();
     render(<EnvironmentsTab />);
-    expect(await screen.findByText('Generated Dockerfile')).toBeInTheDocument();
+    await user.click(await screen.findByRole('tab', { name: /Revisions/ }));
+    await user.click(await screen.findByRole('button', { name: 'Details and evidence' }));
+    await user.click(await screen.findByRole('button', { name: 'Generated Dockerfile' }));
     expect(screen.getByText(/FROM core@sha256:abc/)).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Build' }));
     expect(build).toHaveBeenCalledWith('custom', 'r-1');
+  });
+
+  it('preserves unsaved definition changes while revision actions refresh', async () => {
+    const user = userEvent.setup();
+    render(<EnvironmentsTab />);
+
+    const name = await screen.findByLabelText('Name');
+    await user.clear(name);
+    await user.type(name, 'Unsaved custom name');
+    await user.click(screen.getByRole('tab', { name: /Revisions/ }));
+    await user.click(screen.getByRole('button', { name: 'Build' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Build' })).not.toBeDisabled());
+    await user.click(screen.getByRole('tab', { name: /Definition/ }));
+
+    expect(screen.getByLabelText('Name')).toHaveValue('Unsaved custom name');
   });
 
   it('offers a latest-base rebuild instead of retrying a stale failed revision', async () => {
@@ -299,7 +320,7 @@ describe('EnvironmentsTab', () => {
     render(<EnvironmentsTab />);
 
     const rebuildButton = await screen.findByRole('button', {
-      name: 'Rebuild on Latest Base',
+      name: 'Rebuild on latest base',
     });
     expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
     await user.click(rebuildButton);
@@ -341,10 +362,10 @@ describe('EnvironmentsTab', () => {
     });
 
     render(<EnvironmentsTab />);
-    await screen.findByText('Generated Dockerfile');
-    await user.click(screen.getByRole('button', { name: 'New' }));
+    await screen.findByText('Environment details');
+    await user.click(screen.getByRole('button', { name: 'New environment' }));
     await user.type(screen.getByLabelText('Name'), 'Generated Name');
-    await user.click(screen.getByRole('button', { name: 'Create Draft' }));
+    await user.click(screen.getByRole('button', { name: 'Create draft' }));
 
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -356,6 +377,29 @@ describe('EnvironmentsTab', () => {
     expect(get).toHaveBeenCalledWith('generated-name');
   });
 
+  it('validates generated IDs before sending a create request', async () => {
+    const user = userEvent.setup();
+    render(<EnvironmentsTab />);
+
+    await screen.findByText('Environment details');
+    await user.click(screen.getByRole('button', { name: 'New environment' }));
+    await user.type(screen.getByLabelText('Name'), '123 build');
+
+    expect(
+      screen.getByText('The environment ID must start with a letter and contain 2–63 characters.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create draft' })).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/Environment ID/), 'build-123');
+
+    expect(
+      screen.queryByText(
+        'The environment ID must start with a letter and contain 2–63 characters.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create draft' })).toBeEnabled();
+  });
+
   it('shows inherited and platform versions without archive configuration inputs', async () => {
     const user = userEvent.setup();
     create.mockResolvedValue({
@@ -364,20 +408,22 @@ describe('EnvironmentsTab', () => {
     });
 
     render(<EnvironmentsTab />);
-    await screen.findByText('Generated Dockerfile');
-    await user.click(screen.getByRole('button', { name: 'New' }));
+    await screen.findByText('Environment details');
+    await user.click(screen.getByRole('button', { name: 'New environment' }));
 
+    expect(screen.getByText('Choose the base, tools, and optional settings.')).toBeInTheDocument();
+    expect(screen.getByText('Publish')).toBeInTheDocument();
     expect(await screen.findByText('Node.js 24.15.0')).toBeInTheDocument();
     expect(screen.getByText('Python 3.11')).toBeInTheDocument();
-    expect(screen.getByText('21.0.8')).toBeInTheDocument();
+    expect(screen.getByText('Eclipse Temurin 21.0.8')).toBeInTheDocument();
     expect(screen.queryByRole('combobox', { name: 'Node.js version' })).not.toBeInTheDocument();
     expect(screen.queryByRole('combobox', { name: 'Java version' })).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Java archive URL')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Java checksum')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('switch', { name: 'Include Java JDK' }));
+    await user.click(screen.getByRole('button', { name: 'Add Java JDK' }));
     await user.type(screen.getByLabelText('Name'), 'Java Custom');
-    await user.click(screen.getByRole('button', { name: 'Create Draft' }));
+    await user.click(screen.getByRole('button', { name: 'Create draft' }));
 
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -394,13 +440,13 @@ describe('EnvironmentsTab', () => {
     listTools.mockResolvedValue([javaTool, mavenTool]);
 
     render(<EnvironmentsTab />);
-    await screen.findByText('Generated Dockerfile');
-    await user.click(screen.getByRole('button', { name: 'New' }));
-    await user.click(screen.getByRole('switch', { name: 'Include Apache Maven' }));
+    await screen.findByText('Environment details');
+    await user.click(screen.getByRole('button', { name: 'New environment' }));
+    await user.click(screen.getByRole('button', { name: 'Add Apache Maven' }));
 
     expect(await screen.findByText('Added automatically for Apache Maven')).toBeInTheDocument();
     expect(screen.getByText('Required')).toBeInTheDocument();
-    expect(screen.getByText('Projected 1200 / 2048 MiB')).toBeInTheDocument();
+    expect(screen.getByText('1200 / 2048 MiB')).toBeInTheDocument();
   });
 
   it('shows a successful image build and lets an admin accept security findings', async () => {
@@ -434,24 +480,96 @@ describe('EnvironmentsTab', () => {
         securityFindingsAcceptedBy: 'admin@example.com',
       },
     });
-    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
-
     render(<EnvironmentsTab />);
 
-    expect(await screen.findByText('Build passed')).toBeInTheDocument();
-    expect(screen.getByText('Review required')).toBeInTheDocument();
+    expect(await screen.findByText('Built successfully')).toBeInTheDocument();
+    expect(screen.getByText('1 Critical · 2 High')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /CVE-2026-42010/ })).toHaveAttribute(
       'href',
       'https://example.test/CVE-2026-42010',
     );
     expect(screen.getByText('gnutls28 3.7.9-2+deb12u6')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Accept Findings & Continue' }));
-
-    expect(confirm).toHaveBeenCalledWith(
-      'Accept 1 Critical and 2 High security findings and continue to runtime validation? The findings will remain visible after publication.',
+    await user.click(screen.getByRole('button', { name: 'Review findings' }));
+    expect(screen.getByRole('alertdialog')).toHaveTextContent(
+      'Accept 1 Critical and 2 High security findings',
     );
+    await user.click(screen.getByRole('button', { name: 'Accept and continue' }));
     expect(acceptFindings).toHaveBeenCalledWith('custom', 'r-1');
-    confirm.mockRestore();
+  });
+
+  it('shows live lifecycle progress with CodeBuild and ECR links', async () => {
+    const buildingEnvironment = {
+      ...custom,
+      status: 'SCANNING',
+    };
+    const scanningRevision = {
+      ...revision,
+      status: 'SCANNING',
+      imageUri: '123456789012.dkr.ecr.eu-west-1.amazonaws.com/managed-environments',
+      imageDigest: `sha256:${'f'.repeat(64)}`,
+      buildLogUrl:
+        'https://console.aws.amazon.com/codesuite/codebuild/projects/environments/build/1',
+    };
+    list.mockResolvedValue([buildingEnvironment, standard]);
+    get.mockImplementation(async (environmentId: string) =>
+      environmentId === 'standard'
+        ? standardDetail
+        : {
+            environment: buildingEnvironment,
+            revisions: [scanningRevision],
+            publishedRevision: null,
+          },
+    );
+
+    render(<EnvironmentsTab />);
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'ECR is inspecting its operating-system packages',
+    );
+    expect(screen.getByRole('link', { name: /CodeBuild logs/ })).toHaveAttribute(
+      'href',
+      scanningRevision.buildLogUrl,
+    );
+    expect(screen.getByRole('link', { name: /Open ECR/ })).toHaveAttribute(
+      'href',
+      'https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/123456789012/managed-environments?region=eu-west-1',
+    );
+  });
+
+  it('keeps protected environment revisions compact and shows READY checks as complete', async () => {
+    const readyRevision = {
+      ...standardRevision,
+      revisionId: 'core-96-cde6f3fd0e12',
+      status: 'READY' as const,
+      imageDigest: `sha256:${'f'.repeat(64)}`,
+      verification: { status: 'PASSED' },
+    };
+    const publishedRevision = {
+      ...standardRevision,
+      revisionId: 'core-95-5e8a3c490898',
+    };
+    const readyEnvironment = {
+      ...standard,
+      status: 'READY',
+      currentRevisionId: readyRevision.revisionId,
+      publishedRevisionId: publishedRevision.revisionId,
+      updateAvailable: true,
+    };
+    list.mockResolvedValue([readyEnvironment]);
+    get.mockResolvedValue({
+      environment: readyEnvironment,
+      revisions: [readyRevision, publishedRevision],
+      publishedRevision,
+    });
+
+    render(<EnvironmentsTab />);
+
+    expect(await screen.findByRole('combobox', { name: 'Revision' })).toBeInTheDocument();
+    expect(screen.queryByText('Revision history')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: /Definition/ })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Check: complete')).toBeInTheDocument();
+    expect(screen.getByLabelText('Verify: complete')).toBeInTheDocument();
+    expect(screen.getByLabelText('Publish: current')).toBeInTheDocument();
   });
 
   it('offers acceptance for a prior security-only failure', async () => {
@@ -483,12 +601,13 @@ describe('EnvironmentsTab', () => {
 
     render(<EnvironmentsTab />);
 
-    expect(await screen.findByText('Build passed')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Accept Findings & Continue' })).toBeInTheDocument();
+    expect(await screen.findByText('Built successfully')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Review findings' })).toBeInTheDocument();
     expect(screen.queryByText('critical_vulnerability_findings')).not.toBeInTheDocument();
   });
 
   it('keeps accepted security issues visible after publication', async () => {
+    const user = userEvent.setup();
     const publishedEnvironment = {
       ...custom,
       status: 'PUBLISHED',
@@ -516,12 +635,45 @@ describe('EnvironmentsTab', () => {
 
     render(<EnvironmentsTab />);
 
+    expect(await screen.findByRole('button', { name: 'Details and evidence' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    await user.click(screen.getByRole('button', { name: 'Details and evidence' }));
     expect(await screen.findByText('Findings accepted')).toBeInTheDocument();
     expect(screen.getByText(/Accepted by admin@example.com/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /CVE-2026-42010/ })).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Accept Findings & Continue' }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Review findings' })).not.toBeInTheDocument();
+  });
+
+  it('builds advanced settings with structured rows', async () => {
+    const user = userEvent.setup();
+    create.mockResolvedValue({
+      environment: custom,
+      revision,
+    });
+
+    render(<EnvironmentsTab />);
+    await screen.findByText('Environment details');
+    await user.click(screen.getByRole('button', { name: 'New environment' }));
+    await user.type(screen.getByLabelText('Name'), 'Native Build');
+    await user.click(screen.getByRole('button', { name: /Advanced settings/ }));
+    await user.click(screen.getByRole('button', { name: 'Add package' }));
+    await user.type(screen.getByLabelText('Package name 1'), 'libssl-dev');
+    await user.type(screen.getByLabelText('Package version 1'), '3.0.17-1~deb12u2');
+    await user.click(screen.getByRole('button', { name: 'Add variable' }));
+    await user.type(screen.getByLabelText('Variable name 1'), 'BUILD_MODE');
+    await user.type(screen.getByLabelText('Variable value 1'), 'release');
+    await user.click(screen.getByRole('button', { name: 'Create draft' }));
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipe: expect.objectContaining({
+          aptPackages: [{ name: 'libssl-dev', version: '3.0.17-1~deb12u2' }],
+          environmentVariables: { BUILD_MODE: 'release' },
+        }),
+      }),
+    );
   });
 
   it('points a read-only fixed-tool environment at an action the UI actually offers', async () => {

--- a/frontend/src/components/admin/tabs/EnvironmentsTab.test.tsx
+++ b/frontend/src/components/admin/tabs/EnvironmentsTab.test.tsx
@@ -260,6 +260,14 @@ describe('EnvironmentsTab', () => {
     });
   });
 
+  it('shows plain-language status and the next action in the environment list', async () => {
+    render(<EnvironmentsTab />);
+
+    expect(await screen.findByText('Build the first revision')).toBeInTheDocument();
+    expect(screen.getAllByText('Ready to build').length).toBeGreaterThan(0);
+    expect(screen.getByText('Available to projects')).toBeInTheDocument();
+  });
+
   it('shows revision evidence and starts a draft build', async () => {
     const user = userEvent.setup();
     render(<EnvironmentsTab />);

--- a/frontend/src/components/admin/tabs/ToolsRegistry.test.tsx
+++ b/frontend/src/components/admin/tabs/ToolsRegistry.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const list = vi.fn();
@@ -26,6 +26,7 @@ vi.mock('@/services/environments', () => ({
 }));
 
 import { ToolsRegistry } from './ToolsRegistry';
+import { ApiError } from '@/services/api';
 
 const publishedVersion = {
   toolId: 'go',
@@ -124,17 +125,17 @@ describe('ToolsRegistry', () => {
     const user = userEvent.setup();
     render(<ToolsRegistry />);
 
-    await user.click(await screen.findByRole('button', { name: 'Add Tool' }));
+    await user.click(await screen.findByRole('button', { name: 'New tool family' }));
     await user.type(screen.getByLabelText('Name'), '.NET SDK');
     await user.type(screen.getByLabelText('Publisher'), 'Microsoft');
     await user.type(screen.getByLabelText('Exact version'), '8.0.408');
-    await user.click(screen.getByLabelText('Verification'));
-    await user.click(await screen.findByRole('option', { name: 'dotnet' }));
+    await user.click(screen.getByLabelText('Tool type'));
+    await user.click(await screen.findByRole('option', { name: '.NET SDK' }));
     await user.type(
-      screen.getByLabelText('Official ARM64 archive'),
+      screen.getByLabelText('Linux ARM64 download URL'),
       'https://download.visualstudio.microsoft.com/dotnet-sdk-8.0.408-linux-arm64.tar.gz',
     );
-    await user.click(screen.getByRole('button', { name: 'Create and Build' }));
+    await user.click(screen.getByRole('button', { name: 'Create and start build' }));
 
     expect(create).toHaveBeenCalledWith({
       name: '.NET SDK',
@@ -163,20 +164,160 @@ describe('ToolsRegistry', () => {
     expect(build).toHaveBeenCalledWith('dotnet-sdk', 'tv-dotnet-8');
   });
 
+  it('adds Amazon Corretto as a Java distribution in the existing tool family', async () => {
+    const user = userEvent.setup();
+    const temurinVersion = {
+      ...publishedVersion,
+      toolId: 'java',
+      versionId: 'tv-java-temurin',
+      definition: {
+        ...publishedVersion.definition,
+        version: '21.0.8',
+        distribution: 'Eclipse Temurin',
+        publisher: 'Eclipse Adoptium',
+        executables: [
+          { name: 'java', path: 'bin/java' },
+          { name: 'javac', path: 'bin/javac' },
+        ],
+        environmentVariables: { JAVA_HOME: '${TOOL_ROOT}' },
+        verification: {
+          preset: 'java' as const,
+          versionCommand: { argv: ['java', '-version'], expected: '21.0.8' },
+          script: '',
+          files: [],
+        },
+      },
+    };
+    const javaTool = {
+      ...goTool,
+      toolId: 'java',
+      name: 'Java JDK',
+      publisher: 'Eclipse Temurin',
+      recommendedVersionId: temurinVersion.versionId,
+      versions: [temurinVersion],
+    };
+    list.mockResolvedValue([javaTool]);
+    createVersion.mockResolvedValue({
+      tool: javaTool,
+      version: { ...temurinVersion, versionId: 'tv-java-corretto', status: 'DRAFT' },
+    });
+
+    render(<ToolsRegistry />);
+
+    await user.click(await screen.findByRole('button', { name: 'Add distribution or version' }));
+    expect(screen.getByText(/Java JDK settings are applied automatically/)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Tool type')).not.toBeInTheDocument();
+    expect(screen.getByText('Recommend')).toBeInTheDocument();
+    await user.clear(screen.getByLabelText('Distribution'));
+    await user.type(screen.getByLabelText('Distribution'), 'Amazon Corretto');
+    await user.clear(screen.getByLabelText('Publisher'));
+    await user.type(screen.getByLabelText('Publisher'), 'Amazon Web Services');
+    await user.type(screen.getByLabelText('Exact version'), '21.0.8.9.1');
+    await user.type(
+      screen.getByLabelText('Linux ARM64 download URL'),
+      'https://corretto.aws/downloads/resources/21.0.8.9.1/amazon-corretto-21.0.8.9.1-linux-aarch64.tar.gz',
+    );
+    await user.click(screen.getByRole('button', { name: 'Create and start build' }));
+
+    expect(createVersion).toHaveBeenCalledWith(
+      'java',
+      expect.objectContaining({
+        version: '21.0.8.9.1',
+        distribution: 'Amazon Corretto',
+        publisher: 'Amazon Web Services',
+        verification: expect.objectContaining({ preset: 'java' }),
+      }),
+    );
+    expect(build).toHaveBeenCalledWith('java', 'tv-java-corretto');
+  });
+
+  it('does not mistake JavaScript tool families for Java JDKs', async () => {
+    const user = userEvent.setup();
+    list.mockResolvedValue([
+      {
+        ...goTool,
+        toolId: 'javascript-cli',
+        name: 'JavaScript CLI',
+        recommendedVersionId: null,
+        versions: [],
+      },
+    ]);
+
+    render(<ToolsRegistry />);
+
+    await user.click(await screen.findByRole('button', { name: 'Add distribution or version' }));
+    expect(screen.getByText(/Other CLI settings are applied automatically/)).toBeInTheDocument();
+    expect(screen.queryByLabelText('Tool type')).not.toBeInTheDocument();
+  });
+
+  it('shows field-level API validation instead of a generic definition error', async () => {
+    const user = userEvent.setup();
+    list.mockResolvedValue([goTool]);
+    createVersion.mockRejectedValue(
+      new ApiError(400, 'Invalid tool version definition', {
+        issues: [
+          {
+            path: 'executables.0.path',
+            message: 'executable path must stay inside the tool',
+          },
+        ],
+      }),
+    );
+
+    render(<ToolsRegistry />);
+
+    await user.click(await screen.findByRole('button', { name: 'Add distribution or version' }));
+    await user.type(screen.getByLabelText('Exact version'), '1.25.0');
+    await user.type(
+      screen.getByLabelText('Linux ARM64 download URL'),
+      'https://go.dev/dl/go1.25.0.linux-arm64.tar.gz',
+    );
+    await user.click(screen.getByRole('button', { name: 'Create and start build' }));
+
+    expect(await screen.findByText(/Check these fields/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Executables: executable path must stay inside the tool/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows live build progress and the CodeBuild link in the lifecycle', async () => {
+    const buildingVersion = {
+      ...publishedVersion,
+      status: 'BUILDING' as const,
+      source: null,
+      imageUri: null,
+      imageDigest: null,
+      imageSizeBytes: null,
+      buildLogUrl: 'https://console.aws.amazon.com/codesuite/codebuild/builds/example',
+      verification: null,
+    };
+    list.mockResolvedValue([{ ...goTool, versions: [buildingVersion] }]);
+
+    render(<ToolsRegistry />);
+
+    expect(await screen.findByText(/CodeBuild is downloading the source/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /CodeBuild logs/ })).toHaveAttribute(
+      'href',
+      buildingVersion.buildLogUrl,
+    );
+    expect(screen.getByText('Check')).toBeInTheDocument();
+    expect(screen.getByText('Recommend')).toBeInTheDocument();
+  });
+
   it('uses the sandboxed vendor installer and native compiler prerequisite for Rust', async () => {
     const user = userEvent.setup();
     render(<ToolsRegistry />);
 
-    await user.click(await screen.findByRole('button', { name: 'Add Tool' }));
+    await user.click(await screen.findByRole('button', { name: 'New tool family' }));
     await user.type(screen.getByLabelText('Name'), 'Rust Toolchain');
     await user.type(screen.getByLabelText('Exact version'), '1.89.0');
-    await user.click(screen.getByLabelText('Verification'));
-    await user.click(await screen.findByRole('option', { name: 'rust' }));
+    await user.click(screen.getByLabelText('Tool type'));
+    await user.click(await screen.findByRole('option', { name: 'Rust toolchain' }));
     await user.type(
-      screen.getByLabelText('Official ARM64 archive'),
+      screen.getByLabelText('Linux ARM64 download URL'),
       'https://static.rust-lang.org/dist/rust-1.89.0-aarch64-unknown-linux-gnu.tar.gz',
     );
-    await user.click(screen.getByRole('button', { name: 'Create and Build' }));
+    await user.click(screen.getByRole('button', { name: 'Create and start build' }));
 
     expect(create).toHaveBeenCalledWith(expect.objectContaining({ category: 'language-sdk' }));
     expect(createVersion).toHaveBeenCalledWith(
@@ -212,7 +353,7 @@ describe('ToolsRegistry', () => {
     expect(screen.getByLabelText('Exact version')).toBeDisabled();
     await user.clear(screen.getByLabelText('Root folders to remove'));
     await user.type(screen.getByLabelText('Root folders to remove'), '0');
-    await user.click(screen.getByRole('button', { name: 'Save and Build' }));
+    await user.click(screen.getByRole('button', { name: 'Save and rebuild' }));
 
     expect(create).not.toHaveBeenCalled();
     expect(createVersion).not.toHaveBeenCalled();
@@ -234,8 +375,67 @@ describe('ToolsRegistry', () => {
 
     render(<ToolsRegistry />);
 
-    await user.click(await screen.findByRole('button', { name: 'Recommend' }));
+    expect(await screen.findByRole('button', { name: 'Details and evidence' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.queryByText('Download complete')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Recommendations are replaced/)).not.toBeInTheDocument();
+
+    await user.click(await screen.findByRole('button', { name: 'Make recommended' }));
+    await user.click(
+      within(screen.getByRole('alertdialog')).getByRole('button', {
+        name: 'Make recommended',
+      }),
+    );
     expect(recommend).toHaveBeenCalledWith('go', 'tv-go-1');
+  });
+
+  it('replaces an existing recommendation without requiring a removal step', async () => {
+    const user = userEvent.setup();
+    const current = {
+      ...publishedVersion,
+      versionId: 'tv-java-temurin',
+      definition: {
+        ...publishedVersion.definition,
+        distribution: 'Eclipse Temurin',
+        version: '21.0.8',
+      },
+    };
+    const candidate = {
+      ...publishedVersion,
+      versionId: 'tv-java-corretto',
+      definition: {
+        ...publishedVersion.definition,
+        distribution: 'Amazon Corretto',
+        publisher: 'Amazon Web Services',
+        version: '21.0.8.9.1',
+      },
+    };
+    const javaTool = {
+      ...goTool,
+      toolId: 'java',
+      name: 'Java JDK',
+      recommendedVersionId: current.versionId,
+      versions: [candidate, current],
+    };
+    list.mockResolvedValue([javaTool]);
+    recommend.mockResolvedValue({
+      tool: { ...javaTool, recommendedVersionId: candidate.versionId },
+    });
+
+    render(<ToolsRegistry />);
+
+    await user.click(await screen.findByRole('button', { name: 'Replace recommendation' }));
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toHaveTextContent('Replace Eclipse Temurin as recommended?');
+    await user.click(
+      within(dialog).getByRole('button', {
+        name: 'Replace recommendation',
+      }),
+    );
+
+    expect(recommend).toHaveBeenCalledWith('java', 'tv-java-corretto');
   });
 
   it('requires explicit acceptance when ECR cannot scan a tool artifact', async () => {
@@ -243,6 +443,7 @@ describe('ToolsRegistry', () => {
     const unsupportedVersion = {
       ...publishedVersion,
       status: 'SECURITY_REVIEW' as const,
+      imageUri: '123456789012.dkr.ecr.eu-west-1.amazonaws.com/managed-tools',
       scanFindings: {
         status: 'UNSUPPORTED',
         description:
@@ -252,21 +453,21 @@ describe('ToolsRegistry', () => {
       },
     };
     list.mockResolvedValue([{ ...goTool, versions: [unsupportedVersion] }]);
-    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
-
     render(<ToolsRegistry />);
 
-    expect(await screen.findByText('ECR scan unavailable')).toBeInTheDocument();
+    expect(await screen.findAllByText('Scan unavailable')).toHaveLength(2);
     expect(
-      screen.getByText(
-        'UnsupportedImageError: The operating system and/or package manager are not supported.',
-      ),
+      screen.getByText(/This is a scan limitation, not a detected vulnerability/),
     ).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Accept Scan Limitation' }));
-
-    expect(confirm).toHaveBeenCalledWith(
-      'ECR could not scan this artifact. Accept the scan limitation and continue verification?',
+    expect(screen.getByRole('link', { name: /Open ECR/ })).toHaveAttribute(
+      'href',
+      'https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/123456789012/managed-tools?region=eu-west-1',
     );
+    await user.click(screen.getByRole('button', { name: 'Continue without scan' }));
+    expect(screen.getByRole('alertdialog')).toHaveTextContent(
+      'This does not mean a vulnerability was found',
+    );
+    await user.click(screen.getByRole('button', { name: 'Continue after review' }));
     expect(acceptFindings).toHaveBeenCalledWith('go', 'tv-go-1');
   });
 
@@ -292,14 +493,21 @@ describe('ToolsRegistry', () => {
 
     render(<ToolsRegistry />);
 
-    expect(await screen.findByText('ECR scan limitation accepted')).toBeInTheDocument();
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: 'Details and evidence',
+      }),
+    );
+    expect(
+      await screen.findByText('Automated package scan was unavailable and reviewed.'),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText(
         'UnsupportedImageError: The operating system and/or package manager are not supported.',
       ),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Security scan limitation accepted by admin@example.com/),
+      screen.getByText(/Automated scan limitation reviewed by admin@example.com/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/components/admin/tabs/ToolsRegistry.test.tsx
+++ b/frontend/src/components/admin/tabs/ToolsRegistry.test.tsx
@@ -231,6 +231,36 @@ describe('ToolsRegistry', () => {
     expect(build).toHaveBeenCalledWith('java', 'tv-java-corretto');
   });
 
+  it('searches and filters tool families by their current lifecycle status', async () => {
+    const user = userEvent.setup();
+    const failedTool = {
+      ...goTool,
+      toolId: 'rust',
+      name: 'Rust Toolchain',
+      description: 'Rust compiler and package manager',
+      versions: [{ ...publishedVersion, toolId: 'rust', status: 'FAILED' as const }],
+    };
+    list.mockResolvedValue([goTool, failedTool]);
+
+    render(<ToolsRegistry />);
+
+    const search = await screen.findByLabelText('Search tools');
+    expect(screen.getByRole('button', { name: /Go SDK/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Rust Toolchain/ })).toBeInTheDocument();
+
+    await user.type(search, 'rust');
+    expect(screen.queryByRole('button', { name: /Go SDK/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Rust Toolchain/ })).toHaveTextContent(
+      'Correct or retry the failed build',
+    );
+
+    await user.clear(search);
+    await user.click(screen.getByLabelText('Filter tools'));
+    await user.click(await screen.findByRole('option', { name: 'Needs attention' }));
+    expect(screen.queryByRole('button', { name: /Go SDK/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Rust Toolchain/ })).toBeInTheDocument();
+  });
+
   it('does not mistake JavaScript tool families for Java JDKs', async () => {
     const user = userEvent.setup();
     list.mockResolvedValue([
@@ -455,7 +485,7 @@ describe('ToolsRegistry', () => {
     list.mockResolvedValue([{ ...goTool, versions: [unsupportedVersion] }]);
     render(<ToolsRegistry />);
 
-    expect(await screen.findAllByText('Scan unavailable')).toHaveLength(2);
+    expect(await screen.findAllByText('Scan unavailable')).toHaveLength(3);
     expect(
       screen.getByText(/This is a scan limitation, not a detected vulnerability/),
     ).toBeInTheDocument();

--- a/frontend/src/components/admin/tabs/ToolsRegistry.test.tsx
+++ b/frontend/src/components/admin/tabs/ToolsRegistry.test.tsx
@@ -208,6 +208,7 @@ describe('ToolsRegistry', () => {
     expect(screen.getByText(/Java JDK settings are applied automatically/)).toBeInTheDocument();
     expect(screen.queryByLabelText('Tool type')).not.toBeInTheDocument();
     expect(screen.getByText('Recommend')).toBeInTheDocument();
+    expect(screen.getByLabelText('Publisher')).toHaveValue('');
     await user.clear(screen.getByLabelText('Distribution'));
     await user.type(screen.getByLabelText('Distribution'), 'Amazon Corretto');
     await user.clear(screen.getByLabelText('Publisher'));
@@ -229,6 +230,33 @@ describe('ToolsRegistry', () => {
       }),
     );
     expect(build).toHaveBeenCalledWith('java', 'tv-java-corretto');
+  });
+
+  it('requires a publisher for an added distribution instead of inheriting the family publisher', async () => {
+    const user = userEvent.setup();
+    list.mockResolvedValue([
+      {
+        ...goTool,
+        toolId: 'java',
+        name: 'Java JDK',
+        publisher: 'Eclipse Adoptium',
+      },
+    ]);
+
+    render(<ToolsRegistry />);
+
+    await user.click(await screen.findByRole('button', { name: 'Add distribution or version' }));
+    await user.clear(screen.getByLabelText('Distribution'));
+    await user.type(screen.getByLabelText('Distribution'), 'Amazon Corretto');
+    await user.type(screen.getByLabelText('Exact version'), '21.0.8.9.1');
+    await user.type(
+      screen.getByLabelText('Linux ARM64 download URL'),
+      'https://corretto.aws/downloads/resources/21.0.8.9.1/amazon-corretto-21.0.8.9.1-linux-aarch64.tar.gz',
+    );
+    await user.click(screen.getByRole('button', { name: 'Create and start build' }));
+
+    expect(screen.getByText('Name the publisher for this distribution.')).toBeInTheDocument();
+    expect(createVersion).not.toHaveBeenCalled();
   });
 
   it('searches and filters tool families by their current lifecycle status', async () => {
@@ -297,6 +325,7 @@ describe('ToolsRegistry', () => {
     render(<ToolsRegistry />);
 
     await user.click(await screen.findByRole('button', { name: 'Add distribution or version' }));
+    await user.type(screen.getByLabelText('Publisher'), 'The Go project');
     await user.type(screen.getByLabelText('Exact version'), '1.25.0');
     await user.type(
       screen.getByLabelText('Linux ARM64 download URL'),
@@ -396,6 +425,33 @@ describe('ToolsRegistry', () => {
       }),
     );
     expect(retry).toHaveBeenCalledWith('go', 'tv-go-1');
+  });
+
+  it.each([
+    ['PUBLISHER_VERIFIED', 'Publisher verified'],
+    ['PLATFORM_PINNED', 'Platform pinned'],
+  ] as const)('shows %s source trust as %s in evidence', async (trustLevel, label) => {
+    list.mockResolvedValue([
+      {
+        ...goTool,
+        versions: [
+          {
+            ...publishedVersion,
+            source: { ...publishedVersion.source, trustLevel },
+          },
+        ],
+      },
+    ]);
+
+    render(<ToolsRegistry />);
+
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: 'Details and evidence',
+      }),
+    );
+    expect(await screen.findByText(label)).toBeInTheDocument();
+    expect(screen.getByText('Download complete')).toBeInTheDocument();
   });
 
   it('lets an administrator explicitly recommend a published version', async () => {

--- a/frontend/src/components/admin/tabs/ToolsRegistry.tsx
+++ b/frontend/src/components/admin/tabs/ToolsRegistry.tsx
@@ -13,6 +13,7 @@ import {
   Plus,
   RefreshCw,
   Rocket,
+  Search,
   ShieldQuestion,
   Star,
   Trash2,
@@ -58,6 +59,7 @@ import { cn } from '@/lib/utils';
 import { Disclosure, ProcessOverview } from './environment-builder/ui';
 
 const ACTIVE_STATUSES = new Set(['QUEUED', 'BUILDING', 'SCANNING']);
+type ToolFilter = 'all' | 'attention' | 'progress' | 'published';
 const PRESETS = ['generic', 'java', 'go', 'rust', 'maven', 'gradle', 'dotnet'] as const;
 type VerificationPreset = (typeof PRESETS)[number];
 const PRESET_LABELS: Record<VerificationPreset, string> = {
@@ -515,6 +517,37 @@ const toolStatusLabel = (version: ManagedToolVersion) => {
     FAILED: 'Needs attention',
   };
   return labels[version.status] ?? version.status.replaceAll('_', ' ');
+};
+
+const latestToolVersion = (tool: ManagedTool) => tool.versions[0] ?? null;
+
+const filterTool = (tool: ManagedTool, filter: ToolFilter) => {
+  if (filter === 'all') return true;
+  const status = latestToolVersion(tool)?.status;
+  if (filter === 'attention') return status === 'SECURITY_REVIEW' || status === 'FAILED';
+  if (filter === 'progress') return Boolean(status && ACTIVE_STATUSES.has(status));
+  return status === 'PUBLISHED';
+};
+
+const toolSidebarTask = (tool: ManagedTool, version: ManagedToolVersion | null) => {
+  if (!version) return 'Add the first version';
+  if (version.status === 'DRAFT') return 'Build and verify this version';
+  if (version.status === 'QUEUED') return 'Waiting for the build';
+  if (version.status === 'BUILDING') return 'Building and verifying version';
+  if (version.status === 'SCANNING') return 'Scanning tool image packages';
+  if (version.status === 'SECURITY_REVIEW') {
+    return version.scanFindings?.status === 'UNSUPPORTED'
+      ? 'Review the scan limitation'
+      : 'Review security findings';
+  }
+  if (version.status === 'READY') return 'Publish this version';
+  if (version.status === 'PUBLISHED') {
+    return version.versionId === tool.recommendedVersionId
+      ? 'Recommended for new environments'
+      : 'Available to environments';
+  }
+  if (version.status === 'FAILED') return 'Correct or retry the failed build';
+  return 'Review version status';
 };
 
 function ToolStatus({ version }: { version: ManagedToolVersion }) {
@@ -1493,6 +1526,8 @@ export function ToolsRegistry() {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState<ToolFilter>('all');
   const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
 
   const load = useCallback(async (preferredToolId?: string, preferredVersionId?: string) => {
@@ -1527,6 +1562,18 @@ export function ToolsRegistry() {
       null,
     [selectedTool, selectedVersionId],
   );
+  const filteredTools = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return tools.filter(
+      (tool) =>
+        filterTool(tool, filter) &&
+        (!query ||
+          tool.name.toLowerCase().includes(query) ||
+          tool.toolId.toLowerCase().includes(query) ||
+          tool.description.toLowerCase().includes(query) ||
+          tool.publisher.toLowerCase().includes(query)),
+    );
+  }, [filter, search, tools]);
   const missingDependencies = useMemo(
     () =>
       (selectedVersion?.definition.dependencies ?? []).filter((toolId) => {
@@ -1678,44 +1725,108 @@ export function ToolsRegistry() {
         }
       >
         {loading ? (
-          <div className="grid gap-4 lg:grid-cols-[230px_minmax(0,1fr)]">
+          <div className="grid gap-4 lg:grid-cols-[250px_minmax(0,1fr)]">
             <Skeleton className="h-72" />
             <Skeleton className="h-96" />
           </div>
         ) : (
-          <div className="grid min-w-0 gap-5 lg:grid-cols-[230px_minmax(0,1fr)]">
-            <div className="space-y-1 border-r pr-4">
-              {tools.map((tool) => (
-                <button
-                  key={tool.toolId}
-                  type="button"
-                  aria-pressed={!creatingTool && selectedToolId === tool.toolId}
-                  className={cn(
-                    'flex w-full items-start justify-between gap-2 rounded px-2.5 py-2 text-left hover:bg-muted/60',
-                    !creatingTool && selectedToolId === tool.toolId && 'bg-muted',
-                  )}
-                  onClick={() => {
-                    setCreatingTool(false);
-                    setCreatingVersion(false);
-                    setEditingVersionId(null);
-                    setSelectedToolId(tool.toolId);
-                  }}
-                >
-                  <span className="min-w-0">
-                    <span className="block truncate text-xs font-medium">{tool.name}</span>
-                    <span className="block truncate font-mono text-[10px] text-muted-foreground">
-                      {tool.toolId}
-                    </span>
-                  </span>
-                  {tool.recommendedVersionId && (
-                    <span className="mt-0.5 shrink-0 text-amber-500">
-                      <Star className="h-3.5 w-3.5 fill-amber-400" />
-                      <span className="sr-only">Has a recommended version</span>
-                    </span>
-                  )}
-                </button>
-              ))}
-            </div>
+          <div className="grid min-w-0 gap-5 lg:grid-cols-[250px_minmax(0,1fr)]">
+            <aside className="self-start rounded-xl border bg-muted/10 p-2 lg:sticky lg:top-0">
+              <div className="space-y-2 p-1">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                  <Input
+                    aria-label="Search tools"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search tools"
+                    className="h-9 bg-background pl-8 text-xs"
+                  />
+                </div>
+                <Select value={filter} onValueChange={(value) => setFilter(value as ToolFilter)}>
+                  <SelectTrigger aria-label="Filter tools" className="h-8 bg-background text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All tools</SelectItem>
+                    <SelectItem value="attention">Needs attention</SelectItem>
+                    <SelectItem value="progress">In progress</SelectItem>
+                    <SelectItem value="published">Published</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="mt-1 max-h-[680px] space-y-1 overflow-y-auto">
+                {creatingTool && (
+                  <div className="rounded-lg border border-primary/30 bg-primary/5 px-3 py-2.5">
+                    <div className="flex items-center gap-2">
+                      <Plus className="h-3.5 w-3.5 text-primary" />
+                      <span className="text-xs font-semibold">New tool</span>
+                    </div>
+                    <p className="mt-1 text-[10px] text-muted-foreground">
+                      Unsaved family and first version
+                    </p>
+                  </div>
+                )}
+                {filteredTools.map((tool) => {
+                  const version = latestToolVersion(tool);
+                  const needsAttention =
+                    version?.status === 'SECURITY_REVIEW' || version?.status === 'FAILED';
+                  return (
+                    <button
+                      key={tool.toolId}
+                      type="button"
+                      aria-pressed={!creatingTool && selectedToolId === tool.toolId}
+                      className={cn(
+                        'w-full rounded-lg border border-transparent px-3 py-2.5 text-left transition-colors hover:bg-muted/60',
+                        !creatingTool &&
+                          selectedToolId === tool.toolId &&
+                          'border-border bg-background shadow-sm',
+                      )}
+                      onClick={() => {
+                        setCreatingTool(false);
+                        setCreatingVersion(false);
+                        setEditingVersionId(null);
+                        setSelectedToolId(tool.toolId);
+                      }}
+                    >
+                      <span className="flex items-start justify-between gap-2">
+                        <span className="min-w-0">
+                          <span className="block truncate text-xs font-semibold">{tool.name}</span>
+                          <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
+                            <span className="font-mono">{tool.toolId}</span> ·{' '}
+                            {tool.category.replaceAll('-', ' ')}
+                          </span>
+                        </span>
+                        {version ? (
+                          <ToolStatus version={version} />
+                        ) : (
+                          <Badge
+                            variant="outline"
+                            className="shrink-0 bg-muted/50 px-1.5 py-0 text-[10px] text-muted-foreground"
+                          >
+                            Not created
+                          </Badge>
+                        )}
+                      </span>
+                      <span
+                        className={cn(
+                          'mt-1.5 block text-[10px] font-medium text-muted-foreground',
+                          needsAttention && 'text-amber-700 dark:text-amber-300',
+                        )}
+                      >
+                        {toolSidebarTask(tool, version)}
+                      </span>
+                    </button>
+                  );
+                })}
+                {filteredTools.length === 0 && (
+                  <div className="px-3 py-8 text-center text-xs text-muted-foreground">
+                    No tools match this view.
+                  </div>
+                )}
+              </div>
+            </aside>
 
             <div className="min-w-0 space-y-5">
               {creatingTool || creatingVersion ? (

--- a/frontend/src/components/admin/tabs/ToolsRegistry.tsx
+++ b/frontend/src/components/admin/tabs/ToolsRegistry.tsx
@@ -297,7 +297,7 @@ const emptyForm = (tool?: ManagedTool | null): ToolForm => {
     publisher: tool?.publisher ?? '',
     version: '',
     distribution: reference?.definition.distribution ?? tool?.publisher ?? '',
-    versionPublisher: reference?.definition.publisher ?? tool?.publisher ?? '',
+    versionPublisher: '',
     sourceUrl: '',
     preset,
     installerMode: defaults.installerMode,
@@ -366,15 +366,19 @@ const parsePairs = (value: string) =>
         : [line, ''];
     });
 
-const definitionFromForm = (form: ToolForm): ToolVersionDefinition => ({
+const definitionFromForm = (form: ToolForm, creatingTool: boolean): ToolVersionDefinition => ({
   schemaVersion: 1,
   version: form.version.trim(),
   ...(form.distribution.trim() || form.name.trim()
     ? { distribution: form.distribution.trim() || form.name.trim() }
     : {}),
-  ...(form.versionPublisher.trim() || form.publisher.trim()
-    ? { publisher: form.versionPublisher.trim() || form.publisher.trim() }
-    : {}),
+  ...(creatingTool
+    ? form.publisher.trim()
+      ? { publisher: form.publisher.trim() }
+      : {}
+    : form.versionPublisher.trim()
+      ? { publisher: form.versionPublisher.trim() }
+      : {}),
   source: {
     type: 'https',
     url: form.sourceUrl.trim(),
@@ -428,6 +432,9 @@ const validateToolForm = (form: ToolForm, creatingTool: boolean) => {
   }
   if (!creatingTool && !form.distribution.trim()) {
     issues.push('Name the distribution, for example Amazon Corretto.');
+  }
+  if (!creatingTool && !form.versionPublisher.trim()) {
+    issues.push('Name the publisher for this distribution.');
   }
   if (!form.sourceUrl.trim()) {
     issues.push('Add the Linux ARM64 download URL.');
@@ -726,6 +733,11 @@ function ToolLifecycle({
   );
 }
 
+const SOURCE_TRUST_LABELS = {
+  PLATFORM_PINNED: 'Platform pinned',
+  PUBLISHER_VERIFIED: 'Publisher verified',
+} as const;
+
 function VersionEvidence({ version }: { version: ManagedToolVersion }) {
   const findings = version.scanFindings?.findings ?? [];
   const scanUnsupported = version.scanFindings?.status === 'UNSUPPORTED';
@@ -741,17 +753,20 @@ function VersionEvidence({ version }: { version: ManagedToolVersion }) {
             Source
           </p>
           <p className="mt-2 text-xs font-medium">
-            {version.source ? 'Download complete' : 'Waiting for build'}
+            {version.source ? SOURCE_TRUST_LABELS[version.source.trustLevel] : 'Waiting for build'}
           </p>
           {version.source && (
-            <a
-              href={version.source.requestedUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="mt-1 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
-            >
-              View download <ExternalLink className="h-3 w-3" />
-            </a>
+            <>
+              <p className="mt-1 text-[10px] text-muted-foreground">Download complete</p>
+              <a
+                href={version.source.requestedUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-1 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+              >
+                View download <ExternalLink className="h-3 w-3" />
+              </a>
+            </>
           )}
         </div>
         <div className="rounded-xl border p-3">
@@ -1636,7 +1651,7 @@ export function ToolsRegistry() {
         setCreatingVersion(true);
       }
       if (!tool) throw new Error('Tool is unavailable');
-      const definition = definitionFromForm(form);
+      const definition = definitionFromForm(form, creatingTool);
       if (editingVersionId) {
         const current = tool.versions.find((version) => version.versionId === editingVersionId);
         const updated = await toolsService.updateVersion(tool.toolId, editingVersionId, definition);

--- a/frontend/src/components/admin/tabs/ToolsRegistry.tsx
+++ b/frontend/src/components/admin/tabs/ToolsRegistry.tsx
@@ -1,20 +1,37 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  Check,
+  CheckCircle2,
+  ChevronDown,
+  Circle,
   CircleCheck,
   ExternalLink,
   Hammer,
+  Info,
   Loader2,
   Pencil,
   Plus,
   RefreshCw,
   Rocket,
-  ShieldAlert,
+  ShieldQuestion,
   Star,
   Trash2,
+  TriangleAlert,
   Wrench,
 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -36,11 +53,44 @@ import {
   type ToolVerification,
   type ToolVersionDefinition,
 } from '@/services/environments';
+import { ApiError } from '@/services/api';
 import { cn } from '@/lib/utils';
+import { Disclosure, ProcessOverview } from './environment-builder/ui';
 
 const ACTIVE_STATUSES = new Set(['QUEUED', 'BUILDING', 'SCANNING']);
 const PRESETS = ['generic', 'java', 'go', 'rust', 'maven', 'gradle', 'dotnet'] as const;
 type VerificationPreset = (typeof PRESETS)[number];
+const PRESET_LABELS: Record<VerificationPreset, string> = {
+  generic: 'Other CLI',
+  java: 'Java JDK',
+  go: 'Go SDK',
+  rust: 'Rust toolchain',
+  maven: 'Apache Maven',
+  gradle: 'Gradle',
+  dotnet: '.NET SDK',
+};
+const TOOL_PROCESS_STEPS = [
+  {
+    label: 'Define',
+    description: 'Choose the distribution, exact version, and ARM64 download.',
+  },
+  {
+    label: 'Build',
+    description: 'CodeBuild creates the reusable tool artifact.',
+  },
+  {
+    label: 'Check',
+    description: 'Automatic functional and package checks run.',
+  },
+  {
+    label: 'Publish',
+    description: 'Make the version available to environments.',
+  },
+  {
+    label: 'Recommend',
+    description: 'Optionally make it the default for new environments.',
+  },
+] as const;
 
 const RUST_INSTALLER_SCRIPT = `#!/usr/bin/env bash
 set -Eeuo pipefail
@@ -187,6 +237,8 @@ interface ToolForm {
   category: string;
   publisher: string;
   version: string;
+  distribution: string;
+  versionPublisher: string;
   sourceUrl: string;
   preset: VerificationPreset;
   installerMode: 'generated' | 'script';
@@ -205,8 +257,36 @@ interface ToolForm {
   publisherEvidenceUrl: string;
 }
 
+interface Confirmation {
+  title: string;
+  description: string;
+  actionLabel: string;
+  onConfirm: () => void;
+}
+
+const presetForTool = (tool?: ManagedTool | null): VerificationPreset => {
+  const reference =
+    tool?.versions.find((version) => version.versionId === tool.recommendedVersionId) ??
+    tool?.versions[0];
+  if (reference?.definition.verification.preset) {
+    return reference.definition.verification.preset;
+  }
+  const identity = `${tool?.toolId ?? ''} ${tool?.name ?? ''}`.toLowerCase();
+  if (/\b(java|jdk)\b/.test(identity)) return 'java';
+  if (/\bmaven\b/.test(identity)) return 'maven';
+  if (/\bgradle\b/.test(identity)) return 'gradle';
+  if (/\brust\b/.test(identity)) return 'rust';
+  if (/\bdotnet\b|(^|[^a-z0-9])\.net\b/.test(identity)) return 'dotnet';
+  if (/\bgo\b/.test(identity)) return 'go';
+  return 'generic';
+};
+
 const emptyForm = (tool?: ManagedTool | null): ToolForm => {
-  const defaults = presetDefaults('generic', '');
+  const preset = presetForTool(tool);
+  const defaults = presetDefaults(preset, '');
+  const reference =
+    tool?.versions.find((version) => version.versionId === tool.recommendedVersionId) ??
+    tool?.versions[0];
   return {
     toolId: tool?.toolId ?? '',
     name: tool?.name ?? '',
@@ -214,8 +294,10 @@ const emptyForm = (tool?: ManagedTool | null): ToolForm => {
     category: tool?.category ?? 'cli',
     publisher: tool?.publisher ?? '',
     version: '',
+    distribution: reference?.definition.distribution ?? tool?.publisher ?? '',
+    versionPublisher: reference?.definition.publisher ?? tool?.publisher ?? '',
     sourceUrl: '',
-    preset: 'generic',
+    preset,
     installerMode: defaults.installerMode,
     stripComponents: defaults.stripComponents,
     installerScript: defaults.installerScript,
@@ -240,6 +322,8 @@ const formFromVersion = (tool: ManagedTool, version: ManagedToolVersion): ToolFo
   category: tool.category,
   publisher: tool.publisher,
   version: version.definition.version,
+  distribution: version.definition.distribution ?? tool.publisher,
+  versionPublisher: version.definition.publisher ?? tool.publisher,
   sourceUrl: version.definition.source.url,
   preset: version.definition.verification.preset,
   installerMode: version.definition.installer.mode,
@@ -283,6 +367,12 @@ const parsePairs = (value: string) =>
 const definitionFromForm = (form: ToolForm): ToolVersionDefinition => ({
   schemaVersion: 1,
   version: form.version.trim(),
+  ...(form.distribution.trim() || form.name.trim()
+    ? { distribution: form.distribution.trim() || form.name.trim() }
+    : {}),
+  ...(form.versionPublisher.trim() || form.publisher.trim()
+    ? { publisher: form.versionPublisher.trim() || form.publisher.trim() }
+    : {}),
   source: {
     type: 'https',
     url: form.sourceUrl.trim(),
@@ -320,6 +410,86 @@ const definitionFromForm = (form: ToolForm): ToolVersionDefinition => ({
   },
 });
 
+const VERSION_PATTERN = /^[0-9][0-9A-Za-z.+:~_-]*$/;
+const CHECKSUM_PATTERN = {
+  sha256: /^[a-f0-9]{64}$/i,
+  sha512: /^[a-f0-9]{128}$/i,
+};
+
+const validateToolForm = (form: ToolForm, creatingTool: boolean) => {
+  const issues: string[] = [];
+  if (creatingTool && !form.name.trim()) issues.push('Give the tool family a name.');
+  if (!form.version.trim()) {
+    issues.push('Enter the exact version.');
+  } else if (!VERSION_PATTERN.test(form.version.trim())) {
+    issues.push('The version must start with a number, for example 21.0.8.9.1.');
+  }
+  if (!creatingTool && !form.distribution.trim()) {
+    issues.push('Name the distribution, for example Amazon Corretto.');
+  }
+  if (!form.sourceUrl.trim()) {
+    issues.push('Add the Linux ARM64 download URL.');
+  } else {
+    try {
+      const source = new URL(form.sourceUrl.trim());
+      if (source.protocol !== 'https:') issues.push('The download URL must use HTTPS.');
+      if (source.username || source.password || source.hash || source.search) {
+        issues.push('Use a direct download URL without credentials, fragments, or query values.');
+      }
+    } catch {
+      issues.push('Enter a valid download URL.');
+    }
+  }
+  if (
+    form.publisherChecksum.trim() &&
+    !CHECKSUM_PATTERN[form.publisherChecksumAlgorithm].test(form.publisherChecksum.trim())
+  ) {
+    issues.push(
+      `The optional ${form.publisherChecksumAlgorithm.toUpperCase()} checksum must contain only the digest characters.`,
+    );
+  }
+  if (!form.executables.trim()) issues.push('Advanced options need at least one executable.');
+  if (!form.versionCommand.trim()) issues.push('Advanced options need a version command.');
+  if (!form.expectedVersion.trim()) issues.push('Advanced options need expected version output.');
+  if (form.installerMode === 'script' && !form.installerScript.trim()) {
+    issues.push('Add the custom installer script or use standard archive extraction.');
+  }
+  return [...new Set(issues)];
+};
+
+const issueLabel = (path: string) => {
+  if (path === 'version') return 'Version';
+  if (path === 'distribution') return 'Distribution';
+  if (path === 'publisher') return 'Publisher';
+  if (path.startsWith('source.url')) return 'Download URL';
+  if (path.startsWith('source.expectedChecksum')) return 'Publisher checksum';
+  if (path.startsWith('installer')) return 'Archive installation';
+  if (path.startsWith('executables')) return 'Executables';
+  if (path.startsWith('dependencies')) return 'Dependencies';
+  if (path.startsWith('aptPackages')) return 'Required packages';
+  if (path.startsWith('environmentVariables')) return 'Environment variables';
+  if (path.startsWith('verification')) return 'Verification';
+  return path;
+};
+
+const toolErrorMessage = (reason: unknown) => {
+  if (reason instanceof ApiError && Array.isArray(reason.body?.issues)) {
+    const details = reason.body.issues
+      .filter((entry): entry is { path: string; message: string } =>
+        Boolean(
+          entry &&
+          typeof entry === 'object' &&
+          typeof (entry as { path?: unknown }).path === 'string' &&
+          typeof (entry as { message?: unknown }).message === 'string',
+        ),
+      )
+      .map((entry) => `${issueLabel(entry.path)}: ${entry.message}`);
+    if (details.length)
+      return `Check these fields:\n${details.map((item) => `• ${item}`).join('\n')}`;
+  }
+  return reason instanceof Error ? reason.message : 'Unable to save the tool version';
+};
+
 const statusClass = (status: string) => {
   if (status === 'FAILED') return 'border-destructive/30 bg-destructive/10 text-destructive';
   if (status === 'PUBLISHED' || status === 'READY')
@@ -331,11 +501,195 @@ const statusClass = (status: string) => {
   return 'bg-muted/50 text-muted-foreground';
 };
 
-function ToolStatus({ status }: { status: string }) {
+const toolStatusLabel = (version: ManagedToolVersion) => {
+  if (version.status === 'SECURITY_REVIEW') {
+    return version.scanFindings?.status === 'UNSUPPORTED' ? 'Scan unavailable' : 'Review required';
+  }
+  const labels: Record<string, string> = {
+    DRAFT: 'Draft',
+    QUEUED: 'Queued',
+    BUILDING: 'Building',
+    SCANNING: 'Checking image',
+    READY: 'Ready to publish',
+    PUBLISHED: 'Published',
+    FAILED: 'Needs attention',
+  };
+  return labels[version.status] ?? version.status.replaceAll('_', ' ');
+};
+
+function ToolStatus({ version }: { version: ManagedToolVersion }) {
+  const scanUnavailable =
+    version.status === 'SECURITY_REVIEW' && version.scanFindings?.status === 'UNSUPPORTED';
   return (
-    <Badge variant="outline" className={cn('font-mono text-[10px]', statusClass(status))}>
-      {status.replaceAll('_', ' ')}
+    <Badge
+      variant="outline"
+      className={cn(
+        'text-[10px] font-medium',
+        scanUnavailable
+          ? 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300'
+          : statusClass(version.status),
+      )}
+    >
+      {toolStatusLabel(version)}
     </Badge>
+  );
+}
+
+const ecrConsoleUrl = (imageUri?: string | null) => {
+  const match = imageUri?.match(
+    /^(?<account>\d{12})\.dkr\.ecr\.(?<region>[a-z0-9-]+)\.amazonaws\.com\/(?<repository>[^:@]+)/,
+  );
+  if (!match?.groups) return null;
+  return `https://${match.groups.region}.console.aws.amazon.com/ecr/repositories/private/${match.groups.account}/${match.groups.repository}?region=${match.groups.region}`;
+};
+
+function ToolLifecycle({
+  version,
+  recommended,
+}: {
+  version: ManagedToolVersion;
+  recommended: boolean;
+}) {
+  const scanUnsupported = version.scanFindings?.status === 'UNSUPPORTED';
+  const counts = version.scanFindings?.severityCounts ?? {};
+  const critical = Number(counts.CRITICAL ?? 0);
+  const high = Number(counts.HIGH ?? 0);
+  const waiting = ACTIVE_STATUSES.has(version.status);
+  const activeIndex =
+    version.status === 'DRAFT'
+      ? 0
+      : ['QUEUED', 'BUILDING'].includes(version.status)
+        ? 1
+        : ['SCANNING', 'SECURITY_REVIEW'].includes(version.status)
+          ? 2
+          : version.status === 'READY'
+            ? 3
+            : version.status === 'PUBLISHED' && !recommended
+              ? 4
+              : version.status === 'FAILED'
+                ? version.imageDigest
+                  ? 2
+                  : 1
+                : -1;
+  const completed = [
+    version.status !== 'DRAFT',
+    Boolean(version.imageDigest),
+    ['READY', 'PUBLISHED'].includes(version.status),
+    version.status === 'PUBLISHED',
+    recommended,
+  ];
+  const stages = TOOL_PROCESS_STEPS;
+  const ecrUrl = ecrConsoleUrl(version.imageUri);
+
+  const statusMessage =
+    version.status === 'DRAFT'
+      ? 'The definition is ready. Start the build when the download URL and version look correct.'
+      : ['QUEUED', 'BUILDING'].includes(version.status)
+        ? 'CodeBuild is downloading the source and creating the reusable tool artifact.'
+        : version.status === 'SCANNING'
+          ? 'The image was built. ECR is checking its operating-system packages.'
+          : version.status === 'SECURITY_REVIEW' && scanUnsupported
+            ? 'ECR could not inspect this image format. This is a scan limitation, not a detected vulnerability.'
+            : version.status === 'SECURITY_REVIEW'
+              ? `ECR found ${critical} Critical and ${high} High package findings. Review them before continuing.`
+              : version.status === 'READY'
+                ? 'Build and checks are complete. Publish this version to make it available.'
+                : version.status === 'PUBLISHED' && !recommended
+                  ? 'Published versions can be selected explicitly. Make this recommended to use it by default.'
+                  : version.status === 'PUBLISHED'
+                    ? 'This is the recommended published version for the tool family.'
+                    : version.failure?.detail ||
+                      'The last attempt needs attention before continuing.';
+
+  return (
+    <div className="rounded-xl border bg-card px-3 py-3">
+      <div className="grid grid-cols-5 gap-1">
+        {stages.map((stage, index) => {
+          const active = activeIndex === index;
+          return (
+            <div key={stage.label} className="relative min-w-0 px-1 text-center">
+              {index > 0 && <span className="absolute right-1/2 top-3.5 h-px w-full bg-border" />}
+              <span
+                className={cn(
+                  'relative z-10 mx-auto flex h-6 w-6 items-center justify-center rounded-full border bg-background',
+                  completed[index] && 'border-emerald-500 bg-emerald-500 text-white',
+                  active &&
+                    !completed[index] &&
+                    'border-primary bg-primary text-primary-foreground',
+                )}
+              >
+                {completed[index] ? (
+                  <Check className="h-3.5 w-3.5" />
+                ) : active && waiting ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Circle className="h-3 w-3" />
+                )}
+              </span>
+              <span
+                className={cn(
+                  'mt-1.5 block truncate text-[10px] text-muted-foreground',
+                  active && 'font-medium text-foreground',
+                )}
+              >
+                {stage.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div
+        className={cn(
+          'mt-3 flex flex-col gap-3 rounded-lg bg-muted/20 p-2.5 sm:flex-row sm:items-center sm:justify-between',
+          version.status === 'FAILED' && 'border-destructive/30 bg-destructive/5',
+          version.status === 'SECURITY_REVIEW' &&
+            !scanUnsupported &&
+            'border-amber-500/30 bg-amber-500/5',
+          version.status === 'SECURITY_REVIEW' &&
+            scanUnsupported &&
+            'border-blue-500/30 bg-blue-500/5',
+        )}
+      >
+        <div className="flex min-w-0 items-start gap-2.5">
+          {waiting ? (
+            <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-primary" />
+          ) : version.status === 'SECURITY_REVIEW' ? (
+            scanUnsupported ? (
+              <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
+            ) : (
+              <ShieldQuestion className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            )
+          ) : version.status === 'FAILED' ? (
+            <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+          ) : (
+            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+          )}
+          <div>
+            <p className="text-xs font-semibold">{toolStatusLabel(version)}</p>
+            <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+              {statusMessage}
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          {version.buildLogUrl && (
+            <Button size="sm" variant="outline" asChild>
+              <a href={version.buildLogUrl} target="_blank" rel="noreferrer">
+                CodeBuild logs <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </Button>
+          )}
+          {ecrUrl && version.imageDigest && (
+            <Button size="sm" variant="outline" asChild>
+              <a href={ecrUrl} target="_blank" rel="noreferrer">
+                Open ECR <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -347,77 +701,50 @@ function VersionEvidence({ version }: { version: ManagedToolVersion }) {
     (version.verification?.securityScan === 'ACCEPTED' ||
       Boolean(version.securityFindingsAcceptedAt));
   return (
-    <div className="space-y-3 border-t pt-4">
-      <div className="grid gap-4 sm:grid-cols-3">
-        <div>
-          <p className="text-[11px] text-muted-foreground">Source integrity</p>
-          <p className="mt-1 text-xs font-medium">
-            {version.source?.trustLevel === 'PUBLISHER_VERIFIED'
-              ? 'Publisher verified'
-              : version.source
-                ? 'Platform pinned'
-                : 'Pending'}
+    <div className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-xl border p-3">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Source
+          </p>
+          <p className="mt-2 text-xs font-medium">
+            {version.source ? 'Download complete' : 'Waiting for build'}
           </p>
           {version.source && (
-            <>
-              <p className="mt-1 break-all font-mono text-[10px] text-muted-foreground">
-                sha256:{version.source.sha256}
-              </p>
-              <a
-                href={version.source.requestedUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
-              >
-                Official source <ExternalLink className="h-3 w-3" />
-              </a>
-            </>
-          )}
-        </div>
-        <div>
-          <p className="text-[11px] text-muted-foreground">Artifact</p>
-          <p className="mt-1 font-mono text-[10px]">
-            {version.imageSizeBytes
-              ? `${(version.imageSizeBytes / 1024 / 1024).toFixed(1)} MiB`
-              : 'Pending'}
-          </p>
-          <p className="mt-1 break-all font-mono text-[10px] text-muted-foreground">
-            {version.imageDigest ?? 'No digest'}
-          </p>
-        </div>
-        <div>
-          <p className="text-[11px] text-muted-foreground">Verification</p>
-          <p className="mt-1 text-xs">
-            {version.verification ? 'ARM64 and functional checks passed' : 'Pending'}
-          </p>
-          {version.scanFindings?.status && (
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              {scanUnsupported
-                ? scanLimitationAccepted
-                  ? 'ECR scan limitation accepted'
-                  : 'ECR scan unavailable'
-                : `ECR scan ${version.scanFindings.status.toLowerCase()}`}
-            </p>
-          )}
-          {version.scanFindings?.description && !scanLimitationAccepted && (
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              {version.scanFindings.description}
-            </p>
-          )}
-          {typeof version.verification?.runtimeCompatibilityVersion === 'string' && (
-            <p className="mt-1 font-mono text-[10px] text-muted-foreground">
-              Runtime contract {String(version.verification.runtimeCompatibilityVersion)}
-            </p>
-          )}
-          {version.buildLogUrl && (
             <a
-              href={version.buildLogUrl}
+              href={version.source.requestedUrl}
               target="_blank"
               rel="noreferrer"
-              className="mt-1 inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              className="mt-1 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
             >
-              Build logs <ExternalLink className="h-3 w-3" />
+              View download <ExternalLink className="h-3 w-3" />
             </a>
+          )}
+        </div>
+        <div className="rounded-xl border p-3">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Artifact
+          </p>
+          <p className="mt-2 text-xs font-medium">
+            {version.imageDigest ? 'Image created' : 'Waiting for build'}
+          </p>
+          {version.imageSizeBytes && (
+            <p className="mt-1 font-mono text-[10px] text-muted-foreground">
+              {(version.imageSizeBytes / 1024 / 1024).toFixed(1)} MiB
+            </p>
+          )}
+        </div>
+        <div className="rounded-xl border p-3">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Functional check
+          </p>
+          <p className="mt-2 text-xs font-medium">
+            {version.verification ? 'Passed' : 'Waiting for checks'}
+          </p>
+          {scanUnsupported && scanLimitationAccepted && (
+            <p className="mt-1 text-[10px] text-muted-foreground">
+              Automated package scan was unavailable and reviewed.
+            </p>
           )}
         </div>
       </div>
@@ -455,10 +782,23 @@ function VersionEvidence({ version }: { version: ManagedToolVersion }) {
       )}
       {version.securityFindingsAcceptedAt && (
         <p className="text-[11px] text-muted-foreground">
-          {scanUnsupported ? 'Security scan limitation' : 'Security findings'} accepted by{' '}
+          {scanUnsupported ? 'Automated scan limitation' : 'Package findings'} reviewed by{' '}
           {version.securityFindingsAcceptedBy ?? 'an administrator'} on{' '}
           {new Date(version.securityFindingsAcceptedAt).toLocaleString()}.
         </p>
+      )}
+      {(version.source || version.imageDigest || version.scanFindings) && (
+        <Disclosure
+          title="Technical details"
+          contentClassName="space-y-2 font-mono text-[10px] text-muted-foreground"
+        >
+          {version.source && <p className="break-all">Source SHA-256: {version.source.sha256}</p>}
+          {version.imageDigest && <p className="break-all">Image: {version.imageDigest}</p>}
+          {version.scanFindings?.status && <p>Scan status: {version.scanFindings.status}</p>}
+          {typeof version.verification?.runtimeCompatibilityVersion === 'string' && (
+            <p>Runtime contract: {String(version.verification.runtimeCompatibilityVersion)}</p>
+          )}
+        </Disclosure>
       )}
       {version.failure && (
         <div className="border-l-2 border-destructive/60 pl-3 text-xs text-destructive">
@@ -467,6 +807,73 @@ function VersionEvidence({ version }: { version: ManagedToolVersion }) {
         </div>
       )}
     </div>
+  );
+}
+
+function VersionDetails({ tool, version }: { tool: ManagedTool; version: ManagedToolVersion }) {
+  const needsEvidence =
+    version.status === 'FAILED' ||
+    (version.status === 'SECURITY_REVIEW' && version.scanFindings?.status !== 'UNSUPPORTED');
+  const [open, setOpen] = useState(needsEvidence);
+
+  useEffect(() => {
+    if (needsEvidence) setOpen(true);
+  }, [needsEvidence]);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="overflow-hidden rounded-xl border">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            aria-label="Details and evidence"
+            className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left"
+          >
+            <span>
+              <span className="block text-xs font-semibold">Details and evidence</span>
+              <span className="mt-0.5 block text-[10px] text-muted-foreground">
+                Source, image, checks, and technical metadata.
+              </span>
+            </span>
+            <ChevronDown
+              className={cn(
+                'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
+                open && 'rotate-180',
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="space-y-3 border-t bg-muted/[0.03] p-3">
+            <div className="grid gap-3 rounded-lg border bg-background p-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
+              <div>
+                <p className="text-muted-foreground">Distribution</p>
+                <p className="mt-1 font-medium">
+                  {version.definition.distribution ??
+                    version.definition.publisher ??
+                    tool.publisher}
+                </p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Publisher</p>
+                <p className="mt-1 font-medium">{version.definition.publisher ?? tool.publisher}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Version</p>
+                <p className="mt-1 font-mono">{version.definition.version}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Tool type</p>
+                <p className="mt-1 font-medium">
+                  {PRESET_LABELS[version.definition.verification.preset]}
+                </p>
+              </div>
+            </div>
+            <VersionEvidence version={version} />
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
   );
 }
 
@@ -489,6 +896,8 @@ function ToolVersionForm({
   onCancel: () => void;
   onSubmit: () => void;
 }) {
+  const [advancedOpen, setAdvancedOpen] = useState(editing);
+  const issues = validateToolForm(form, creatingTool);
   const applyPreset = (preset: VerificationPreset) => {
     const defaults = presetDefaults(preset, form.version);
     onChange({
@@ -511,89 +920,160 @@ function ToolVersionForm({
       <div className="flex items-center justify-between gap-3">
         <h3 className="text-sm font-semibold">
           {creatingTool
-            ? 'New Tool'
+            ? 'New tool family'
             : editing
               ? `Edit ${form.name} ${form.version}`
-              : `Add ${form.name} Version`}
+              : `Add a ${form.name} distribution or version`}
         </h3>
         <Button variant="ghost" size="sm" onClick={onCancel}>
           Cancel
         </Button>
       </div>
 
+      <ProcessOverview steps={[...TOOL_PROCESS_STEPS]} />
+
+      {!creatingTool && !editing && (
+        <div className="flex items-start gap-2 rounded-lg border border-blue-500/25 bg-blue-500/5 p-3">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            Alternatives that provide the same capability belong in this tool family. For example,
+            add Amazon Corretto here as another Java JDK distribution, then publish it and make it
+            recommended. {PRESET_LABELS[form.preset]} settings are applied automatically.
+          </p>
+        </div>
+      )}
+
       {creatingTool && (
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-name" className="text-xs">
-              Name
-            </Label>
-            <Input
-              id="tool-name"
-              value={form.name}
-              onChange={(event) => onChange({ ...form, name: event.target.value })}
-              placeholder=".NET SDK"
-              disabled={disabled}
-            />
+        <div className="space-y-3">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="tool-name" className="text-xs">
+                Name
+              </Label>
+              <Input
+                id="tool-name"
+                value={form.name}
+                onChange={(event) => onChange({ ...form, name: event.target.value })}
+                placeholder=".NET SDK"
+                disabled={disabled}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tool-publisher" className="text-xs">
+                Publisher
+              </Label>
+              <Input
+                id="tool-publisher"
+                value={form.publisher}
+                onChange={(event) => onChange({ ...form, publisher: event.target.value })}
+                placeholder="Microsoft"
+                disabled={disabled}
+              />
+            </div>
           </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-id" className="text-xs">
-              ID
-            </Label>
-            <Input
-              id="tool-id"
-              value={form.toolId}
-              onChange={(event) => onChange({ ...form, toolId: event.target.value })}
-              placeholder="generated-from-name"
-              disabled={disabled}
-              className="font-mono"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-publisher" className="text-xs">
-              Publisher
-            </Label>
-            <Input
-              id="tool-publisher"
-              value={form.publisher}
-              onChange={(event) => onChange({ ...form, publisher: event.target.value })}
-              placeholder="Microsoft"
-              disabled={disabled}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-category" className="text-xs">
-              Category
-            </Label>
-            <Select
-              value={form.category}
-              onValueChange={(category) => onChange({ ...form, category })}
-              disabled={disabled}
-            >
-              <SelectTrigger id="tool-category">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="language-sdk">Language SDK</SelectItem>
-                <SelectItem value="build-tool">Build tool</SelectItem>
-                <SelectItem value="cli">CLI</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-1.5 sm:col-span-2">
-            <Label htmlFor="tool-description" className="text-xs">
-              Description
-            </Label>
-            <Input
-              id="tool-description"
-              value={form.description}
-              onChange={(event) => onChange({ ...form, description: event.target.value })}
-              disabled={disabled}
-            />
-          </div>
+          <Disclosure
+            title="Family details (optional)"
+            contentClassName="grid gap-3 sm:grid-cols-2"
+          >
+            <div className="space-y-1.5">
+              <Label htmlFor="tool-id" className="text-xs">
+                ID
+              </Label>
+              <Input
+                id="tool-id"
+                value={form.toolId}
+                onChange={(event) => onChange({ ...form, toolId: event.target.value })}
+                placeholder="Generated from the name"
+                disabled={disabled}
+                className="font-mono"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tool-category" className="text-xs">
+                Category
+              </Label>
+              <Select
+                value={form.category}
+                onValueChange={(category) => onChange({ ...form, category })}
+                disabled={disabled}
+              >
+                <SelectTrigger id="tool-category">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="language-sdk">Language SDK</SelectItem>
+                  <SelectItem value="build-tool">Build tool</SelectItem>
+                  <SelectItem value="cli">CLI</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5 sm:col-span-2">
+              <Label htmlFor="tool-description" className="text-xs">
+                Description
+              </Label>
+              <Input
+                id="tool-description"
+                value={form.description}
+                onChange={(event) => onChange({ ...form, description: event.target.value })}
+                disabled={disabled}
+              />
+            </div>
+          </Disclosure>
         </div>
       )}
 
       <div className="grid gap-3 sm:grid-cols-2">
+        {!creatingTool && (
+          <>
+            <div className="space-y-1.5">
+              <Label htmlFor="tool-distribution" className="text-xs">
+                Distribution
+              </Label>
+              <Input
+                id="tool-distribution"
+                value={form.distribution}
+                onChange={(event) => onChange({ ...form, distribution: event.target.value })}
+                placeholder="Amazon Corretto"
+                disabled={disabled}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tool-version-publisher" className="text-xs">
+                Publisher
+              </Label>
+              <Input
+                id="tool-version-publisher"
+                value={form.versionPublisher}
+                onChange={(event) => onChange({ ...form, versionPublisher: event.target.value })}
+                placeholder="Amazon Web Services"
+                disabled={disabled}
+              />
+            </div>
+          </>
+        )}
+        {(creatingTool || editing) && (
+          <div className="space-y-1.5">
+            <Label htmlFor="tool-preset" className="text-xs">
+              Tool type
+            </Label>
+            <Select
+              value={form.preset}
+              onValueChange={(value) => applyPreset(value as VerificationPreset)}
+              disabled={disabled}
+            >
+              <SelectTrigger id="tool-preset">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PRESETS.map((preset) => (
+                  <SelectItem key={preset} value={preset}>
+                    {PRESET_LABELS[preset]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
         <div className="space-y-1.5">
           <Label htmlFor="tool-version" className="text-xs">
             Exact version
@@ -610,35 +1090,14 @@ function ToolVersionForm({
                 expectedVersion: defaults.verification.versionCommand.expected,
               });
             }}
-            placeholder="8.0.408"
+            placeholder="21.0.8.9.1"
             disabled={disabled || editing}
             className="font-mono"
           />
         </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="tool-preset" className="text-xs">
-            Verification
-          </Label>
-          <Select
-            value={form.preset}
-            onValueChange={(value) => applyPreset(value as VerificationPreset)}
-            disabled={disabled}
-          >
-            <SelectTrigger id="tool-preset">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {PRESETS.map((preset) => (
-                <SelectItem key={preset} value={preset}>
-                  {preset === 'generic' ? 'Generic CLI' : preset}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
         <div className="space-y-1.5 sm:col-span-2">
           <Label htmlFor="tool-source" className="text-xs">
-            Official ARM64 archive
+            Linux ARM64 download URL
           </Label>
           <Input
             id="tool-source"
@@ -650,322 +1109,374 @@ function ToolVersionForm({
             className="font-mono text-xs"
           />
           <p className="text-[11px] text-muted-foreground">
-            The platform downloads this once, validates the archive, computes SHA-256, and retains
-            the immutable source and OCI artifact.
+            Use the publisher's direct `.tar.gz` or `.zip` download. The platform stores the exact
+            file, builds it, and runs the checks automatically.
           </p>
         </div>
       </div>
 
-      <details className="rounded border">
-        <summary className="cursor-pointer px-3 py-2 text-xs font-medium">
-          Publisher checksum
-        </summary>
-        <div className="grid gap-3 border-t p-3 sm:grid-cols-[140px_minmax(0,1fr)]">
-          <Select
-            value={form.publisherChecksumAlgorithm}
-            onValueChange={(value) =>
-              onChange({
-                ...form,
-                publisherChecksumAlgorithm: value as 'sha256' | 'sha512',
-              })
-            }
-            disabled={disabled}
-          >
-            <SelectTrigger aria-label="Checksum algorithm">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="sha256">SHA-256</SelectItem>
-              <SelectItem value="sha512">SHA-512</SelectItem>
-            </SelectContent>
-          </Select>
-          <Input
-            aria-label="Publisher checksum"
-            value={form.publisherChecksum}
-            onChange={(event) => onChange({ ...form, publisherChecksum: event.target.value })}
-            placeholder="Optional published digest"
-            disabled={disabled}
-            className="font-mono text-xs"
-          />
-          <Input
-            aria-label="Checksum evidence URL"
-            value={form.publisherEvidenceUrl}
-            onChange={(event) => onChange({ ...form, publisherEvidenceUrl: event.target.value })}
-            placeholder="https://publisher.example/checksums.txt"
-            disabled={disabled}
-            className="font-mono text-xs sm:col-span-2"
-          />
-          <p className="text-[11px] text-muted-foreground sm:col-span-2">
-            When both values are supplied and independently match, the version is marked Publisher
-            verified. Otherwise it is still securely pinned to the platform-computed SHA-256.
-          </p>
-        </div>
-      </details>
-
-      <div className="space-y-3 rounded border p-3">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <p className="text-xs font-medium">Generated archive installation</p>
-            <p className="text-[11px] text-muted-foreground">
-              Extract the verified archive without executing publisher code.
-            </p>
-          </div>
-          <Switch
-            aria-label="Use custom installer"
-            checked={form.installerMode === 'script'}
-            onCheckedChange={(checked) =>
-              onChange({ ...form, installerMode: checked ? 'script' : 'generated' })
-            }
-            disabled={disabled}
-          />
-        </div>
-        {form.installerMode === 'generated' ? (
-          <div className="max-w-40 space-y-1.5">
-            <Label htmlFor="tool-strip-components" className="text-xs">
-              Root folders to remove
-            </Label>
-            <Input
-              id="tool-strip-components"
-              type="number"
-              min={0}
-              max={4}
-              value={form.stripComponents}
-              onChange={(event) =>
-                onChange({ ...form, stripComponents: Number(event.target.value) })
-              }
-              disabled={disabled}
-            />
-          </div>
-        ) : (
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-installer" className="text-xs">
-              Sandboxed Bash installer
-            </Label>
-            <Textarea
-              id="tool-installer"
-              value={form.installerScript}
-              onChange={(event) => onChange({ ...form, installerScript: event.target.value })}
-              placeholder={'#!/usr/bin/env bash\nset -Eeuo pipefail\n...'}
-              disabled={disabled}
-              className="min-h-40 font-mono text-xs"
-            />
-            <p className="text-[11px] text-muted-foreground">
-              Runs without AWS credentials, metadata access, host mounts, Docker access, or private
-              network access. Public internet downloads are permitted and make the script
-              non-reproducible; the resulting artifact digest remains immutable.
-            </p>
-          </div>
-        )}
+      <div className="flex items-start gap-2 rounded-lg border bg-muted/15 p-3">
+        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          For standard Java, Go, Rust, Maven, Gradle, and .NET archives, these fields are normally
+          enough. Open Advanced options only when the archive layout or verification is unusual.
+        </p>
       </div>
 
-      <details className="rounded border">
-        <summary className="cursor-pointer px-3 py-2 text-xs font-medium">
-          Executables, dependencies, and custom verification
-        </summary>
-        <div className="grid gap-4 border-t p-3 lg:grid-cols-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-executables" className="text-xs">
-              Exposed executables
-            </Label>
-            <Textarea
-              id="tool-executables"
-              value={form.executables}
-              onChange={(event) => onChange({ ...form, executables: event.target.value })}
-              disabled={disabled}
-              className="min-h-28 font-mono text-xs"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label className="text-xs">Tool dependencies</Label>
-            {tools.length ? (
-              <div className="flex flex-wrap gap-2">
-                {tools.map((tool) => (
-                  <Button
-                    key={tool.toolId}
-                    type="button"
-                    size="sm"
-                    variant={form.dependencies.includes(tool.toolId) ? 'default' : 'outline'}
-                    disabled={disabled || tool.toolId === form.toolId}
-                    onClick={() =>
-                      onChange({
-                        ...form,
-                        dependencies: form.dependencies.includes(tool.toolId)
-                          ? form.dependencies.filter((value) => value !== tool.toolId)
-                          : [...form.dependencies, tool.toolId],
-                      })
-                    }
-                  >
-                    {tool.name}
-                  </Button>
-                ))}
-              </div>
-            ) : (
-              <p className="text-[11px] text-muted-foreground">No catalog dependencies</p>
-            )}
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-apt" className="text-xs">
-              Required apt packages
-            </Label>
-            <Textarea
-              id="tool-apt"
-              value={form.aptPackages}
-              onChange={(event) => onChange({ ...form, aptPackages: event.target.value })}
-              placeholder="package=exact-version"
-              disabled={disabled}
-              className="min-h-24 font-mono text-xs"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-environment" className="text-xs">
-              Environment variables
-            </Label>
-            <Textarea
-              id="tool-environment"
-              value={form.environmentVariables}
-              onChange={(event) => onChange({ ...form, environmentVariables: event.target.value })}
-              placeholder="TOOL_HOME=${TOOL_ROOT}"
-              disabled={disabled}
-              className="min-h-24 font-mono text-xs"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-version-command" className="text-xs">
-              Version command
-            </Label>
-            <Input
-              id="tool-version-command"
-              value={form.versionCommand}
-              onChange={(event) => onChange({ ...form, versionCommand: event.target.value })}
-              disabled={disabled}
-              className="font-mono text-xs"
-            />
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="tool-version-output" className="text-xs">
-              Expected output
-            </Label>
-            <Input
-              id="tool-version-output"
-              value={form.expectedVersion}
-              onChange={(event) => onChange({ ...form, expectedVersion: event.target.value })}
-              disabled={disabled}
-              className="font-mono text-xs"
-            />
-          </div>
-          <div className="space-y-1.5 lg:col-span-2">
-            <Label htmlFor="tool-verifier" className="text-xs">
-              Additional networkless verification
-            </Label>
-            <Textarea
-              id="tool-verifier"
-              value={form.verificationScript}
-              onChange={(event) => onChange({ ...form, verificationScript: event.target.value })}
-              disabled={disabled}
-              className="min-h-28 font-mono text-xs"
-            />
-          </div>
-          <div className="space-y-1.5 lg:col-span-2">
-            <div className="flex items-center justify-between gap-3">
-              <Label className="text-xs">Verification fixture files</Label>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={disabled || form.verificationFiles.length >= 32}
-                onClick={() =>
-                  onChange({
-                    ...form,
-                    verificationFiles: [...form.verificationFiles, { path: '', content: '' }],
-                  })
-                }
+      <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+        <section className="rounded-xl border">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left"
+            >
+              <span>
+                <span className="block text-xs font-semibold">Advanced options</span>
+                <span className="mt-0.5 block text-[11px] text-muted-foreground">
+                  Only for non-standard archives or custom runtime requirements.
+                </span>
+              </span>
+              <ChevronDown
+                className={cn(
+                  'h-4 w-4 text-muted-foreground transition-transform',
+                  advancedOpen && 'rotate-180',
+                )}
+              />
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="space-y-4 border-t p-4">
+              <Disclosure
+                title="Publisher integrity details (optional)"
+                contentClassName="grid gap-3 sm:grid-cols-[140px_minmax(0,1fr)]"
               >
-                <Plus className="h-3.5 w-3.5" />
-                Add File
-              </Button>
-            </div>
-            {form.verificationFiles.length ? (
-              <div className="divide-y rounded border">
-                {form.verificationFiles.map((file, index) => (
-                  <div key={index} className="space-y-2 p-3">
-                    <div className="flex items-center gap-2">
-                      <Input
-                        aria-label={`Verification file ${index + 1} path`}
-                        value={file.path}
-                        onChange={(event) =>
-                          onChange({
-                            ...form,
-                            verificationFiles: form.verificationFiles.map((entry, entryIndex) =>
-                              entryIndex === index ? { ...entry, path: event.target.value } : entry,
-                            ),
-                          })
-                        }
-                        placeholder="project/expected.txt"
-                        disabled={disabled}
-                        className="font-mono text-xs"
-                      />
-                      <Button
-                        type="button"
-                        size="icon"
-                        variant="ghost"
-                        title="Remove fixture"
-                        disabled={disabled}
-                        onClick={() =>
-                          onChange({
-                            ...form,
-                            verificationFiles: form.verificationFiles.filter(
-                              (_, entryIndex) => entryIndex !== index,
-                            ),
-                          })
-                        }
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                    <Textarea
-                      aria-label={`Verification file ${index + 1} content`}
-                      value={file.content}
+                <Select
+                  value={form.publisherChecksumAlgorithm}
+                  onValueChange={(value) =>
+                    onChange({
+                      ...form,
+                      publisherChecksumAlgorithm: value as 'sha256' | 'sha512',
+                    })
+                  }
+                  disabled={disabled}
+                >
+                  <SelectTrigger aria-label="Checksum algorithm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="sha256">SHA-256</SelectItem>
+                    <SelectItem value="sha512">SHA-512</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Input
+                  aria-label="Publisher checksum"
+                  value={form.publisherChecksum}
+                  onChange={(event) => onChange({ ...form, publisherChecksum: event.target.value })}
+                  placeholder="Optional published digest"
+                  disabled={disabled}
+                  className="font-mono text-xs"
+                />
+                <Input
+                  aria-label="Checksum evidence URL"
+                  value={form.publisherEvidenceUrl}
+                  onChange={(event) =>
+                    onChange({ ...form, publisherEvidenceUrl: event.target.value })
+                  }
+                  placeholder="https://publisher.example/checksums.txt"
+                  disabled={disabled}
+                  className="font-mono text-xs sm:col-span-2"
+                />
+                <p className="text-[11px] text-muted-foreground sm:col-span-2">
+                  When both values are supplied and independently match, the version is marked
+                  Publisher verified. Otherwise it is still securely pinned to the platform-computed
+                  SHA-256.
+                </p>
+              </Disclosure>
+
+              <div className="space-y-3 rounded border p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-medium">Generated archive installation</p>
+                    <p className="text-[11px] text-muted-foreground">
+                      Extract the verified archive without executing publisher code.
+                    </p>
+                  </div>
+                  <Switch
+                    aria-label="Use custom installer"
+                    checked={form.installerMode === 'script'}
+                    onCheckedChange={(checked) =>
+                      onChange({ ...form, installerMode: checked ? 'script' : 'generated' })
+                    }
+                    disabled={disabled}
+                  />
+                </div>
+                {form.installerMode === 'generated' ? (
+                  <div className="max-w-40 space-y-1.5">
+                    <Label htmlFor="tool-strip-components" className="text-xs">
+                      Root folders to remove
+                    </Label>
+                    <Input
+                      id="tool-strip-components"
+                      type="number"
+                      min={0}
+                      max={4}
+                      value={form.stripComponents}
                       onChange={(event) =>
-                        onChange({
-                          ...form,
-                          verificationFiles: form.verificationFiles.map((entry, entryIndex) =>
-                            entryIndex === index
-                              ? { ...entry, content: event.target.value }
-                              : entry,
-                          ),
-                        })
+                        onChange({ ...form, stripComponents: Number(event.target.value) })
                       }
                       disabled={disabled}
-                      className="min-h-28 font-mono text-xs"
                     />
                   </div>
-                ))}
+                ) : (
+                  <div className="space-y-1.5">
+                    <Label htmlFor="tool-installer" className="text-xs">
+                      Sandboxed Bash installer
+                    </Label>
+                    <Textarea
+                      id="tool-installer"
+                      value={form.installerScript}
+                      onChange={(event) =>
+                        onChange({ ...form, installerScript: event.target.value })
+                      }
+                      placeholder={'#!/usr/bin/env bash\nset -Eeuo pipefail\n...'}
+                      disabled={disabled}
+                      className="min-h-40 font-mono text-xs"
+                    />
+                    <p className="text-[11px] text-muted-foreground">
+                      Runs without AWS credentials, metadata access, host mounts, Docker access, or
+                      private network access. Public internet downloads are permitted and make the
+                      script non-reproducible; the resulting artifact digest remains immutable.
+                    </p>
+                  </div>
+                )}
               </div>
-            ) : (
-              <p className="text-[11px] text-muted-foreground">
-                Optional text files mounted read-only for custom networkless verification.
-              </p>
-            )}
-          </div>
+
+              <Disclosure
+                title="Executables, dependencies, and custom verification"
+                contentClassName="grid gap-4 lg:grid-cols-2"
+              >
+                <div className="space-y-1.5">
+                  <Label htmlFor="tool-executables" className="text-xs">
+                    Exposed executables
+                  </Label>
+                  <Textarea
+                    id="tool-executables"
+                    value={form.executables}
+                    onChange={(event) => onChange({ ...form, executables: event.target.value })}
+                    disabled={disabled}
+                    className="min-h-28 font-mono text-xs"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-xs">Tool dependencies</Label>
+                  {tools.length ? (
+                    <div className="flex flex-wrap gap-2">
+                      {tools.map((tool) => (
+                        <Button
+                          key={tool.toolId}
+                          type="button"
+                          size="sm"
+                          variant={form.dependencies.includes(tool.toolId) ? 'default' : 'outline'}
+                          disabled={disabled || tool.toolId === form.toolId}
+                          onClick={() =>
+                            onChange({
+                              ...form,
+                              dependencies: form.dependencies.includes(tool.toolId)
+                                ? form.dependencies.filter((value) => value !== tool.toolId)
+                                : [...form.dependencies, tool.toolId],
+                            })
+                          }
+                        >
+                          {tool.name}
+                        </Button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-[11px] text-muted-foreground">No catalog dependencies</p>
+                  )}
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="tool-apt" className="text-xs">
+                    Required apt packages
+                  </Label>
+                  <Textarea
+                    id="tool-apt"
+                    value={form.aptPackages}
+                    onChange={(event) => onChange({ ...form, aptPackages: event.target.value })}
+                    placeholder="package=exact-version"
+                    disabled={disabled}
+                    className="min-h-24 font-mono text-xs"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="tool-environment" className="text-xs">
+                    Environment variables
+                  </Label>
+                  <Textarea
+                    id="tool-environment"
+                    value={form.environmentVariables}
+                    onChange={(event) =>
+                      onChange({ ...form, environmentVariables: event.target.value })
+                    }
+                    placeholder="TOOL_HOME=${TOOL_ROOT}"
+                    disabled={disabled}
+                    className="min-h-24 font-mono text-xs"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="tool-version-command" className="text-xs">
+                    Version command
+                  </Label>
+                  <Input
+                    id="tool-version-command"
+                    value={form.versionCommand}
+                    onChange={(event) => onChange({ ...form, versionCommand: event.target.value })}
+                    disabled={disabled}
+                    className="font-mono text-xs"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="tool-version-output" className="text-xs">
+                    Expected output
+                  </Label>
+                  <Input
+                    id="tool-version-output"
+                    value={form.expectedVersion}
+                    onChange={(event) => onChange({ ...form, expectedVersion: event.target.value })}
+                    disabled={disabled}
+                    className="font-mono text-xs"
+                  />
+                </div>
+                <div className="space-y-1.5 lg:col-span-2">
+                  <Label htmlFor="tool-verifier" className="text-xs">
+                    Additional networkless verification
+                  </Label>
+                  <Textarea
+                    id="tool-verifier"
+                    value={form.verificationScript}
+                    onChange={(event) =>
+                      onChange({ ...form, verificationScript: event.target.value })
+                    }
+                    disabled={disabled}
+                    className="min-h-28 font-mono text-xs"
+                  />
+                </div>
+                <div className="space-y-1.5 lg:col-span-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <Label className="text-xs">Verification fixture files</Label>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={disabled || form.verificationFiles.length >= 32}
+                      onClick={() =>
+                        onChange({
+                          ...form,
+                          verificationFiles: [...form.verificationFiles, { path: '', content: '' }],
+                        })
+                      }
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      Add File
+                    </Button>
+                  </div>
+                  {form.verificationFiles.length ? (
+                    <div className="divide-y rounded border">
+                      {form.verificationFiles.map((file, index) => (
+                        <div key={index} className="space-y-2 p-3">
+                          <div className="flex items-center gap-2">
+                            <Input
+                              aria-label={`Verification file ${index + 1} path`}
+                              value={file.path}
+                              onChange={(event) =>
+                                onChange({
+                                  ...form,
+                                  verificationFiles: form.verificationFiles.map(
+                                    (entry, entryIndex) =>
+                                      entryIndex === index
+                                        ? { ...entry, path: event.target.value }
+                                        : entry,
+                                  ),
+                                })
+                              }
+                              placeholder="project/expected.txt"
+                              disabled={disabled}
+                              className="font-mono text-xs"
+                            />
+                            <Button
+                              type="button"
+                              size="icon"
+                              variant="ghost"
+                              title="Remove fixture"
+                              disabled={disabled}
+                              onClick={() =>
+                                onChange({
+                                  ...form,
+                                  verificationFiles: form.verificationFiles.filter(
+                                    (_, entryIndex) => entryIndex !== index,
+                                  ),
+                                })
+                              }
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                          <Textarea
+                            aria-label={`Verification file ${index + 1} content`}
+                            value={file.content}
+                            onChange={(event) =>
+                              onChange({
+                                ...form,
+                                verificationFiles: form.verificationFiles.map(
+                                  (entry, entryIndex) =>
+                                    entryIndex === index
+                                      ? { ...entry, content: event.target.value }
+                                      : entry,
+                                ),
+                              })
+                            }
+                            disabled={disabled}
+                            className="min-h-28 font-mono text-xs"
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-[11px] text-muted-foreground">
+                      Optional text files mounted read-only for custom networkless verification.
+                    </p>
+                  )}
+                </div>
+              </Disclosure>
+            </div>
+          </CollapsibleContent>
+        </section>
+      </Collapsible>
+
+      {issues.length > 0 && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3">
+          <p className="text-xs font-medium text-amber-800 dark:text-amber-200">
+            Before starting the build
+          </p>
+          <ul className="mt-1.5 space-y-1 text-[11px] text-amber-800/90 dark:text-amber-200/90">
+            {issues.map((issue) => (
+              <li key={issue} className="flex items-start gap-1.5">
+                <span aria-hidden="true">•</span>
+                <span>{issue}</span>
+              </li>
+            ))}
+          </ul>
         </div>
-      </details>
+      )}
 
       <Button
         size="sm"
         className="gap-1.5"
-        disabled={
-          disabled ||
-          !form.name.trim() ||
-          !form.version.trim() ||
-          !form.sourceUrl.trim() ||
-          !form.executables.trim() ||
-          !form.versionCommand.trim() ||
-          !form.expectedVersion.trim()
-        }
+        disabled={disabled || issues.length > 0}
         onClick={onSubmit}
       >
         {disabled ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Hammer />}
-        {editing ? 'Save and Build' : 'Create and Build'}
+        {editing ? 'Save and rebuild' : 'Create and start build'}
       </Button>
     </div>
   );
@@ -982,6 +1493,7 @@ export function ToolsRegistry() {
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [confirmation, setConfirmation] = useState<Confirmation | null>(null);
 
   const load = useCallback(async (preferredToolId?: string, preferredVersionId?: string) => {
     const values = await toolsService.list();
@@ -1050,7 +1562,7 @@ export function ToolsRegistry() {
       await action();
       await load(selectedToolId ?? undefined, selectedVersionId ?? undefined);
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : 'Tool action failed');
+      setError(toolErrorMessage(reason));
     } finally {
       setBusy(null);
     }
@@ -1099,7 +1611,7 @@ export function ToolsRegistry() {
       setEditingVersionId(null);
       await load(tool.toolId, persistedVersionId ?? undefined);
     } catch (reason) {
-      setError(reason instanceof Error ? reason.message : 'Unable to create tool version');
+      setError(toolErrorMessage(reason));
       if (persistedToolId) {
         await load(persistedToolId, persistedVersionId ?? undefined).catch(() => undefined);
       }
@@ -1108,316 +1620,370 @@ export function ToolsRegistry() {
     }
   };
 
+  const requestSecurityReview = (tool: ManagedTool, version: ManagedToolVersion) => {
+    const scanUnsupported = version.scanFindings?.status === 'UNSUPPORTED';
+    const counts = version.scanFindings?.severityCounts ?? {};
+    const critical = Number(counts.CRITICAL ?? 0);
+    const high = Number(counts.HIGH ?? 0);
+    setConfirmation({
+      title: scanUnsupported ? 'Continue without an automated package scan?' : 'Review findings?',
+      description: scanUnsupported
+        ? 'ECR could not inspect this image format. This does not mean a vulnerability was found. Continue only when you trust the publisher and download source.'
+        : `ECR found ${critical} Critical and ${high} High package findings. Continuing records your review and allows this version to be published.`,
+      actionLabel: scanUnsupported ? 'Continue after review' : 'Accept findings',
+      onConfirm: () =>
+        void run('accept', () => toolsService.acceptFindings(tool.toolId, version.versionId)),
+    });
+  };
+
+  const requestRecommendation = (tool: ManagedTool, version: ManagedToolVersion) => {
+    const current = tool.versions.find((item) => item.versionId === tool.recommendedVersionId);
+    const candidateName =
+      version.definition.distribution ?? version.definition.publisher ?? tool.publisher;
+    const currentName =
+      current?.definition.distribution ?? current?.definition.publisher ?? tool.publisher;
+    setConfirmation({
+      title: current ? `Replace ${currentName} as recommended?` : `Recommend ${candidateName}?`,
+      description: current
+        ? `${candidateName} ${version.definition.version} will replace ${currentName} ${current.definition.version} as the default for ${tool.name}. Existing environments remain unchanged until an administrator creates a new revision.`
+        : `${candidateName} ${version.definition.version} will become the default version offered for ${tool.name}.`,
+      actionLabel: current ? 'Replace recommendation' : 'Make recommended',
+      onConfirm: () =>
+        void run('recommend', () => toolsService.recommend(tool.toolId, version.versionId)),
+    });
+  };
+
   return (
-    <SettingsCard
-      icon={<Wrench />}
-      title="Tool Catalog"
-      description="Verified ARM64 tool artifacts available to managed environments."
-      headerAction={
-        <Button
-          size="sm"
-          className="gap-1.5"
-          disabled={Boolean(busy)}
-          onClick={() => {
-            setCreatingTool(true);
-            setCreatingVersion(false);
-            setEditingVersionId(null);
-            setForm(emptyForm());
-            setError(null);
-          }}
-        >
-          <Plus className="h-3.5 w-3.5" />
-          Add Tool
-        </Button>
-      }
-    >
-      {loading ? (
-        <div className="grid gap-4 lg:grid-cols-[230px_minmax(0,1fr)]">
-          <Skeleton className="h-72" />
-          <Skeleton className="h-96" />
-        </div>
-      ) : (
-        <div className="grid min-w-0 gap-5 lg:grid-cols-[230px_minmax(0,1fr)]">
-          <div className="space-y-1 border-r pr-4">
-            {tools.map((tool) => (
-              <button
-                key={tool.toolId}
-                type="button"
-                className={cn(
-                  'flex w-full items-start justify-between gap-2 rounded px-2.5 py-2 text-left hover:bg-muted/60',
-                  !creatingTool && selectedToolId === tool.toolId && 'bg-muted',
-                )}
-                onClick={() => {
-                  setCreatingTool(false);
-                  setCreatingVersion(false);
-                  setEditingVersionId(null);
-                  setSelectedToolId(tool.toolId);
-                }}
-              >
-                <span className="min-w-0">
-                  <span className="block truncate text-xs font-medium">{tool.name}</span>
-                  <span className="block truncate font-mono text-[10px] text-muted-foreground">
-                    {tool.toolId}
-                  </span>
-                </span>
-                {tool.recommendedVersionId && (
-                  <Star className="mt-0.5 h-3.5 w-3.5 fill-amber-400 text-amber-500" />
-                )}
-              </button>
-            ))}
+    <>
+      <SettingsCard
+        icon={<Wrench />}
+        title="Tool Catalog"
+        description="Add a distribution, let the platform build and check it, then publish it for environments."
+        headerAction={
+          <Button
+            size="sm"
+            className="gap-1.5"
+            disabled={Boolean(busy)}
+            onClick={() => {
+              setCreatingTool(true);
+              setCreatingVersion(false);
+              setEditingVersionId(null);
+              setForm(emptyForm());
+              setError(null);
+            }}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New tool family
+          </Button>
+        }
+      >
+        {loading ? (
+          <div className="grid gap-4 lg:grid-cols-[230px_minmax(0,1fr)]">
+            <Skeleton className="h-72" />
+            <Skeleton className="h-96" />
           </div>
+        ) : (
+          <div className="grid min-w-0 gap-5 lg:grid-cols-[230px_minmax(0,1fr)]">
+            <div className="space-y-1 border-r pr-4">
+              {tools.map((tool) => (
+                <button
+                  key={tool.toolId}
+                  type="button"
+                  aria-pressed={!creatingTool && selectedToolId === tool.toolId}
+                  className={cn(
+                    'flex w-full items-start justify-between gap-2 rounded px-2.5 py-2 text-left hover:bg-muted/60',
+                    !creatingTool && selectedToolId === tool.toolId && 'bg-muted',
+                  )}
+                  onClick={() => {
+                    setCreatingTool(false);
+                    setCreatingVersion(false);
+                    setEditingVersionId(null);
+                    setSelectedToolId(tool.toolId);
+                  }}
+                >
+                  <span className="min-w-0">
+                    <span className="block truncate text-xs font-medium">{tool.name}</span>
+                    <span className="block truncate font-mono text-[10px] text-muted-foreground">
+                      {tool.toolId}
+                    </span>
+                  </span>
+                  {tool.recommendedVersionId && (
+                    <span className="mt-0.5 shrink-0 text-amber-500">
+                      <Star className="h-3.5 w-3.5 fill-amber-400" />
+                      <span className="sr-only">Has a recommended version</span>
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
 
-          <div className="min-w-0 space-y-5">
-            {creatingTool || creatingVersion ? (
-              <ToolVersionForm
-                form={form}
-                tools={tools}
-                creatingTool={creatingTool}
-                editing={Boolean(editingVersionId)}
-                disabled={Boolean(busy)}
-                onChange={setForm}
-                onCancel={() => {
-                  setCreatingTool(false);
-                  setCreatingVersion(false);
-                  setEditingVersionId(null);
-                }}
-                onSubmit={() => void createAndBuild()}
-              />
-            ) : selectedTool ? (
-              <>
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <h3 className="text-sm font-semibold">{selectedTool.name}</h3>
-                      {selectedTool.system && <Badge variant="secondary">Platform</Badge>}
-                    </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {selectedTool.publisher || 'Administrator managed'}
-                    </p>
-                    {selectedTool.description && (
+            <div className="min-w-0 space-y-5">
+              {creatingTool || creatingVersion ? (
+                <ToolVersionForm
+                  form={form}
+                  tools={tools}
+                  creatingTool={creatingTool}
+                  editing={Boolean(editingVersionId)}
+                  disabled={Boolean(busy)}
+                  onChange={(value) => {
+                    setForm(value);
+                    setError(null);
+                  }}
+                  onCancel={() => {
+                    setCreatingTool(false);
+                    setCreatingVersion(false);
+                    setEditingVersionId(null);
+                  }}
+                  onSubmit={() => void createAndBuild()}
+                />
+              ) : selectedTool ? (
+                <>
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-sm font-semibold">{selectedTool.name}</h3>
+                        {selectedTool.system && <Badge variant="secondary">Platform</Badge>}
+                      </div>
                       <p className="mt-1 text-xs text-muted-foreground">
-                        {selectedTool.description}
+                        Versions and distributions for this capability.
                       </p>
-                    )}
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="gap-1.5"
+                      disabled={Boolean(busy)}
+                      onClick={() => {
+                        setCreatingVersion(true);
+                        setEditingVersionId(null);
+                        setForm(emptyForm(selectedTool));
+                      }}
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      Add distribution or version
+                    </Button>
                   </div>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="gap-1.5"
-                    onClick={() => {
-                      setCreatingVersion(true);
-                      setEditingVersionId(null);
-                      setForm(emptyForm(selectedTool));
-                    }}
-                  >
-                    <Plus className="h-3.5 w-3.5" />
-                    Add Version
-                  </Button>
-                </div>
 
-                {selectedTool.versions.length ? (
-                  <>
-                    <div className="flex flex-wrap items-center gap-2 border-y py-3">
-                      <Select
-                        value={selectedVersion?.versionId}
-                        onValueChange={setSelectedVersionId}
-                      >
-                        <SelectTrigger
-                          aria-label="Tool version"
-                          className="h-8 w-72 font-mono text-xs"
+                  {selectedTool.versions.length ? (
+                    <>
+                      <div className="flex flex-wrap items-center gap-2 border-y py-3">
+                        <Select
+                          value={selectedVersion?.versionId}
+                          onValueChange={setSelectedVersionId}
                         >
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {selectedTool.versions.map((version) => (
-                            <SelectItem key={version.versionId} value={version.versionId}>
-                              {version.definition.version} · {version.status}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      {selectedVersion && <ToolStatus status={selectedVersion.status} />}
-                      {selectedVersion?.versionId === selectedTool.recommendedVersionId && (
-                        <Badge variant="outline" className="gap-1 text-[10px]">
-                          <Star className="h-3 w-3 fill-amber-400 text-amber-500" />
-                          Recommended
-                        </Badge>
-                      )}
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="h-8 w-8"
-                        title="Refresh"
-                        onClick={() => void load(selectedTool.toolId)}
-                      >
-                        <RefreshCw className="h-3.5 w-3.5" />
-                      </Button>
-                      <div className="ml-auto flex flex-wrap gap-2">
-                        {selectedVersion &&
-                          ['DRAFT', 'FAILED'].includes(selectedVersion.status) && (
+                          <SelectTrigger
+                            aria-label="Tool version"
+                            className="h-8 w-72 font-mono text-xs"
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {selectedTool.versions.map((version) => (
+                              <SelectItem key={version.versionId} value={version.versionId}>
+                                {version.definition.distribution ??
+                                  version.definition.publisher ??
+                                  selectedTool.publisher}{' '}
+                                {version.definition.version} · {toolStatusLabel(version)}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        {selectedVersion && <ToolStatus version={selectedVersion} />}
+                        {selectedVersion?.versionId === selectedTool.recommendedVersionId && (
+                          <Badge variant="outline" className="gap-1 text-[10px]">
+                            <Star className="h-3 w-3 fill-amber-400 text-amber-500" />
+                            Recommended
+                          </Badge>
+                        )}
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8"
+                          title="Refresh"
+                          aria-label="Refresh tool status"
+                          disabled={Boolean(busy)}
+                          onClick={() => void load(selectedTool.toolId)}
+                        >
+                          <RefreshCw className="h-3.5 w-3.5" />
+                        </Button>
+                        <div className="ml-auto flex flex-wrap gap-2">
+                          {selectedVersion &&
+                            ['DRAFT', 'FAILED'].includes(selectedVersion.status) && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={Boolean(busy)}
+                                onClick={() => {
+                                  setCreatingVersion(true);
+                                  setEditingVersionId(selectedVersion.versionId);
+                                  setForm(formFromVersion(selectedTool, selectedVersion));
+                                }}
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                                Edit
+                              </Button>
+                            )}
+                          {selectedVersion?.status === 'DRAFT' && (
                             <Button
                               size="sm"
-                              variant="outline"
-                              onClick={() => {
-                                setCreatingVersion(true);
-                                setEditingVersionId(selectedVersion.versionId);
-                                setForm(formFromVersion(selectedTool, selectedVersion));
-                              }}
-                            >
-                              <Pencil className="h-3.5 w-3.5" />
-                              Edit
-                            </Button>
-                          )}
-                        {selectedVersion?.status === 'DRAFT' && (
-                          <Button
-                            size="sm"
-                            disabled={missingDependencies.length > 0}
-                            onClick={() =>
-                              void run('build', () =>
-                                toolsService.build(selectedTool.toolId, selectedVersion.versionId),
-                              )
-                            }
-                          >
-                            <Hammer className="h-3.5 w-3.5" />
-                            Build
-                          </Button>
-                        )}
-                        {selectedVersion?.status === 'FAILED' && (
-                          <Button
-                            size="sm"
-                            disabled={missingDependencies.length > 0}
-                            onClick={() =>
-                              void run('retry', () =>
-                                toolsService.retry(selectedTool.toolId, selectedVersion.versionId),
-                              )
-                            }
-                          >
-                            <RefreshCw className="h-3.5 w-3.5" />
-                            Retry
-                          </Button>
-                        )}
-                        {selectedVersion?.status === 'SECURITY_REVIEW' && (
-                          <Button
-                            size="sm"
-                            onClick={() => {
-                              const scanUnsupported =
-                                selectedVersion.scanFindings?.status === 'UNSUPPORTED';
-                              const counts = selectedVersion.scanFindings?.severityCounts ?? {};
-                              const critical = counts.CRITICAL ?? 0;
-                              const high = counts.HIGH ?? 0;
-                              if (
-                                !window.confirm(
-                                  scanUnsupported
-                                    ? 'ECR could not scan this artifact. Accept the scan limitation and continue verification?'
-                                    : `Accept ${critical} Critical and ${high} High findings and continue verification?`,
-                                )
-                              ) {
-                                return;
-                              }
-                              void run('accept', () =>
-                                toolsService.acceptFindings(
-                                  selectedTool.toolId,
-                                  selectedVersion.versionId,
-                                ),
-                              );
-                            }}
-                          >
-                            <ShieldAlert className="h-3.5 w-3.5" />
-                            {selectedVersion.scanFindings?.status === 'UNSUPPORTED'
-                              ? 'Accept Scan Limitation'
-                              : 'Accept Findings'}
-                          </Button>
-                        )}
-                        {selectedVersion?.status === 'READY' && (
-                          <Button
-                            size="sm"
-                            onClick={() =>
-                              void run('publish', () =>
-                                toolsService.publish(
-                                  selectedTool.toolId,
-                                  selectedVersion.versionId,
-                                ),
-                              )
-                            }
-                          >
-                            <Rocket className="h-3.5 w-3.5" />
-                            Publish
-                          </Button>
-                        )}
-                        {selectedVersion?.status === 'PUBLISHED' &&
-                          selectedVersion.versionId !== selectedTool.recommendedVersionId && (
-                            <Button
-                              size="sm"
-                              variant="outline"
+                              disabled={Boolean(busy) || missingDependencies.length > 0}
                               onClick={() =>
-                                void run('recommend', () =>
-                                  toolsService.recommend(
+                                void run('build', () =>
+                                  toolsService.build(
                                     selectedTool.toolId,
                                     selectedVersion.versionId,
                                   ),
                                 )
                               }
                             >
-                              <Star className="h-3.5 w-3.5" />
-                              Recommend
+                              <Hammer className="h-3.5 w-3.5" />
+                              Build
                             </Button>
                           )}
+                          {selectedVersion?.status === 'FAILED' && (
+                            <Button
+                              size="sm"
+                              disabled={Boolean(busy) || missingDependencies.length > 0}
+                              onClick={() =>
+                                void run('retry', () =>
+                                  toolsService.retry(
+                                    selectedTool.toolId,
+                                    selectedVersion.versionId,
+                                  ),
+                                )
+                              }
+                            >
+                              <RefreshCw className="h-3.5 w-3.5" />
+                              Retry
+                            </Button>
+                          )}
+                          {selectedVersion?.status === 'SECURITY_REVIEW' && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              disabled={Boolean(busy)}
+                              onClick={() => requestSecurityReview(selectedTool, selectedVersion)}
+                            >
+                              {selectedVersion.scanFindings?.status === 'UNSUPPORTED' ? (
+                                <Info className="h-3.5 w-3.5" />
+                              ) : (
+                                <ShieldQuestion className="h-3.5 w-3.5" />
+                              )}
+                              {selectedVersion.scanFindings?.status === 'UNSUPPORTED'
+                                ? 'Continue without scan'
+                                : 'Review package findings'}
+                            </Button>
+                          )}
+                          {selectedVersion?.status === 'READY' && (
+                            <Button
+                              size="sm"
+                              disabled={Boolean(busy)}
+                              onClick={() =>
+                                void run('publish', () =>
+                                  toolsService.publish(
+                                    selectedTool.toolId,
+                                    selectedVersion.versionId,
+                                  ),
+                                )
+                              }
+                            >
+                              <Rocket className="h-3.5 w-3.5" />
+                              Publish
+                            </Button>
+                          )}
+                          {selectedVersion?.status === 'PUBLISHED' &&
+                            selectedVersion.versionId !== selectedTool.recommendedVersionId && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={Boolean(busy)}
+                                onClick={() => requestRecommendation(selectedTool, selectedVersion)}
+                              >
+                                <Star className="h-3.5 w-3.5" />
+                                {selectedTool.recommendedVersionId
+                                  ? 'Replace recommendation'
+                                  : 'Make recommended'}
+                              </Button>
+                            )}
+                        </div>
                       </div>
-                    </div>
-                    {missingDependencies.length > 0 &&
-                      selectedVersion &&
-                      ['DRAFT', 'FAILED'].includes(selectedVersion.status) && (
-                        <div className="border-l-2 border-amber-500/60 pl-3 text-xs text-amber-700 dark:text-amber-300">
-                          Publish and recommend{' '}
-                          {missingDependencies
-                            .map(
-                              (toolId) =>
-                                tools.find((tool) => tool.toolId === toolId)?.name ?? toolId,
-                            )
-                            .join(', ')}{' '}
-                          before building this version.
-                        </div>
+                      {missingDependencies.length > 0 &&
+                        selectedVersion &&
+                        ['DRAFT', 'FAILED'].includes(selectedVersion.status) && (
+                          <div className="border-l-2 border-amber-500/60 pl-3 text-xs text-amber-700 dark:text-amber-300">
+                            Publish and recommend{' '}
+                            {missingDependencies
+                              .map(
+                                (toolId) =>
+                                  tools.find((tool) => tool.toolId === toolId)?.name ?? toolId,
+                              )
+                              .join(', ')}{' '}
+                            before building this version.
+                          </div>
+                        )}
+                      {selectedVersion && (
+                        <>
+                          <ToolLifecycle
+                            version={selectedVersion}
+                            recommended={
+                              selectedVersion.versionId === selectedTool.recommendedVersionId
+                            }
+                          />
+                          <VersionDetails
+                            key={selectedVersion.versionId}
+                            tool={selectedTool}
+                            version={selectedVersion}
+                          />
+                        </>
                       )}
-                    {selectedVersion && (
-                      <>
-                        <div className="grid gap-3 text-xs sm:grid-cols-3">
-                          <div>
-                            <p className="text-muted-foreground">Version</p>
-                            <p className="mt-1 font-mono">{selectedVersion.definition.version}</p>
-                          </div>
-                          <div>
-                            <p className="text-muted-foreground">Preset</p>
-                            <p className="mt-1">{selectedVersion.definition.verification.preset}</p>
-                          </div>
-                          <div>
-                            <p className="text-muted-foreground">Executables</p>
-                            <p className="mt-1 font-mono">
-                              {selectedVersion.definition.executables
-                                .map((entry) => entry.name)
-                                .join(', ')}
-                            </p>
-                          </div>
-                        </div>
-                        <VersionEvidence version={selectedVersion} />
-                      </>
-                    )}
-                  </>
-                ) : (
-                  <div className="border-l-2 border-muted pl-3 text-xs text-muted-foreground">
-                    No versions have been added.
-                  </div>
-                )}
-              </>
-            ) : (
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <CircleCheck className="h-4 w-4" />
-                Add a tool to begin.
-              </div>
-            )}
-            {error && <p className="text-xs text-destructive">{error}</p>}
+                    </>
+                  ) : (
+                    <div className="border-l-2 border-muted pl-3 text-xs text-muted-foreground">
+                      No versions have been added.
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <CircleCheck className="h-4 w-4" />
+                  Add a tool family to begin.
+                </div>
+              )}
+              {error && (
+                <div className="whitespace-pre-line rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+                  {error}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
-    </SettingsCard>
+        )}
+      </SettingsCard>
+
+      <AlertDialog
+        open={Boolean(confirmation)}
+        onOpenChange={(open) => {
+          if (!open) setConfirmation(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirmation?.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirmation?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const action = confirmation?.onConfirm;
+                setConfirmation(null);
+                action?.();
+              }}
+            >
+              {confirmation?.actionLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/frontend/src/components/admin/tabs/environment-builder/EnvironmentBuilder.tsx
+++ b/frontend/src/components/admin/tabs/environment-builder/EnvironmentBuilder.tsx
@@ -1,0 +1,948 @@
+import { useMemo, useState } from 'react';
+import {
+  Box,
+  Check,
+  ChevronDown,
+  CircleGauge,
+  Info,
+  Layers3,
+  Loader2,
+  PackagePlus,
+  Plus,
+  Save,
+  Search,
+  Settings2,
+  Trash2,
+  Wrench,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import type {
+  EnvironmentRevision,
+  ManagedEnvironment,
+  ManagedTool,
+  ManagedToolVersion,
+} from '@/services/environments';
+import { cn } from '@/lib/utils';
+import {
+  RUNTIME_IMAGE_LIMIT_BYTES,
+  environmentIdPreview,
+  protectedRuntimeVersions,
+  resolvedTools,
+  validateEnvironmentForm,
+  type EnvironmentForm,
+  type KeyValueEntry,
+} from './model';
+import { ProcessOverview, Section } from './ui';
+
+interface Props {
+  form: EnvironmentForm;
+  onChange: (next: EnvironmentForm) => void;
+  baseOptions: ManagedEnvironment[];
+  baseEnvironment: ManagedEnvironment | null;
+  baseRevision: EnvironmentRevision | null;
+  baseLoading: boolean;
+  tools: ManagedTool[];
+  disabled: boolean;
+  showId: boolean;
+  actionLabel: string;
+  actionBusy: boolean;
+  actionDisabled: boolean;
+  onAction: () => void;
+}
+
+const publishedVersions = (tool: ManagedTool) =>
+  tool.versions.filter((version) => version.status === 'PUBLISHED');
+
+const recommendedVersion = (tool: ManagedTool) =>
+  publishedVersions(tool).find((version) => version.versionId === tool.recommendedVersionId) ??
+  publishedVersions(tool)[0] ??
+  null;
+
+const distributionName = (tool: ManagedTool, version: ManagedToolVersion | null | undefined) =>
+  version?.definition.distribution ?? version?.definition.publisher ?? tool.publisher;
+
+const ENVIRONMENT_PROCESS_STEPS = [
+  {
+    label: 'Define',
+    description: 'Choose the base, tools, and optional settings.',
+  },
+  {
+    label: 'Build',
+    description: 'CodeBuild composes the immutable environment image.',
+  },
+  {
+    label: 'Check',
+    description: 'Automatic image and package checks run.',
+  },
+  {
+    label: 'Verify',
+    description: 'The platform starts the runtime and validates its behavior.',
+  },
+  {
+    label: 'Publish',
+    description: 'Make the revision available to projects.',
+  },
+] as const;
+
+function KeyValueListEditor({
+  entries,
+  onChange,
+  nameLabel,
+  valueLabel,
+  namePlaceholder,
+  valuePlaceholder,
+  addLabel,
+  disabled,
+}: {
+  entries: KeyValueEntry[];
+  onChange: (entries: KeyValueEntry[]) => void;
+  nameLabel: string;
+  valueLabel: string;
+  namePlaceholder: string;
+  valuePlaceholder: string;
+  addLabel: string;
+  disabled: boolean;
+}) {
+  const update = (index: number, patch: Partial<KeyValueEntry>) =>
+    onChange(entries.map((entry, current) => (current === index ? { ...entry, ...patch } : entry)));
+
+  return (
+    <div className="space-y-2.5">
+      {entries.map((entry, index) => (
+        <div
+          key={index}
+          className="grid gap-2 rounded-lg border bg-background p-2.5 sm:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)_auto]"
+        >
+          <div>
+            <Label htmlFor={`${nameLabel}-${index}`} className="sr-only">
+              {nameLabel} {index + 1}
+            </Label>
+            <Input
+              id={`${nameLabel}-${index}`}
+              aria-label={`${nameLabel} ${index + 1}`}
+              value={entry.name}
+              onChange={(event) => update(index, { name: event.target.value })}
+              placeholder={namePlaceholder}
+              disabled={disabled}
+              className="h-8 font-mono text-xs"
+            />
+          </div>
+          <div>
+            <Label htmlFor={`${valueLabel}-${index}`} className="sr-only">
+              {valueLabel} {index + 1}
+            </Label>
+            <Input
+              id={`${valueLabel}-${index}`}
+              aria-label={`${valueLabel} ${index + 1}`}
+              value={entry.value}
+              onChange={(event) => update(index, { value: event.target.value })}
+              placeholder={valuePlaceholder}
+              disabled={disabled}
+              className="h-8 font-mono text-xs"
+            />
+          </div>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 text-muted-foreground hover:text-destructive"
+            aria-label={`Remove ${nameLabel.toLowerCase()} ${index + 1}`}
+            disabled={disabled}
+            onClick={() => onChange(entries.filter((_, current) => current !== index))}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="gap-1.5"
+        disabled={disabled}
+        onClick={() => onChange([...entries, { name: '', value: '' }])}
+      >
+        <Plus className="h-3.5 w-3.5" />
+        {addLabel}
+      </Button>
+    </div>
+  );
+}
+
+function CommandListEditor({
+  commands,
+  onChange,
+  disabled,
+}: {
+  commands: string[];
+  onChange: (commands: string[]) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="space-y-2.5">
+      {commands.map((command, index) => (
+        <div
+          key={index}
+          className="grid grid-cols-[minmax(0,1fr)_auto] gap-2 rounded-lg border bg-background p-2.5"
+        >
+          <Label htmlFor={`build-command-${index}`} className="sr-only">
+            Build command {index + 1}
+          </Label>
+          <Input
+            id={`build-command-${index}`}
+            aria-label={`Build command ${index + 1}`}
+            value={command}
+            onChange={(event) =>
+              onChange(
+                commands.map((value, current) => (current === index ? event.target.value : value)),
+              )
+            }
+            placeholder="apt-get update"
+            disabled={disabled}
+            className="h-8 font-mono text-xs"
+          />
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 text-muted-foreground hover:text-destructive"
+            aria-label={`Remove build command ${index + 1}`}
+            disabled={disabled}
+            onClick={() => onChange(commands.filter((_, current) => current !== index))}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="gap-1.5"
+        disabled={disabled || commands.length >= 20}
+        onClick={() => onChange([...commands, ''])}
+      >
+        <Plus className="h-3.5 w-3.5" />
+        Add command
+      </Button>
+    </div>
+  );
+}
+
+export function EnvironmentBuilder({
+  form,
+  onChange,
+  baseOptions,
+  baseEnvironment,
+  baseRevision,
+  baseLoading,
+  tools,
+  disabled,
+  showId,
+  actionLabel,
+  actionBusy,
+  actionDisabled,
+  onAction,
+}: Props) {
+  const [toolSearch, setToolSearch] = useState('');
+  const [toolFilter, setToolFilter] = useState<'all' | 'included'>('all');
+  const [advancedOpen, setAdvancedOpen] = useState(
+    form.aptPackages.length > 0 ||
+      form.environmentVariables.length > 0 ||
+      form.buildCommands.length > 0,
+  );
+
+  const composition = useMemo(() => {
+    const inherited = resolvedTools(baseRevision);
+    const inheritedById = new Map(inherited.map((tool) => [tool.toolId, tool]));
+    const selectedVersions = new Map<string, ManagedToolVersion>();
+    for (const tool of tools) {
+      const selected = tool.versions.find((version) =>
+        form.toolVersionIds.includes(version.versionId),
+      );
+      if (selected) selectedVersions.set(tool.toolId, selected);
+    }
+    const toolById = new Map(tools.map((tool) => [tool.toolId, tool]));
+    const effectiveSelectedVersions = new Map(selectedVersions);
+    const requiredBy = new Map<string, Set<string>>();
+    const resolving = new Set<string>();
+
+    const includeDependencies = (version: ManagedToolVersion) => {
+      if (resolving.has(version.toolId)) return;
+      resolving.add(version.toolId);
+      for (const dependencyId of version.definition.dependencies) {
+        if (inheritedById.has(dependencyId)) continue;
+        const owners = requiredBy.get(dependencyId) ?? new Set<string>();
+        owners.add(toolById.get(version.toolId)?.name ?? version.toolId);
+        requiredBy.set(dependencyId, owners);
+        let dependency = effectiveSelectedVersions.get(dependencyId);
+        if (!dependency) {
+          const family = toolById.get(dependencyId);
+          dependency = family ? (recommendedVersion(family) ?? undefined) : undefined;
+          if (dependency) effectiveSelectedVersions.set(dependencyId, dependency);
+        }
+        if (dependency) includeDependencies(dependency);
+      }
+      resolving.delete(version.toolId);
+    };
+    for (const version of selectedVersions.values()) includeDependencies(version);
+
+    const selectedSize = [...effectiveSelectedVersions.values()].reduce(
+      (total, version) => total + Number(version.imageSizeBytes ?? 0),
+      0,
+    );
+    const sizesKnown =
+      Number(baseRevision?.imageSizeBytes ?? 0) > 0 &&
+      [...effectiveSelectedVersions.values()].every(
+        (version) => Number(version.imageSizeBytes ?? 0) > 0,
+      );
+    const projectedSize = sizesKnown
+      ? Number(baseRevision?.imageSizeBytes ?? 0) + selectedSize
+      : null;
+
+    return {
+      inherited,
+      inheritedById,
+      selectedVersions,
+      effectiveSelectedVersions,
+      requiredBy,
+      projectedSize,
+    };
+  }, [baseRevision, form.toolVersionIds, tools]);
+
+  const protectedVersions = protectedRuntimeVersions(baseRevision);
+  const setVersion = (tool: ManagedTool, versionId: string | null) => {
+    const familyVersionIds = new Set(tool.versions.map((version) => version.versionId));
+    const remaining = form.toolVersionIds.filter((id) => !familyVersionIds.has(id));
+    onChange({
+      ...form,
+      toolVersionIds: versionId ? [...remaining, versionId] : remaining,
+    });
+  };
+
+  const visibleTools = tools.filter((tool) => {
+    const query = toolSearch.trim().toLowerCase();
+    const included =
+      composition.inheritedById.has(tool.toolId) ||
+      composition.effectiveSelectedVersions.has(tool.toolId);
+    if (toolFilter === 'included' && !included) return false;
+    return (
+      !query ||
+      tool.name.toLowerCase().includes(query) ||
+      tool.description.toLowerCase().includes(query) ||
+      tool.publisher.toLowerCase().includes(query) ||
+      tool.category.toLowerCase().includes(query) ||
+      tool.versions.some(
+        (version) =>
+          version.definition.distribution?.toLowerCase().includes(query) ||
+          version.definition.publisher?.toLowerCase().includes(query),
+      )
+    );
+  });
+
+  const customSettingCount =
+    form.aptPackages.filter((entry) => entry.name.trim() || entry.value.trim()).length +
+    form.environmentVariables.filter((entry) => entry.name.trim() || entry.value).length +
+    form.buildCommands.filter((command) => command.trim()).length;
+  const issues = validateEnvironmentForm(form, composition.projectedSize);
+  const selectedSummary = tools
+    .map((tool) => ({
+      tool,
+      version: composition.effectiveSelectedVersions.get(tool.toolId),
+      inherited: composition.inheritedById.get(tool.toolId),
+    }))
+    .filter(({ version, inherited }) => version || inherited);
+  const progress =
+    composition.projectedSize === null
+      ? 0
+      : Math.min(100, (composition.projectedSize / RUNTIME_IMAGE_LIMIT_BYTES) * 100);
+
+  return (
+    <div className="space-y-4">
+      <ProcessOverview steps={[...ENVIRONMENT_PROCESS_STEPS]} />
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_280px] xl:items-start">
+        <div className="min-w-0 space-y-4">
+          <Section
+            title="Environment details"
+            description="Use a name people will recognize when assigning this environment to a space."
+          >
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="environment-name" className="text-xs">
+                  Name
+                </Label>
+                <Input
+                  id="environment-name"
+                  value={form.name}
+                  onChange={(event) => onChange({ ...form, name: event.target.value })}
+                  placeholder="Java services"
+                  disabled={disabled}
+                  className="h-9 text-sm"
+                />
+              </div>
+              {showId && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="environment-id" className="text-xs">
+                    Environment ID{' '}
+                    <span className="font-normal text-muted-foreground">(optional)</span>
+                  </Label>
+                  <Input
+                    id="environment-id"
+                    value={form.environmentId}
+                    onChange={(event) => onChange({ ...form, environmentId: event.target.value })}
+                    placeholder={environmentIdPreview(form.name)}
+                    disabled={disabled}
+                    className="h-9 font-mono text-sm"
+                  />
+                  <p className="text-[11px] text-muted-foreground">
+                    {form.environmentId.trim()
+                      ? `Saved as ${environmentIdPreview(form.environmentId)}`
+                      : `Generated as ${environmentIdPreview(form.name)}`}
+                  </p>
+                </div>
+              )}
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label htmlFor="environment-description" className="text-xs">
+                  Description
+                </Label>
+                <Textarea
+                  id="environment-description"
+                  value={form.description}
+                  onChange={(event) => onChange({ ...form, description: event.target.value })}
+                  placeholder="What this environment is for and who should use it."
+                  disabled={disabled}
+                  className="min-h-20 resize-y text-sm"
+                />
+              </div>
+            </div>
+          </Section>
+
+          <Section
+            title="Base environment"
+            description="Start from a published environment. Its runtime and tools are inherited."
+          >
+            <div className="space-y-3">
+              <div className="max-w-md space-y-1.5">
+                <Label htmlFor="environment-base" className="text-xs">
+                  Base
+                </Label>
+                <Select
+                  value={form.baseEnvironmentId}
+                  onValueChange={(baseEnvironmentId) => onChange({ ...form, baseEnvironmentId })}
+                  disabled={disabled}
+                >
+                  <SelectTrigger id="environment-base" className="h-9 text-sm">
+                    <SelectValue placeholder="Choose a base environment" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {baseOptions.map((environment) => (
+                      <SelectItem key={environment.environmentId} value={environment.environmentId}>
+                        {environment.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {baseLoading ? (
+                <Skeleton className="h-20" />
+              ) : baseRevision ? (
+                <div className="rounded-lg border border-primary/20 bg-primary/[0.03] p-3">
+                  <div className="flex items-start gap-2.5">
+                    <Layers3 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                    <div className="min-w-0">
+                      <p className="text-xs font-medium">
+                        Inherited from {baseEnvironment?.name ?? 'the selected base'}
+                      </p>
+                      <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                        Protected runtime behavior remains unchanged. Add or override catalog tools
+                        below.
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        <Badge variant="secondary" className="text-[10px]">
+                          Node.js{protectedVersions.node ? ` ${protectedVersions.node}` : ''}
+                        </Badge>
+                        <Badge variant="secondary" className="text-[10px]">
+                          Python{protectedVersions.python ? ` ${protectedVersions.python}` : ''}
+                        </Badge>
+                        {composition.inherited.map((tool) => (
+                          <Badge key={tool.toolId} variant="outline" className="text-[10px]">
+                            {tool.name} {tool.version}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+                  The selected base does not have a published revision.
+                </div>
+              )}
+            </div>
+          </Section>
+
+          <Section
+            title="Tools"
+            description="Add published tools. Dependencies are included automatically."
+            badge={
+              <Badge variant="secondary" className="text-[10px]">
+                {selectedSummary.length} included
+              </Badge>
+            }
+          >
+            <div className="space-y-3">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <div className="relative min-w-0 flex-1">
+                  <Search className="pointer-events-none absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                  <Input
+                    aria-label="Search tools"
+                    value={toolSearch}
+                    onChange={(event) => setToolSearch(event.target.value)}
+                    placeholder="Search tools, publishers or categories"
+                    className="h-9 pl-8 text-xs"
+                  />
+                </div>
+                <div className="flex rounded-lg border bg-muted/30 p-0.5">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={toolFilter === 'all' ? 'secondary' : 'ghost'}
+                    className="h-7 shadow-none"
+                    aria-pressed={toolFilter === 'all'}
+                    onClick={() => setToolFilter('all')}
+                  >
+                    All
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={toolFilter === 'included' ? 'secondary' : 'ghost'}
+                    className="h-7 shadow-none"
+                    aria-pressed={toolFilter === 'included'}
+                    onClick={() => setToolFilter('included')}
+                  >
+                    Included
+                  </Button>
+                </div>
+              </div>
+
+              <div className="grid gap-2">
+                {visibleTools.map((tool) => {
+                  const versions = publishedVersions(tool);
+                  const inheritedTool = composition.inheritedById.get(tool.toolId) ?? null;
+                  const selected = composition.selectedVersions.get(tool.toolId) ?? null;
+                  const effective = composition.effectiveSelectedVersions.get(tool.toolId) ?? null;
+                  const required =
+                    composition.requiredBy.has(tool.toolId) &&
+                    !composition.inheritedById.has(tool.toolId);
+                  const recommended = recommendedVersion(tool);
+                  const included = Boolean(inheritedTool || effective);
+                  const showVersionSelect =
+                    Boolean(inheritedTool && versions.length) ||
+                    Boolean(effective && versions.length > 1);
+                  const displayedPublisher =
+                    effective?.definition.publisher ??
+                    inheritedTool?.publisher ??
+                    recommended?.definition.publisher ??
+                    tool.publisher;
+
+                  return (
+                    <div
+                      key={tool.toolId}
+                      className={cn(
+                        'rounded-xl border p-3 transition-colors',
+                        included && 'border-primary/25 bg-primary/[0.025]',
+                      )}
+                    >
+                      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                        <div className="flex min-w-0 items-start gap-3">
+                          <div
+                            className={cn(
+                              'mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border bg-muted/40 text-muted-foreground',
+                              included && 'border-primary/20 bg-primary/10 text-primary',
+                            )}
+                          >
+                            <Wrench className="h-3.5 w-3.5" />
+                          </div>
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-1.5">
+                              <span className="text-xs font-semibold">{tool.name}</span>
+                              {inheritedTool && !selected && (
+                                <Badge variant="secondary" className="text-[9px]">
+                                  Inherited
+                                </Badge>
+                              )}
+                              {selected && (
+                                <Badge variant="outline" className="text-[9px]">
+                                  Added here
+                                </Badge>
+                              )}
+                              {required && (
+                                <Badge variant="secondary" className="text-[9px]">
+                                  Required
+                                </Badge>
+                              )}
+                            </div>
+                            <p className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">
+                              {required
+                                ? `Added automatically for ${[
+                                    ...(composition.requiredBy.get(tool.toolId) ?? []),
+                                  ].join(', ')}`
+                                : `${displayedPublisher} · ${tool.category}`}
+                            </p>
+                            <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-[10px] text-muted-foreground">
+                              {(effective?.definition.version ||
+                                inheritedTool?.version ||
+                                recommended) && (
+                                <span className="font-mono text-foreground">
+                                  {effective
+                                    ? `${distributionName(tool, effective)} ${effective.definition.version}`
+                                    : inheritedTool
+                                      ? `${inheritedTool.distribution ?? inheritedTool.publisher} ${inheritedTool.version}`
+                                      : recommended
+                                        ? `${distributionName(tool, recommended)} ${recommended.definition.version}`
+                                        : null}
+                                </span>
+                              )}
+                              {effective?.imageSizeBytes && (
+                                <span>
+                                  {(effective.imageSizeBytes / 1024 / 1024).toFixed(0)} MiB
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="flex flex-wrap items-center justify-end gap-2">
+                          {showVersionSelect && (
+                            <Select
+                              value={selected?.versionId ?? effective?.versionId ?? 'inherit'}
+                              disabled={disabled}
+                              onValueChange={(value) =>
+                                setVersion(tool, value === 'inherit' ? null : value)
+                              }
+                            >
+                              <SelectTrigger
+                                aria-label={`${tool.name} version`}
+                                className="h-8 w-48 text-xs"
+                              >
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {inheritedTool && (
+                                  <SelectItem value="inherit">
+                                    Base · {inheritedTool.version}
+                                  </SelectItem>
+                                )}
+                                {versions.map((version) => (
+                                  <SelectItem key={version.versionId} value={version.versionId}>
+                                    {distributionName(tool, version)} · {version.definition.version}
+                                    {version.versionId === tool.recommendedVersionId
+                                      ? ' · recommended'
+                                      : ''}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          )}
+                          {required ? (
+                            <div className="flex h-8 items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 text-[10px] font-medium text-muted-foreground">
+                              <Check className="h-3 w-3" />
+                              Automatic
+                            </div>
+                          ) : selected ? (
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              className="gap-1.5"
+                              disabled={disabled}
+                              aria-label={
+                                inheritedTool ? `Use base ${tool.name}` : `Remove ${tool.name}`
+                              }
+                              onClick={() => setVersion(tool, null)}
+                            >
+                              {inheritedTool ? (
+                                <>
+                                  <Layers3 className="h-3.5 w-3.5" />
+                                  Use base
+                                </>
+                              ) : (
+                                <>
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                  Remove
+                                </>
+                              )}
+                            </Button>
+                          ) : inheritedTool ? (
+                            <div className="flex h-8 items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 text-[10px] font-medium text-muted-foreground">
+                              <Check className="h-3 w-3" />
+                              Included
+                            </div>
+                          ) : (
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              className="gap-1.5"
+                              disabled={disabled || !recommended}
+                              aria-label={`Add ${tool.name}`}
+                              onClick={() => setVersion(tool, recommended?.versionId ?? null)}
+                            >
+                              <PackagePlus className="h-3.5 w-3.5" />
+                              Add
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                      {(effective?.definition.dependencies.length ?? 0) > 0 && (
+                        <div className="mt-2 flex items-start gap-1.5 border-t pt-2 text-[10px] text-muted-foreground">
+                          <Info className="mt-px h-3 w-3 shrink-0" />
+                          Requires {effective?.definition.dependencies.join(', ')}. Missing
+                          dependencies use their recommended published version.
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+                {visibleTools.length === 0 && (
+                  <div className="rounded-xl border border-dashed px-4 py-8 text-center">
+                    <Wrench className="mx-auto h-5 w-5 text-muted-foreground/60" />
+                    <p className="mt-2 text-xs font-medium">
+                      {tools.length === 0 ? 'No published tools yet' : 'No tools match this view'}
+                    </p>
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      {tools.length === 0
+                        ? 'Publish a tool version before composing an environment.'
+                        : 'Try another search or show all tools.'}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </Section>
+
+          <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+            <section className="rounded-xl border bg-card">
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between gap-3 px-4 py-3.5 text-left"
+                >
+                  <span className="flex items-start gap-3">
+                    <Settings2 className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                    <span>
+                      <span className="block text-sm font-semibold">Advanced settings</span>
+                      <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                        Exact Debian packages, non-secret variables, and restricted build commands.
+                      </span>
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-2">
+                    {customSettingCount > 0 && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        {customSettingCount}
+                      </Badge>
+                    )}
+                    <ChevronDown
+                      className={cn(
+                        'h-4 w-4 text-muted-foreground transition-transform',
+                        advancedOpen && 'rotate-180',
+                      )}
+                    />
+                  </span>
+                </button>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="space-y-5 border-t p-4">
+                  <div className="space-y-2">
+                    <div>
+                      <h5 className="text-xs font-semibold">Debian packages</h5>
+                      <p className="mt-0.5 text-[11px] text-muted-foreground">
+                        Every package needs an exact version.
+                      </p>
+                    </div>
+                    <KeyValueListEditor
+                      entries={form.aptPackages}
+                      onChange={(aptPackages) => onChange({ ...form, aptPackages })}
+                      nameLabel="Package name"
+                      valueLabel="Package version"
+                      namePlaceholder="libssl-dev"
+                      valuePlaceholder="3.0.17-1~deb12u2"
+                      addLabel="Add package"
+                      disabled={disabled}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <div>
+                      <h5 className="text-xs font-semibold">Environment variables</h5>
+                      <p className="mt-0.5 text-[11px] text-muted-foreground">
+                        Variables are visible to platform administrators. Do not add secrets.
+                      </p>
+                    </div>
+                    <KeyValueListEditor
+                      entries={form.environmentVariables}
+                      onChange={(environmentVariables) =>
+                        onChange({ ...form, environmentVariables })
+                      }
+                      nameLabel="Variable name"
+                      valueLabel="Variable value"
+                      namePlaceholder="JAVA_HOME"
+                      valuePlaceholder="/opt/runtime"
+                      addLabel="Add variable"
+                      disabled={disabled}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <div>
+                      <h5 className="text-xs font-semibold">Build commands</h5>
+                      <p className="mt-0.5 text-[11px] text-muted-foreground">
+                        Commands run while the image is built. Protected runtime behavior cannot be
+                        changed.
+                      </p>
+                    </div>
+                    <CommandListEditor
+                      commands={form.buildCommands}
+                      onChange={(buildCommands) => onChange({ ...form, buildCommands })}
+                      disabled={disabled}
+                    />
+                  </div>
+                </div>
+              </CollapsibleContent>
+            </section>
+          </Collapsible>
+        </div>
+
+        <aside className="space-y-3 xl:sticky xl:top-0">
+          <div className="rounded-xl border bg-card p-4 shadow-sm">
+            <div className="flex items-center gap-2">
+              <CircleGauge className="h-4 w-4 text-primary" />
+              <h4 className="text-sm font-semibold">Composition</h4>
+            </div>
+            <div className="mt-4 space-y-3">
+              <div className="flex items-start justify-between gap-3 text-xs">
+                <span className="text-muted-foreground">Base</span>
+                <span className="text-right font-medium">
+                  {baseEnvironment?.name ?? 'Not selected'}
+                </span>
+              </div>
+              <div className="flex items-start justify-between gap-3 text-xs">
+                <span className="text-muted-foreground">Tools</span>
+                <span className="font-medium">{selectedSummary.length}</span>
+              </div>
+              <div className="flex items-start justify-between gap-3 text-xs">
+                <span className="text-muted-foreground">Custom settings</span>
+                <span className="font-medium">{customSettingCount}</span>
+              </div>
+
+              <div className="border-t pt-3">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs text-muted-foreground">Projected image</span>
+                  <span
+                    className={cn(
+                      'font-mono text-[10px] font-medium',
+                      composition.projectedSize !== null &&
+                        composition.projectedSize > RUNTIME_IMAGE_LIMIT_BYTES &&
+                        'text-destructive',
+                    )}
+                  >
+                    {composition.projectedSize === null
+                      ? 'Available after tool builds'
+                      : `${(composition.projectedSize / 1024 / 1024).toFixed(0)} / 2048 MiB`}
+                  </span>
+                </div>
+                <Progress
+                  value={progress}
+                  aria-label="Projected image size"
+                  className={cn(
+                    'mt-2 h-1.5',
+                    composition.projectedSize !== null &&
+                      composition.projectedSize > RUNTIME_IMAGE_LIMIT_BYTES &&
+                      '[&>div]:bg-destructive',
+                  )}
+                />
+              </div>
+
+              {selectedSummary.length > 0 && (
+                <div className="border-t pt-3">
+                  <p className="mb-2 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    Effective tools
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {selectedSummary.map(({ tool, version, inherited }) => (
+                      <Badge key={tool.toolId} variant="outline" className="max-w-full text-[9px]">
+                        <span className="truncate">{tool.name}</span>
+                        <span className="ml-1 font-mono text-muted-foreground">
+                          {version
+                            ? `${distributionName(tool, version)} ${version.definition.version}`
+                            : `${inherited?.distribution ?? inherited?.publisher ?? ''} ${inherited?.version ?? ''}`}
+                        </span>
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {issues.length > 0 && (
+                <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-2.5">
+                  <p className="text-[11px] font-medium text-amber-800 dark:text-amber-200">
+                    Before saving
+                  </p>
+                  <ul className="mt-1.5 space-y-1 text-[10px] leading-relaxed text-amber-800/90 dark:text-amber-200/90">
+                    {issues.map((issue) => (
+                      <li key={issue} className="flex items-start gap-1.5">
+                        <span aria-hidden="true">•</span>
+                        <span>{issue}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+            <div className="mt-4 border-t pt-4">
+              <Button
+                className="w-full gap-1.5"
+                disabled={actionDisabled || issues.length > 0}
+                aria-busy={actionBusy}
+                onClick={onAction}
+              >
+                {actionBusy ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" />
+                )}
+                {actionLabel}
+              </Button>
+            </div>
+          </div>
+
+          <div className="rounded-xl border bg-muted/20 p-3">
+            <div className="flex items-start gap-2">
+              <Box className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <p className="text-[10px] leading-relaxed text-muted-foreground">
+                Saving creates an immutable draft revision. Build and publish it from the Revisions
+                view when the definition is ready.
+              </p>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/tabs/environment-builder/EnvironmentRevisionWorkspace.tsx
+++ b/frontend/src/components/admin/tabs/environment-builder/EnvironmentRevisionWorkspace.tsx
@@ -439,7 +439,7 @@ export function EnvironmentRevisionWorkspace({
                   ))}
                 </SelectContent>
               </Select>
-              <StatusBadge status={selectedRevision.status} />
+              <StatusBadge status={selectedRevision.status} technical />
               <Button
                 size="icon"
                 variant="ghost"

--- a/frontend/src/components/admin/tabs/environment-builder/EnvironmentRevisionWorkspace.tsx
+++ b/frontend/src/components/admin/tabs/environment-builder/EnvironmentRevisionWorkspace.tsx
@@ -1,0 +1,554 @@
+import { useEffect, useState } from 'react';
+import {
+  CheckCircle2,
+  ChevronDown,
+  Circle,
+  CircleCheck,
+  ExternalLink,
+  FileCode2,
+  Hammer,
+  Loader2,
+  RefreshCw,
+  Rocket,
+  RotateCw,
+  ShieldAlert,
+  ShieldCheck,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type {
+  EnvironmentDetail,
+  EnvironmentRevision,
+  ManagedEnvironment,
+} from '@/services/environments';
+import { environmentsService } from '@/services/environments';
+import { cn } from '@/lib/utils';
+import { isCatalogRecipe } from './model';
+import {
+  ACTIVE_REVISION_STATUSES,
+  Disclosure,
+  severityClass,
+  statusClass,
+  StatusBadge,
+} from './ui';
+
+const securityFindingsAcceptedAt = (revision: EnvironmentRevision) =>
+  revision.securityFindingsAcceptedAt ?? revision.highFindingsAcknowledgedAt ?? null;
+const securityFindingsAcceptedBy = (revision: EnvironmentRevision) =>
+  revision.securityFindingsAcceptedBy ?? revision.highFindingsAcknowledgedBy ?? null;
+
+const ecrConsoleUrl = (imageUri: string | null) => {
+  const match = imageUri?.match(
+    /^(?<account>\d{12})\.dkr\.ecr\.(?<region>[a-z0-9-]+)\.amazonaws\.com\/(?<repository>[^:@]+)/,
+  );
+  if (!match?.groups) return null;
+  return `https://${match.groups.region}.console.aws.amazon.com/ecr/repositories/private/${match.groups.account}/${match.groups.repository}?region=${match.groups.region}`;
+};
+
+export const isActiveRevision = (revision: EnvironmentRevision) =>
+  ACTIVE_REVISION_STATUSES.has(revision.status) ||
+  (revision.status === 'SECURITY_REVIEW' && Boolean(securityFindingsAcceptedAt(revision)));
+
+function Lifecycle({ revision }: { revision: EnvironmentRevision }) {
+  const failed = revision.status === 'FAILED';
+  const buildComplete =
+    Boolean(revision.imageDigest) ||
+    ['SCANNING', 'SECURITY_REVIEW', 'VERIFYING', 'READY', 'PUBLISHED', 'SUPERSEDED'].includes(
+      revision.status,
+    );
+  const checkComplete = ['VERIFYING', 'READY', 'PUBLISHED', 'SUPERSEDED'].includes(revision.status);
+  const verificationComplete =
+    Boolean(revision.verification) ||
+    ['READY', 'PUBLISHED', 'SUPERSEDED'].includes(revision.status);
+  const stages = [
+    {
+      label: 'Define',
+      complete: revision.status !== 'DRAFT',
+      active: revision.status === 'DRAFT',
+    },
+    {
+      label: 'Build',
+      complete: buildComplete,
+      active: ['QUEUED', 'BUILDING'].includes(revision.status),
+    },
+    {
+      label: 'Check',
+      complete:
+        checkComplete &&
+        !(
+          failed &&
+          revision.failure?.reason === 'critical_vulnerability_findings' &&
+          !securityFindingsAcceptedAt(revision)
+        ),
+      active:
+        ['SCANNING', 'SECURITY_REVIEW'].includes(revision.status) ||
+        (failed && revision.failure?.reason === 'critical_vulnerability_findings'),
+    },
+    {
+      label: 'Verify',
+      complete: verificationComplete,
+      active: revision.status === 'VERIFYING',
+    },
+    {
+      label: 'Publish',
+      complete: revision.status === 'PUBLISHED' || revision.status === 'SUPERSEDED',
+      active: revision.status === 'READY',
+    },
+  ];
+  const waiting = ['QUEUED', 'BUILDING', 'SCANNING', 'VERIFYING'].includes(revision.status);
+  const ecrUrl = ecrConsoleUrl(revision.imageUri);
+  const statusMessage =
+    revision.status === 'DRAFT'
+      ? 'The definition is ready. Start the build when the composition looks correct.'
+      : ['QUEUED', 'BUILDING'].includes(revision.status)
+        ? 'CodeBuild is composing and validating the environment image.'
+        : revision.status === 'SCANNING'
+          ? 'The image is built. ECR is inspecting its operating-system packages.'
+          : revision.status === 'SECURITY_REVIEW'
+            ? 'The image is built, but package findings need an administrator decision.'
+            : revision.status === 'VERIFYING'
+              ? 'AgentCore is starting the runtime and checking its behavior.'
+              : revision.status === 'READY'
+                ? 'All checks are complete. Publish this revision when it is ready for projects.'
+                : ['PUBLISHED', 'SUPERSEDED'].includes(revision.status)
+                  ? 'This immutable revision has completed the lifecycle.'
+                  : revision.failure?.detail || 'This revision needs attention before continuing.';
+
+  return (
+    <div className="rounded-lg bg-muted/20 p-2.5">
+      <div className="grid grid-cols-5 gap-1">
+        {stages.map((stage, index) => (
+          <div key={stage.label} className="relative min-w-0 px-1 py-1.5 text-center">
+            {index > 0 && (
+              <span className="absolute right-1/2 top-[13px] -z-0 h-px w-full bg-border" />
+            )}
+            <span
+              aria-label={`${stage.label}: ${
+                stage.complete ? 'complete' : stage.active ? 'current' : 'pending'
+              }`}
+              className={cn(
+                'relative z-10 mx-auto flex h-5 w-5 items-center justify-center rounded-full border bg-background',
+                stage.complete && 'border-emerald-500 bg-emerald-500 text-white',
+                stage.active && 'border-primary bg-primary text-primary-foreground',
+              )}
+            >
+              {stage.complete ? (
+                <CheckCircle2 className="h-3 w-3" />
+              ) : stage.active && waiting ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Circle className="h-2.5 w-2.5" />
+              )}
+            </span>
+            <span
+              className={cn(
+                'mt-1 block truncate text-[9px] text-muted-foreground',
+                stage.active && 'font-medium text-foreground',
+              )}
+            >
+              {stage.label}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div
+        role="status"
+        className="mt-2 flex flex-col gap-2 border-t px-1 pt-2 text-[11px] text-muted-foreground sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div className="flex min-w-0 items-start gap-2">
+          {waiting && <Loader2 className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin text-primary" />}
+          <span>{statusMessage}</span>
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          {revision.buildLogUrl && (
+            <Button size="sm" variant="outline" asChild>
+              <a href={revision.buildLogUrl} target="_blank" rel="noreferrer">
+                CodeBuild logs <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </Button>
+          )}
+          {ecrUrl && revision.imageDigest && (
+            <Button size="sm" variant="outline" asChild>
+              <a href={ecrUrl} target="_blank" rel="noreferrer">
+                Open ECR <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const revisionRole = (environment: ManagedEnvironment, revision: EnvironmentRevision): string => {
+  const current = environment.currentRevisionId === revision.revisionId;
+  const published = environment.publishedRevisionId === revision.revisionId;
+  if (current && published) return 'Current published revision';
+  if (current) return 'Current revision';
+  if (published) return 'Published revision';
+  return 'Previous revision';
+};
+
+function EvidenceContent({ revision }: { revision: EnvironmentRevision }) {
+  const findings = revision.scanFindings?.findings ?? [];
+  const acceptedAt = securityFindingsAcceptedAt(revision);
+  const acceptedBy = securityFindingsAcceptedBy(revision);
+  const critical = Number(revision.scanFindings?.severityCounts?.CRITICAL ?? 0);
+  const high = Number(revision.scanFindings?.severityCounts?.HIGH ?? 0);
+  const securityOnlyFailure =
+    revision.failure?.reason === 'critical_vulnerability_findings' && Boolean(revision.imageDigest);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="rounded-xl border p-3">
+          <div className="flex items-center justify-between gap-2">
+            <h4 className="text-xs font-semibold">Image</h4>
+            {revision.imageDigest && <CircleCheck className="h-4 w-4 text-emerald-600" />}
+          </div>
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            {revision.imageDigest ? 'Built successfully' : 'Not built yet'}
+          </p>
+          {revision.imageSizeBytes && (
+            <p className="mt-1 font-mono text-[10px] text-muted-foreground">
+              {(revision.imageSizeBytes / 1024 / 1024).toFixed(1)} MiB
+            </p>
+          )}
+        </div>
+        <div className="rounded-xl border p-3">
+          <div className="flex items-center justify-between gap-2">
+            <h4 className="text-xs font-semibold">Image check</h4>
+            {acceptedAt ? (
+              <ShieldAlert className="h-4 w-4 text-amber-600" />
+            ) : revision.scanFindings && critical + high === 0 ? (
+              <ShieldCheck className="h-4 w-4 text-emerald-600" />
+            ) : null}
+          </div>
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            {acceptedAt
+              ? 'Findings accepted'
+              : critical + high > 0
+                ? `${critical} Critical · ${high} High`
+                : revision.scanFindings
+                  ? 'Scan passed'
+                  : 'Not scanned yet'}
+          </p>
+          {acceptedAt && (
+            <p className="mt-1 text-[10px] text-muted-foreground">
+              Accepted{acceptedBy ? ` by ${acceptedBy}` : ''}{' '}
+              <time dateTime={acceptedAt}>{new Date(acceptedAt).toLocaleString()}</time>
+            </p>
+          )}
+        </div>
+        <div className="rounded-xl border p-3">
+          <div className="flex items-center justify-between gap-2">
+            <h4 className="text-xs font-semibold">Runtime</h4>
+            {revision.verification && <CircleCheck className="h-4 w-4 text-emerald-600" />}
+          </div>
+          <p className="mt-2 text-[11px] text-muted-foreground">
+            {revision.verification ? 'Validation recorded' : 'Not validated yet'}
+          </p>
+          {revision.runtimeVersion && (
+            <p className="mt-1 font-mono text-[10px] text-muted-foreground">
+              Version {revision.runtimeVersion}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {revision.imageDigest && (
+        <Disclosure
+          title="Technical image details"
+          contentClassName="font-mono text-[10px] text-muted-foreground"
+        >
+          <p className="break-all">{revision.imageDigest}</p>
+        </Disclosure>
+      )}
+
+      {findings.length > 0 && (
+        <div className="overflow-hidden rounded-xl border">
+          <div className="border-b bg-muted/20 px-3 py-2">
+            <h4 className="text-xs font-semibold">Security findings</h4>
+          </div>
+          <div className="divide-y">
+            {findings.map((finding, index) => (
+              <div
+                key={`${finding.id}-${index}`}
+                className="grid gap-2 px-3 py-2.5 sm:grid-cols-[90px_minmax(0,1fr)_auto]"
+              >
+                <Badge
+                  variant="outline"
+                  className={cn('w-fit font-mono text-[10px]', severityClass(finding.severity))}
+                >
+                  {finding.severity}
+                </Badge>
+                {finding.uri ? (
+                  <a
+                    href={finding.uri}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="truncate font-mono text-[11px] text-primary hover:underline"
+                  >
+                    {finding.id}
+                  </a>
+                ) : (
+                  <span className="truncate font-mono text-[11px]">{finding.id}</span>
+                )}
+                <span className="font-mono text-[11px] text-muted-foreground">
+                  {finding.packageName ?? 'Unknown package'}
+                  {finding.packageVersion ? ` ${finding.packageVersion}` : ''}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {revision.failure && !securityOnlyFailure && (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+          <div className="font-medium">{revision.failure.reason ?? 'Build failed'}</div>
+          {revision.failure.detail && <div className="mt-1">{revision.failure.detail}</div>}
+        </div>
+      )}
+
+      {revision.generatedDockerfile && (
+        <Disclosure
+          title="Generated Dockerfile"
+          icon={<FileCode2 className="h-3.5 w-3.5 text-muted-foreground" />}
+          contentClassName="p-0"
+        >
+          <pre className="max-h-96 overflow-auto bg-muted/20 p-3 font-mono text-[11px] leading-relaxed">
+            {revision.generatedDockerfile}
+          </pre>
+        </Disclosure>
+      )}
+    </div>
+  );
+}
+
+function Evidence({ revision }: { revision: EnvironmentRevision }) {
+  const needsEvidence = revision.status === 'FAILED' || revision.status === 'SECURITY_REVIEW';
+  const [open, setOpen] = useState(needsEvidence);
+
+  useEffect(() => {
+    if (needsEvidence) setOpen(true);
+  }, [needsEvidence]);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <div className="overflow-hidden rounded-xl border">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            aria-label="Details and evidence"
+            className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left"
+          >
+            <span>
+              <span className="block text-xs font-semibold">Details and evidence</span>
+              <span className="mt-0.5 block text-[10px] text-muted-foreground">
+                Image, package checks, runtime verification, and generated Dockerfile.
+              </span>
+            </span>
+            <ChevronDown
+              className={cn(
+                'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
+                open && 'rotate-180',
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="border-t bg-muted/[0.03] p-3">
+            <EvidenceContent revision={revision} />
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+export function EnvironmentRevisionWorkspace({
+  environment,
+  detail,
+  selectedRevisionId,
+  onSelectRevision,
+  busy,
+  onRefresh,
+  onRun,
+  onRequestAccept,
+}: {
+  environment: ManagedEnvironment;
+  detail: EnvironmentDetail;
+  selectedRevisionId: string | null;
+  onSelectRevision: (revisionId: string) => void;
+  busy: string | null;
+  onRefresh: () => void;
+  onRun: (name: string, action: () => Promise<unknown>) => void;
+  onRequestAccept: (revision: EnvironmentRevision, critical: number, high: number) => void;
+}) {
+  const selectedRevision =
+    detail.revisions.find((revision) => revision.revisionId === selectedRevisionId) ??
+    detail.revisions[0] ??
+    null;
+  if (!selectedRevision) {
+    return (
+      <div className="rounded-xl border border-dashed px-4 py-12 text-center text-xs text-muted-foreground">
+        No revisions are available for this environment.
+      </div>
+    );
+  }
+
+  const findingsAcceptedAt = securityFindingsAcceptedAt(selectedRevision);
+  const legacySecurityFailure =
+    selectedRevision.status === 'FAILED' &&
+    selectedRevision.failure?.reason === 'critical_vulnerability_findings' &&
+    Boolean(selectedRevision.imageDigest);
+  const requiresSecurityAcceptance =
+    !findingsAcceptedAt && (selectedRevision.status === 'SECURITY_REVIEW' || legacySecurityFailure);
+  const critical = Number(selectedRevision.scanFindings?.severityCounts?.CRITICAL ?? 0);
+  const high = Number(selectedRevision.scanFindings?.severityCounts?.HIGH ?? 0);
+
+  return (
+    <div className="min-w-0 space-y-3">
+      <div className="rounded-xl border bg-card p-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <Select value={selectedRevision.revisionId} onValueChange={onSelectRevision}>
+                <SelectTrigger aria-label="Revision" className="h-9 w-full max-w-sm bg-background">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {detail.revisions.map((revision) => (
+                    <SelectItem key={revision.revisionId} value={revision.revisionId}>
+                      <span className="flex min-w-0 items-center gap-2">
+                        <span>{revisionRole(environment, revision)}</span>
+                        <span className="truncate font-mono text-[10px] text-muted-foreground">
+                          {revision.revisionId}
+                        </span>
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <StatusBadge status={selectedRevision.status} />
+              <Button
+                size="icon"
+                variant="ghost"
+                className="h-8 w-8"
+                title="Refresh revisions"
+                aria-label="Refresh revisions"
+                onClick={onRefresh}
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+            <p className="mt-1.5 flex flex-wrap gap-x-2 text-[10px] text-muted-foreground">
+              <span>{revisionRole(environment, selectedRevision)}</span>
+              <span aria-hidden="true">·</span>
+              <span className="font-mono">{selectedRevision.revisionId}</span>
+              <span aria-hidden="true">·</span>
+              <span>Created {new Date(selectedRevision.createdAt).toLocaleString()}</span>
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {selectedRevision.status === 'DRAFT' &&
+              !environment.updateAvailable &&
+              isCatalogRecipe(selectedRevision.recipe) && (
+                <Button
+                  size="sm"
+                  className="gap-1.5"
+                  disabled={Boolean(busy)}
+                  onClick={() =>
+                    onRun('build', () =>
+                      environmentsService.build(
+                        environment.environmentId,
+                        selectedRevision.revisionId,
+                      ),
+                    )
+                  }
+                >
+                  <Hammer className="h-3.5 w-3.5" />
+                  Build
+                </Button>
+              )}
+            {selectedRevision.status === 'FAILED' &&
+              !environment.updateAvailable &&
+              isCatalogRecipe(selectedRevision.recipe) &&
+              !legacySecurityFailure && (
+                <Button
+                  size="sm"
+                  className="gap-1.5"
+                  disabled={Boolean(busy)}
+                  onClick={() =>
+                    onRun('retry', () =>
+                      environmentsService.retry(
+                        environment.environmentId,
+                        selectedRevision.revisionId,
+                      ),
+                    )
+                  }
+                >
+                  <RotateCw className="h-3.5 w-3.5" />
+                  Retry
+                </Button>
+              )}
+            {requiresSecurityAcceptance && (
+              <Button
+                size="sm"
+                className="gap-1.5"
+                disabled={Boolean(busy)}
+                onClick={() => onRequestAccept(selectedRevision, critical, high)}
+              >
+                <ShieldAlert className="h-3.5 w-3.5" />
+                Review findings
+              </Button>
+            )}
+            {selectedRevision.status === 'SECURITY_REVIEW' && findingsAcceptedAt && (
+              <Badge
+                variant="outline"
+                className={cn('gap-1.5 py-1.5', statusClass('SECURITY_REVIEW'))}
+              >
+                <ShieldCheck className="h-3.5 w-3.5" />
+                Accepted · validation pending
+              </Badge>
+            )}
+            {selectedRevision.status === 'READY' &&
+              (environment.environmentId === 'standard' ||
+                isCatalogRecipe(selectedRevision.recipe)) && (
+                <Button
+                  size="sm"
+                  className="gap-1.5"
+                  disabled={Boolean(busy)}
+                  onClick={() =>
+                    onRun('publish', () =>
+                      environmentsService.publish(
+                        environment.environmentId,
+                        selectedRevision.revisionId,
+                      ),
+                    )
+                  }
+                >
+                  <Rocket className="h-3.5 w-3.5" />
+                  Publish
+                </Button>
+              )}
+          </div>
+        </div>
+        <div className="mt-3 border-t pt-3">
+          <Lifecycle revision={selectedRevision} />
+        </div>
+      </div>
+
+      <Evidence key={selectedRevision.revisionId} revision={selectedRevision} />
+    </div>
+  );
+}

--- a/frontend/src/components/admin/tabs/environment-builder/model.ts
+++ b/frontend/src/components/admin/tabs/environment-builder/model.ts
@@ -1,0 +1,169 @@
+import type {
+  CatalogEnvironmentRecipe,
+  EnvironmentRecipeInput,
+  EnvironmentRevision,
+  EnvironmentToolSnapshot,
+  ManagedEnvironment,
+} from '@/services/environments';
+
+export const RUNTIME_IMAGE_LIMIT_BYTES = 2048 * 1024 * 1024;
+
+export interface KeyValueEntry {
+  name: string;
+  value: string;
+}
+
+export interface EnvironmentForm {
+  environmentId: string;
+  name: string;
+  description: string;
+  baseEnvironmentId: string;
+  toolVersionIds: string[];
+  aptPackages: KeyValueEntry[];
+  environmentVariables: KeyValueEntry[];
+  buildCommands: string[];
+}
+
+export const emptyEnvironmentForm = (): EnvironmentForm => ({
+  environmentId: '',
+  name: '',
+  description: '',
+  baseEnvironmentId: 'standard',
+  toolVersionIds: [],
+  aptPackages: [],
+  environmentVariables: [],
+  buildCommands: [],
+});
+
+export const isCatalogRecipe = (
+  recipe: EnvironmentRevision['recipe'] | undefined,
+): recipe is CatalogEnvironmentRecipe => recipe?.schemaVersion === 2;
+
+export const resolvedTools = (revision: EnvironmentRevision | null): EnvironmentToolSnapshot[] => {
+  const recipe = revision?.flattenedRecipe;
+  if (!isCatalogRecipe(recipe)) return [];
+  return recipe.resolvedTools ?? recipe.tools;
+};
+
+export const directToolVersionIds = (revision: EnvironmentRevision | null) =>
+  isCatalogRecipe(revision?.recipe) ? revision.recipe.toolVersionIds : [];
+
+export const protectedRuntimeVersions = (revision: EnvironmentRevision | null) => {
+  const recipe = revision?.flattenedRecipe;
+  if (!recipe || recipe.schemaVersion !== 1) return { node: null, python: null };
+  return {
+    node: recipe.tools.node?.version ?? null,
+    python: recipe.tools.python?.version ?? null,
+  };
+};
+
+export const formFromRevision = (
+  environment: ManagedEnvironment,
+  revision: EnvironmentRevision | null,
+): EnvironmentForm => {
+  const recipe = revision?.recipe;
+  return {
+    environmentId: environment.environmentId,
+    name: environment.name,
+    description: environment.description ?? '',
+    baseEnvironmentId:
+      environment.environmentId === 'standard'
+        ? ''
+        : (recipe?.base?.environmentId ?? environment.baseEnvironmentId ?? 'standard'),
+    toolVersionIds: directToolVersionIds(revision),
+    aptPackages: (recipe?.aptPackages ?? []).map((pkg) => ({
+      name: pkg.name,
+      value: pkg.version,
+    })),
+    environmentVariables: Object.entries(recipe?.environmentVariables ?? {}).map(
+      ([name, value]) => ({ name, value }),
+    ),
+    buildCommands: [...(recipe?.buildCommands ?? [])],
+  };
+};
+
+export const recipeFromForm = (form: EnvironmentForm): EnvironmentRecipeInput => ({
+  schemaVersion: 2,
+  toolVersionIds: form.toolVersionIds,
+  aptPackages: form.aptPackages
+    .filter((entry) => entry.name.trim() || entry.value.trim())
+    .map((entry) => ({ name: entry.name.trim(), version: entry.value.trim() })),
+  environmentVariables: Object.fromEntries(
+    form.environmentVariables
+      .filter((entry) => entry.name.trim() || entry.value)
+      .map((entry) => [entry.name.trim(), entry.value]),
+  ),
+  buildCommands: form.buildCommands.map((command) => command.trim()).filter(Boolean),
+});
+
+const PACKAGE_PATTERN = /^[a-z0-9][a-z0-9+.-]*$/;
+const VERSION_PATTERN = /^[0-9][0-9A-Za-z.+:~_-]*$/;
+const VARIABLE_PATTERN = /^[A-Z][A-Z0-9_]{0,63}$/;
+const ENVIRONMENT_ID_PATTERN = /^[a-z][a-z0-9-]{1,62}$/;
+
+export const validateEnvironmentForm = (
+  form: EnvironmentForm,
+  projectedSize: number | null,
+): string[] => {
+  const issues: string[] = [];
+  if (!form.name.trim()) issues.push('Give the environment a name.');
+  const requestedId = form.environmentId.trim() || form.name.trim();
+  const normalizedId = requestedId ? environmentIdPreview(requestedId) : '';
+  if (form.environmentId.trim() && !/[a-z0-9]/i.test(form.environmentId)) {
+    issues.push('The environment ID must contain at least one letter or digit.');
+  } else if (requestedId && !ENVIRONMENT_ID_PATTERN.test(normalizedId)) {
+    issues.push('The environment ID must start with a letter and contain 2–63 characters.');
+  }
+  if (normalizedId === 'rebuild') {
+    issues.push('The environment ID "rebuild" is reserved by the platform.');
+  }
+  if (!form.baseEnvironmentId) issues.push('Choose a published base environment.');
+  if (projectedSize !== null && projectedSize > RUNTIME_IMAGE_LIMIT_BYTES) {
+    issues.push('The projected image is larger than the 2048 MiB runtime limit.');
+  }
+
+  for (const [index, entry] of form.aptPackages.entries()) {
+    if (!entry.name.trim() && !entry.value.trim()) continue;
+    if (!PACKAGE_PATTERN.test(entry.name.trim())) {
+      issues.push(`Package ${index + 1} needs a valid Debian package name.`);
+    }
+    if (!VERSION_PATTERN.test(entry.value.trim())) {
+      issues.push(`Package ${index + 1} needs an exact version.`);
+    }
+  }
+
+  const variableNames = new Set<string>();
+  for (const [index, entry] of form.environmentVariables.entries()) {
+    if (!entry.name.trim() && !entry.value) continue;
+    const name = entry.name.trim();
+    if (!VARIABLE_PATTERN.test(name)) {
+      issues.push(`Variable ${index + 1} needs an uppercase name such as JAVA_HOME.`);
+    } else if (variableNames.has(name)) {
+      issues.push(`Variable ${name} is listed more than once.`);
+    }
+    variableNames.add(name);
+  }
+
+  if (form.buildCommands.filter((command) => command.trim()).length > 20) {
+    issues.push('At most 20 build commands are allowed.');
+  }
+  if (form.buildCommands.some((command) => /[\r\n]/.test(command))) {
+    issues.push('Build commands must contain one command per row.');
+  }
+
+  return issues;
+};
+
+export const environmentIdPreview = (value: string) => {
+  const collapsed = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+  const withoutLeadingSeparator = collapsed.startsWith('-') ? collapsed.slice(1) : collapsed;
+  const withoutBoundarySeparators = withoutLeadingSeparator.endsWith('-')
+    ? withoutLeadingSeparator.slice(0, -1)
+    : withoutLeadingSeparator;
+  return withoutBoundarySeparators.slice(0, 63) || 'generated-after-you-enter-a-name';
+};
+
+export const formFingerprint = (form: EnvironmentForm) => JSON.stringify(form);

--- a/frontend/src/components/admin/tabs/environment-builder/ui.tsx
+++ b/frontend/src/components/admin/tabs/environment-builder/ui.tsx
@@ -31,13 +31,44 @@ export const severityClass = (severity: string) => {
   return 'bg-muted/50 text-muted-foreground';
 };
 
-export function StatusBadge({ status, className }: { status: string; className?: string }) {
+export const statusLabel = (status: string) => {
+  const labels: Record<string, string> = {
+    DRAFT: 'Ready to build',
+    QUEUED: 'In progress',
+    BUILDING: 'In progress',
+    SCANNING: 'In progress',
+    SECURITY_REVIEW: 'Action required',
+    VERIFYING: 'In progress',
+    READY: 'Ready to publish',
+    PUBLISHED: 'Published',
+    FAILED: 'Needs attention',
+    SUPERSEDED: 'Previous revision',
+    RETIRED: 'Retired',
+    UPDATE_AVAILABLE: 'Update available',
+  };
+  return labels[status] ?? status.replaceAll('_', ' ');
+};
+
+export function StatusBadge({
+  status,
+  className,
+  technical = false,
+}: {
+  status: string;
+  className?: string;
+  technical?: boolean;
+}) {
   return (
     <Badge
       variant="outline"
-      className={cn('font-mono text-[10px] font-medium', statusClass(status), className)}
+      className={cn(
+        technical && 'font-mono',
+        'text-[10px] font-medium',
+        statusClass(status),
+        className,
+      )}
     >
-      {status.replaceAll('_', ' ')}
+      {technical ? status.replaceAll('_', ' ') : statusLabel(status)}
     </Badge>
   );
 }

--- a/frontend/src/components/admin/tabs/environment-builder/ui.tsx
+++ b/frontend/src/components/admin/tabs/environment-builder/ui.tsx
@@ -1,0 +1,170 @@
+import { useState, type ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { cn } from '@/lib/utils';
+
+export const ACTIVE_REVISION_STATUSES = new Set(['QUEUED', 'BUILDING', 'SCANNING', 'VERIFYING']);
+
+export const statusClass = (status: string) => {
+  if (status === 'FAILED') return 'border-destructive/30 bg-destructive/10 text-destructive';
+  if (status === 'PUBLISHED' || status === 'READY') {
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300';
+  }
+  if (status === 'SECURITY_REVIEW' || status === 'UPDATE_AVAILABLE') {
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300';
+  }
+  if (ACTIVE_REVISION_STATUSES.has(status)) {
+    return 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300';
+  }
+  return 'bg-muted/50 text-muted-foreground';
+};
+
+export const severityClass = (severity: string) => {
+  if (severity === 'CRITICAL') return 'border-destructive/40 bg-destructive/10 text-destructive';
+  if (severity === 'HIGH') {
+    return 'border-orange-500/40 bg-orange-500/10 text-orange-700 dark:text-orange-300';
+  }
+  if (severity === 'MEDIUM') {
+    return 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300';
+  }
+  return 'bg-muted/50 text-muted-foreground';
+};
+
+export function StatusBadge({ status, className }: { status: string; className?: string }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn('font-mono text-[10px] font-medium', statusClass(status), className)}
+    >
+      {status.replaceAll('_', ' ')}
+    </Badge>
+  );
+}
+
+export function Section({
+  title,
+  description,
+  badge,
+  children,
+}: {
+  title: string;
+  description?: string;
+  badge?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border bg-card">
+      <div className="flex items-start justify-between gap-3 border-b px-4 py-3.5">
+        <div>
+          <h4 className="text-sm font-semibold">{title}</h4>
+          {description && (
+            <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{description}</p>
+          )}
+        </div>
+        {badge}
+      </div>
+      <div className="p-4">{children}</div>
+    </section>
+  );
+}
+
+export function ProcessOverview({
+  title = 'How this works',
+  steps,
+  activeIndex = 0,
+}: {
+  title?: string;
+  steps: { label: string; description: string }[];
+  activeIndex?: number;
+}) {
+  const activeStep = steps[activeIndex] ?? steps[0];
+  return (
+    <section aria-label={title} className="rounded-lg border bg-muted/10 px-3 py-2.5">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {title}
+        </p>
+        <ol className="flex flex-wrap items-center gap-1.5">
+          {steps.map((step, index) => (
+            <li key={step.label} className="flex items-center gap-1.5">
+              <span
+                className={cn(
+                  'flex h-4 w-4 shrink-0 items-center justify-center rounded-full border text-[9px] font-semibold text-muted-foreground',
+                  index === activeIndex && 'border-primary bg-primary text-primary-foreground',
+                )}
+              >
+                {index + 1}
+              </span>
+              <span
+                className={cn(
+                  'text-[11px] text-muted-foreground',
+                  index === activeIndex && 'font-semibold text-foreground',
+                )}
+              >
+                {step.label}
+              </span>
+              {index < steps.length - 1 && (
+                <span aria-hidden="true" className="text-[10px] text-muted-foreground/60">
+                  →
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </div>
+      {activeStep && (
+        <p className="mt-2 border-t pt-2 text-[10px] leading-relaxed text-muted-foreground">
+          <span className="font-medium text-foreground">Current: {activeStep.label}.</span>{' '}
+          {activeStep.description}
+        </p>
+      )}
+    </section>
+  );
+}
+
+export function Disclosure({
+  title,
+  icon,
+  children,
+  defaultOpen = false,
+  className,
+  contentClassName,
+}: {
+  title: string;
+  icon?: ReactNode;
+  children: ReactNode;
+  defaultOpen?: boolean;
+  className?: string;
+  contentClassName?: string;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className={className}>
+      <div className="overflow-hidden rounded-xl border bg-background">
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            aria-label={title}
+            className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left"
+          >
+            <span className="flex items-center gap-2 text-xs font-semibold">
+              {icon}
+              {title}
+            </span>
+            <ChevronDown
+              className={cn(
+                'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform',
+                open && 'rotate-180',
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className={cn('border-t p-3', contentClassName)}>{children}</div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}

--- a/frontend/src/services/environments.ts
+++ b/frontend/src/services/environments.ts
@@ -56,6 +56,7 @@ export interface EnvironmentToolSnapshot {
   toolId: string;
   name: string;
   category: string;
+  distribution?: string;
   publisher: string;
   versionId: string;
   version: string;
@@ -209,6 +210,8 @@ export interface ToolVerification {
 export interface ToolVersionDefinition {
   schemaVersion: 1;
   version: string;
+  distribution?: string;
+  publisher?: string;
   source: {
     type: 'https';
     url: string;

--- a/lambda/environments/test/tool-catalog.test.js
+++ b/lambda/environments/test/tool-catalog.test.js
@@ -10,6 +10,7 @@ import {
   normalizeToolId,
   normalizeToolVersionDefinition,
   resolveToolDependencies,
+  toolVersionSnapshot,
 } from '../tool-catalog.js';
 
 const exec = promisify(execFile);
@@ -60,6 +61,10 @@ describe('managed tool catalog', () => {
       algorithm: 'sha256',
       evidenceUrl: expect.stringMatching(/^https:/),
     });
+    expect(javaTemplate.version).toMatchObject({
+      distribution: 'Eclipse Temurin',
+      publisher: 'Eclipse Adoptium',
+    });
     expect(goTemplate.version.source.expectedChecksum.evidenceUrl).toBe(
       'https://go.dev/dl/?mode=json&include=all',
     );
@@ -72,6 +77,34 @@ describe('managed tool catalog', () => {
 
   it('normalizes administrator tool ids without ambiguous boundary matching', () => {
     expect(normalizeToolId(`---Dot${'-'.repeat(100_000)}Net SDK---`)).toBe('dot-net-sdk');
+  });
+
+  it('preserves per-version distribution and publisher metadata', () => {
+    const definition = normalizeToolVersionDefinition({
+      ...javaTemplate.version,
+      version: '21.0.8.9.1',
+      distribution: ' Amazon Corretto ',
+      publisher: ' Amazon Web Services ',
+    });
+
+    expect(definition).toMatchObject({
+      version: '21.0.8.9.1',
+      distribution: 'Amazon Corretto',
+      publisher: 'Amazon Web Services',
+    });
+    expect(
+      toolVersionSnapshot(
+        {
+          toolId: 'java',
+          versionId: 'tv-corretto',
+          definition,
+        },
+        javaTemplate,
+      ),
+    ).toMatchObject({
+      distribution: 'Amazon Corretto',
+      publisher: 'Amazon Web Services',
+    });
   });
 
   it('rejects credential-bearing and mutable source URLs', () => {

--- a/lambda/environments/tool-catalog.js
+++ b/lambda/environments/tool-catalog.js
@@ -43,6 +43,8 @@ const presetVersionCommand = (preset, version) => {
 
 const archiveVersion = ({
   version,
+  distribution,
+  publisher,
   url,
   checksum,
   checksumAlgorithm = 'sha256',
@@ -57,6 +59,8 @@ const archiveVersion = ({
 }) => ({
   schemaVersion: TOOL_SCHEMA_VERSION,
   version,
+  distribution,
+  publisher,
   source: {
     type: 'https',
     url,
@@ -109,6 +113,8 @@ export const SYSTEM_TOOL_TEMPLATES = [
     publisher: 'Eclipse Temurin',
     version: archiveVersion({
       version: '21.0.8',
+      distribution: 'Eclipse Temurin',
+      publisher: 'Eclipse Adoptium',
       url: 'https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.8_9.tar.gz',
       checksum: 'e5c41a1ab0865ea5de9b4529bf8526005f1d4593090845387d14fe450ce39c33',
       checksumEvidenceUrl:
@@ -130,6 +136,8 @@ export const SYSTEM_TOOL_TEMPLATES = [
     publisher: 'The Go project',
     version: archiveVersion({
       version: '1.24.6',
+      distribution: 'Official Go',
+      publisher: 'The Go project',
       url: 'https://go.dev/dl/go1.24.6.linux-arm64.tar.gz',
       checksum: '124ea6033a8bf98aa9fbab53e58d134905262d45a022af3a90b73320f3c3afd5',
       checksumEvidenceUrl: 'https://go.dev/dl/?mode=json&include=all',
@@ -149,6 +157,8 @@ export const SYSTEM_TOOL_TEMPLATES = [
     publisher: 'The Rust project',
     version: archiveVersion({
       version: '1.89.0',
+      distribution: 'Official Rust',
+      publisher: 'The Rust project',
       url: 'https://static.rust-lang.org/dist/rust-1.89.0-aarch64-unknown-linux-gnu.tar.gz',
       checksum: '26d6de84ac59da702aa8c2f903e3c344e3259da02e02ce92ad1c735916b29a4a',
       checksumEvidenceUrl:
@@ -171,6 +181,8 @@ export const SYSTEM_TOOL_TEMPLATES = [
     publisher: 'Apache Software Foundation',
     version: archiveVersion({
       version: '3.9.11',
+      distribution: 'Apache Maven',
+      publisher: 'Apache Software Foundation',
       url: 'https://archive.apache.org/dist/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz',
       checksum:
         'bcfe4fe305c962ace56ac7b5fc7a08b87d5abd8b7e89027ab251069faebee516b0ded8961445d6d91ec1985dfe30f8153268843c89aa392733d1a3ec956c9978',
@@ -190,6 +202,8 @@ export const SYSTEM_TOOL_TEMPLATES = [
     publisher: 'Gradle',
     version: archiveVersion({
       version: '9.0.0',
+      distribution: 'Gradle',
+      publisher: 'Gradle',
       url: 'https://services.gradle.org/distributions/gradle-9.0.0-bin.zip',
       checksum: '8fad3d78296ca518113f3d29016617c7f9367dc005f932bd9d93bf45ba46072b',
       checksumEvidenceUrl: 'https://services.gradle.org/distributions/gradle-9.0.0-bin.zip.sha256',
@@ -293,6 +307,12 @@ export const validateToolVersionDefinition = (definition) => {
   }
   if (!VERSION_PATTERN.test(definition.version ?? '')) {
     issues.push(issue('version', 'version must be exact and start with a number'));
+  }
+  for (const field of ['distribution', 'publisher']) {
+    const value = definition[field];
+    if (value !== undefined && (typeof value !== 'string' || !value.trim() || value.length > 120)) {
+      issues.push(issue(field, `${field} must be between 1 and 120 characters`));
+    }
   }
   if (definition.source?.type !== 'https') {
     issues.push(issue('source.type', 'source type must be https'));
@@ -441,6 +461,10 @@ export const normalizeToolVersionDefinition = (input = {}) => {
   const definition = {
     schemaVersion: TOOL_SCHEMA_VERSION,
     version,
+    ...(String(input.distribution ?? '').trim()
+      ? { distribution: String(input.distribution).trim() }
+      : {}),
+    ...(String(input.publisher ?? '').trim() ? { publisher: String(input.publisher).trim() } : {}),
     source: {
       type: 'https',
       url: String(input.source?.url ?? input.sourceUrl ?? '').trim(),
@@ -1274,7 +1298,8 @@ export const toolVersionSnapshot = (version, tool = {}) => ({
   toolId: version.toolId,
   name: tool.name ?? version.toolId,
   category: tool.category ?? 'cli',
-  publisher: tool.publisher ?? '',
+  distribution: version.definition.distribution ?? tool.publisher ?? '',
+  publisher: version.definition.publisher ?? tool.publisher ?? '',
   versionId: version.versionId,
   version: version.definition.version,
   imageUri: version.imageUri,


### PR DESCRIPTION
## Summary

- simplify tool distribution and version creation with presets, progressive disclosure, and actionable validation errors
- support alternative distributions such as Amazon Corretto and replacing the recommended version
- make both managed catalogs easier to scan with searchable, filterable master-detail navigation
- show plain-language lifecycle status and the next administrator task directly in tool and environment list rows
- keep raw revision status available as technical evidence while using human-readable status in operational views
- clarify scan limitations, findings review, lifecycle progress, and operational links
- rebuild the managed environment definition and revision experience with compact navigation and evidence-on-demand
- standardize disclosure styling across tools and environments
- update managed environment documentation and automated coverage

## Validation

- 28 focused managed-tool and managed-environment UI tests passed
- frontend TypeScript build passed
- frontend production build passed
- changed-file lint passed with 0 warnings and 0 errors
- formatting and `git diff --check` passed
- repository pre-commit hooks passed

Closes #436

## Screenshots

Captured from the local UI on 14 September 2026, including the provenance updates in `47679cc`. The distribution form is an unsaved example.

<details open>
<summary>Tool catalog, lifecycle, and source evidence</summary>

Searchable and filterable tool families show lifecycle status and the next administrator action. The selected Java distribution shows its recommendation and publisher-verified source evidence.

![Tool catalog, lifecycle, and source evidence](https://github.com/user-attachments/assets/74bced17-c780-4ba7-b321-4765ab01af48)

</details>

<details>
<summary>Add an alternative distribution</summary>

An unsaved Amazon Corretto example shows the compact form, automatic Java defaults, collapsed advanced options, and actionable validation. The publisher starts blank and must be supplied explicitly.

![Add an alternative distribution](https://github.com/user-attachments/assets/952d96b2-5cdd-440b-9960-9b9204a57206)

</details>

<details>
<summary>Scan limitation guidance</summary>

The Check step explains why scanning is unavailable and identifies the next review action. Build logs and artifact navigation remain available.

![Scan limitation guidance](https://github.com/user-attachments/assets/243d6a94-9a32-41cb-8e0e-55e4f4fbb3c3)

</details>

<details>
<summary>Environment catalog and revision lifecycle</summary>

The catalog shows published environments and update guidance beside the selected revision, with a compact Define → Build → Check → Verify → Publish path.

![Environment catalog and revision lifecycle](https://github.com/user-attachments/assets/3c3b990b-ae33-4c82-bc19-c52133f836d8)

</details>

<details>
<summary>Environment definition and composition</summary>

Definition and Revisions have separate views. The definition editor pairs the environment settings with a composition summary, effective tools, and projected image size.

![Environment definition and composition](https://github.com/user-attachments/assets/910658f5-4d6c-4861-b6d7-54aa707ab825)

</details>

<details>
<summary>Tool selection and automatic dependencies</summary>

Searchable tool cards distinguish added tools from required dependencies. Java is included automatically for Maven, and advanced settings stay collapsed.

![Tool selection and automatic dependencies](https://github.com/user-attachments/assets/a5cf4ac4-f073-486e-b50f-5488339d680e)

</details>
