### PR TITLE
ci: deploy main to isolated demo environment

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -156,7 +156,6 @@ jobs:
             AWS_REGION
             AWS_ROLE_ARN
             BEDROCK_MODEL
-            TF_PROJECT_NAME
             TF_STATE_BUCKET
             TF_STATE_KEY
             TF_STATE_REGION

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -4,8 +4,28 @@ on:
   workflow_call:
     inputs:
       ref:
-        description: Immutable release tag to deploy
+        description: Immutable release tag or commit SHA to deploy
         required: true
+        type: string
+      ref_type:
+        description: How to validate ref (release-tag or commit)
+        required: false
+        default: release-tag
+        type: string
+      deployment_target:
+        description: Stable target identifier used for concurrency and reporting
+        required: false
+        default: release
+        type: string
+      github_environment:
+        description: Protected GitHub Environment containing deployment variables
+        required: false
+        default: demo-release
+        type: string
+      terraform_project_name:
+        description: Project namespace used to isolate account-global AWS resource names
+        required: false
+        default: collaborative-ai-dlc
         type: string
   workflow_dispatch:
     inputs:
@@ -19,7 +39,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: deploy-demo
+  group: deploy-demo-${{ inputs.deployment_target || 'release' }}
   cancel-in-progress: false
 
 jobs:
@@ -27,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     environment:
-      name: demo
+      name: ${{ inputs.github_environment || 'demo-release' }}
       url: ${{ steps.deployment.outputs.url }}
     env:
       AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
@@ -35,7 +55,10 @@ jobs:
       AWS_ROLE_ARN: ${{ vars.AWS_ROLE_ARN }}
       BEDROCK_MODEL: ${{ vars.BEDROCK_MODEL }}
       DEPLOY_REF: ${{ inputs.ref }}
+      DEPLOY_REF_TYPE: ${{ inputs.ref_type || 'release-tag' }}
+      DEPLOY_TARGET: ${{ inputs.deployment_target || 'release' }}
       TF_ENVIRONMENT: prod
+      TF_PROJECT_NAME: ${{ inputs.terraform_project_name || 'collaborative-ai-dlc' }}
       TF_INPUT: 'false'
       TF_IN_AUTOMATION: 'true'
       # Clean runners do not have archives recorded in remote Terraform state.
@@ -50,32 +73,65 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
 
-      - name: Verify release tag
+      - name: Verify deployment ref
         run: |
           set -euo pipefail
-          if [[ ! "$DEPLOY_REF" =~ ^v[0-9] ]]; then
-            echo "Deployment ref must be a version tag beginning with v: $DEPLOY_REF" >&2
+
+          if [[ ! "$DEPLOY_TARGET" =~ ^[a-z0-9][a-z0-9-]{0,19}$ ]]; then
+            echo "deployment_target must be 1-20 lowercase letters, digits, or hyphens: $DEPLOY_TARGET" >&2
             exit 1
           fi
-          tag_ref="refs/tags/$DEPLOY_REF"
-          if ! git show-ref --verify --quiet "$tag_ref"; then
-            echo "Deployment tag does not exist: $DEPLOY_REF" >&2
-            exit 1
-          fi
-          if ! git rev-parse --verify "$tag_ref^{tag}" >/dev/null; then
-            echo "Deployment tag must be annotated: $DEPLOY_REF" >&2
+          if [[ ! "$TF_PROJECT_NAME" =~ ^[a-z0-9][a-z0-9-]{0,26}[a-z0-9]$ ]]; then
+            echo "terraform_project_name must be 2-28 lowercase letters, digits, or hyphens: $TF_PROJECT_NAME" >&2
             exit 1
           fi
 
-          tag_commit="$(git rev-parse --verify "$tag_ref^{commit}")"
           main_commit="$(git rev-parse --verify "refs/remotes/origin/main^{commit}")"
-          if ! git merge-base --is-ancestor "$tag_commit" "$main_commit"; then
-            echo "Deployment tag $DEPLOY_REF ($tag_commit) is not reachable from main." >&2
-            exit 1
-          fi
+          case "$DEPLOY_REF_TYPE" in
+            release-tag)
+              if [[ ! "$DEPLOY_REF" =~ ^v[0-9] ]]; then
+                echo "Deployment ref must be a version tag beginning with v: $DEPLOY_REF" >&2
+                exit 1
+              fi
+              tag_ref="refs/tags/$DEPLOY_REF"
+              if ! git show-ref --verify --quiet "$tag_ref"; then
+                echo "Deployment tag does not exist: $DEPLOY_REF" >&2
+                exit 1
+              fi
+              if ! git rev-parse --verify "$tag_ref^{tag}" >/dev/null; then
+                echo "Deployment tag must be annotated: $DEPLOY_REF" >&2
+                exit 1
+              fi
 
-          echo "Verified $DEPLOY_REF resolves to main commit $tag_commit."
-          echo "DEPLOY_COMMIT=$tag_commit" >> "$GITHUB_ENV"
+              deploy_commit="$(git rev-parse --verify "$tag_ref^{commit}")"
+              if ! git merge-base --is-ancestor "$deploy_commit" "$main_commit"; then
+                echo "Deployment tag $DEPLOY_REF ($deploy_commit) is not reachable from main." >&2
+                exit 1
+              fi
+              ;;
+            commit)
+              if [[ ! "$DEPLOY_REF" =~ ^[0-9a-f]{40}$ ]]; then
+                echo "Commit deployment ref must be a full 40-character SHA: $DEPLOY_REF" >&2
+                exit 1
+              fi
+              deploy_commit="$(git rev-parse --verify "$DEPLOY_REF^{commit}")"
+              if [[ "$deploy_commit" != "$DEPLOY_REF" ]]; then
+                echo "Deployment ref did not resolve to the requested commit: $DEPLOY_REF" >&2
+                exit 1
+              fi
+              if ! git merge-base --is-ancestor "$deploy_commit" "$main_commit"; then
+                echo "Deployment commit $deploy_commit is not reachable from main." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "ref_type must be release-tag or commit: $DEPLOY_REF_TYPE" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "Verified $DEPLOY_REF resolves to main commit $deploy_commit."
+          echo "DEPLOY_COMMIT=$deploy_commit" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -100,13 +156,14 @@ jobs:
             AWS_REGION
             AWS_ROLE_ARN
             BEDROCK_MODEL
+            TF_PROJECT_NAME
             TF_STATE_BUCKET
             TF_STATE_KEY
             TF_STATE_REGION
           )
           for name in "${required[@]}"; do
             if [[ -z "${!name:-}" ]]; then
-              echo "GitHub Environment variable $name is required." >&2
+              echo "GitHub Environment variable or workflow input $name is required." >&2
               exit 1
             fi
           done
@@ -126,7 +183,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           mask-aws-account-id: true
           role-duration-seconds: 10800
-          role-session-name: aidlc-demo-${{ github.run_id }}-${{ github.run_attempt }}
+          role-session-name: aidlc-${{ inputs.deployment_target || 'release' }}-${{ github.run_id }}-${{ github.run_attempt }}
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
 
       - name: Create Terraform environment files
@@ -144,6 +201,7 @@ jobs:
 
           {
             printf 'environment   = %s\n' "$(hcl_string "$TF_ENVIRONMENT")"
+            printf 'project_name  = %s\n' "$(hcl_string "$TF_PROJECT_NAME")"
             printf 'aws_region    = %s\n' "$(hcl_string "$AWS_REGION")"
             printf 'bedrock_model = %s\n' "$(hcl_string "$BEDROCK_MODEL")"
           } > "$config_dir/environments/$TF_ENVIRONMENT.tfvars"
@@ -241,10 +299,12 @@ jobs:
             "$app_url" >/dev/null
           echo "url=$app_url" >> "$GITHUB_OUTPUT"
           {
-            echo "### Demo deployment"
+            echo "### ${DEPLOY_TARGET^} demo deployment"
             echo
-            echo "- Release: \`$DEPLOY_REF\`"
+            echo "- Source: \`$DEPLOY_REF\`"
             echo "- Commit: \`$DEPLOY_COMMIT\`"
+            echo "- Terraform project: \`$TF_PROJECT_NAME\`"
             echo "- Terraform environment: \`$TF_ENVIRONMENT\`"
+            echo "- Region: \`$AWS_REGION\`"
             echo "- URL: $app_url"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -13,7 +13,7 @@ on:
         default: release-tag
         type: string
       deployment_target:
-        description: Stable target identifier used for concurrency and reporting
+        description: Stable target identifier used for reporting
         required: false
         default: release
         type: string
@@ -38,14 +38,58 @@ permissions:
   contents: read
   id-token: write
 
-concurrency:
-  group: deploy-demo-${{ inputs.deployment_target || 'release' }}
-  cancel-in-progress: false
-
 jobs:
+  # Environment variables are available only after a job starts. Capture the
+  # backend before the deployment job's concurrency group is evaluated.
+  resolve-backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    environment:
+      name: ${{ inputs.github_environment || 'demo-release' }}
+      deployment: false
+    outputs:
+      backend: ${{ steps.backend.outputs.backend }}
+      concurrency_group: ${{ steps.backend.outputs.concurrency_group }}
+    steps:
+      - name: Resolve Terraform backend
+        id: backend
+        env:
+          TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
+          TF_STATE_KEY: ${{ vars.TF_STATE_KEY }}
+          TF_STATE_REGION: ${{ vars.TF_STATE_REGION }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import { appendFileSync } from 'node:fs';
+
+          const backend = {};
+          for (const [field, name] of Object.entries({
+            bucket: 'TF_STATE_BUCKET',
+            key: 'TF_STATE_KEY',
+            region: 'TF_STATE_REGION',
+          })) {
+            const value = process.env[name];
+            if (!value) {
+              throw new Error(`GitHub Environment variable ${name} is required.`);
+            }
+            backend[field] = value;
+          }
+
+          // Hash the tuple to preserve key case and avoid ambiguous separators.
+          const identity = JSON.stringify([backend.bucket, backend.key]);
+          const digest = createHash('sha256').update(identity).digest('hex');
+          appendFileSync(process.env.GITHUB_OUTPUT,
+            `backend=${JSON.stringify(backend)}\nconcurrency_group=deploy-demo-${digest}\n`);
+          NODE
+
   deploy:
+    needs: resolve-backend
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    concurrency:
+      group: ${{ needs.resolve-backend.outputs.concurrency_group }}
+      cancel-in-progress: false
     environment:
       name: ${{ inputs.github_environment || 'demo-release' }}
       url: ${{ steps.deployment.outputs.url }}
@@ -64,9 +108,9 @@ jobs:
       # Clean runners do not have archives recorded in remote Terraform state.
       # Do not turn that expected absence into timestamp-driven Lambda rebuilds.
       TF_RECREATE_MISSING_LAMBDA_PACKAGE: 'false'
-      TF_STATE_BUCKET: ${{ vars.TF_STATE_BUCKET }}
-      TF_STATE_KEY: ${{ vars.TF_STATE_KEY }}
-      TF_STATE_REGION: ${{ vars.TF_STATE_REGION }}
+      TF_STATE_BUCKET: ${{ fromJSON(needs.resolve-backend.outputs.backend).bucket }}
+      TF_STATE_KEY: ${{ fromJSON(needs.resolve-backend.outputs.backend).key }}
+      TF_STATE_REGION: ${{ fromJSON(needs.resolve-backend.outputs.backend).region }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,0 +1,24 @@
+name: Deploy Main Demo
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy-main:
+    uses: ./.github/workflows/deploy-demo.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      ref: ${{ github.sha }}
+      ref_type: commit
+      deployment_target: main
+      github_environment: demo-main
+      terraform_project_name: collaborative-ai-dlc-main

--- a/docs/development/demo-deployment.md
+++ b/docs/development/demo-deployment.md
@@ -1,18 +1,26 @@
-# Demo release deployment
+# Demo deployments
 
 The release workflow deploys every published release to the AWS demo account.
 It calls the reusable **Deploy Demo** workflow after creating the immutable
 release tag and GitHub Release. The reusable workflow can also deploy an
 existing release tag manually.
 
-The GitHub deployment environment is named `demo`. The existing Terraform
-logical environment remains `prod`; changing it would rename or replace
-resources already recorded in the remote state.
+The **Deploy Main Demo** workflow deploys every commit pushed to `main` through
+the same reusable workflow. It uses an immutable commit SHA, a separate GitHub
+Environment, Terraform state key, AWS region, and project namespace so it can
+coexist with the release demo in the same AWS account.
+
+The release GitHub deployment environment is named `demo-release`. Its existing
+Terraform logical environment remains `prod`; changing it would rename or
+replace resources already recorded in the remote state. The main demo also
+uses the `prod` logical environment to retain production capacity, retention,
+and deletion behavior, but changes `project_name` to
+`collaborative-ai-dlc-main` to isolate account-global resource names.
 
 ## Configure the GitHub environment
 
 In the repository, open **Settings → Environments** and create an environment
-named `demo`. Configure all of these protection settings before granting the
+named `demo-release`. Configure all of these protection settings before granting the
 deployment role access to the AWS account:
 
 1. Under **Deployment protection rules**, add the `collaborative-ai-dlc` team
@@ -62,6 +70,108 @@ exist. Apply reuses those exact packages, so neither missing files nor changed
 source hashes can invalidate the saved plan. Source changes still produce and
 deploy new content-addressed archives.
 
+## Configure the continuous main demo
+
+The main deployment is intentionally a separate target rather than another
+view of the release state. Before enabling `.github/workflows/deploy-main.yml`,
+create a GitHub Environment named `demo-main` and restrict its deployment
+branches to `main`. Required reviewers are optional: adding them makes every
+push wait for approval; omitting them makes deployment continuous after a push
+lands on protected `main`.
+
+Provision the dedicated Terraform state bucket and `demo-main` deployment role
+through the account's normal administrative process before configuring the
+GitHub Environment. The state bucket and application deployment both use
+`eu-central-1`; the manual IAM and state requirements are documented below.
+
+Add these environment variables to `demo-main`:
+
+| Variable          | Value                                                           |
+| ----------------- | --------------------------------------------------------------- |
+| `AWS_ACCOUNT_ID`  | The same 12-digit demo AWS account ID                           |
+| `AWS_REGION`      | `eu-central-1`                                                  |
+| `AWS_ROLE_ARN`    | ARN of the main-demo OIDC deployment role described below       |
+| `BEDROCK_MODEL`   | A Bedrock inference profile available in the application region |
+| `TF_STATE_BUCKET` | The existing demo state bucket, or a dedicated state bucket     |
+| `TF_STATE_KEY`    | `main/terraform.tfstate`                                        |
+| `TF_STATE_REGION` | The state bucket's region; this may differ from `AWS_REGION`    |
+
+The workflow supplies the isolation values itself:
+
+- Terraform `environment = "prod"`, preserving production behavior.
+- Terraform `project_name = "collaborative-ai-dlc-main"`, isolating IAM roles,
+  CloudFront functions and origin controls, SSM paths, Lambda functions, and
+  other fixed names that are account-global or otherwise shared across regions.
+- `ref_type = "commit"`, requiring the full immutable commit SHA and verifying
+  that it is reachable from `main` before requesting AWS credentials.
+
+Do not reuse `terraform.tfstate`: changing the provider region in the release
+state would plan replacement of the release deployment rather than a second
+stack. Sharing the bucket is safe when the key and lock-file permissions are
+separate.
+
+### Create or update the main-demo deployment role
+
+Reuse the account's existing GitHub Actions OIDC provider, but prefer a separate
+role for the continuous deployment. Its trust policy must use the protected
+GitHub Environment subject:
+
+```json
+{
+  "Effect": "Allow",
+  "Principal": {
+    "Federated": "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com"
+  },
+  "Action": "sts:AssumeRoleWithWebIdentity",
+  "Condition": {
+    "StringEquals": {
+      "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+      "token.actions.githubusercontent.com:sub": "repo:aws-samples/sample-collaborative-ai-dlc:environment:demo-main"
+    }
+  }
+}
+```
+
+Attach the reviewed Terraform deployment policy used by the release demo. If
+that policy restricts `aws:RequestedRegion` or contains region-qualified ARNs,
+add the main demo's application region. IAM and CloudFront permissions remain
+account-global. A reviewed least-privilege policy remains recommended. Existing
+demo accounts that deliberately mirror AWS-managed `AdministratorAccess` must
+use its AWS-owned ARN (`arn:aws:iam::aws:policy/AdministratorAccess`) and treat
+the unrestricted account access as an accepted risk.
+
+Grant the role access to the chosen backend bucket and only the new state
+objects (plus `s3:GetBucketLocation` and `s3:ListBucket` on the bucket):
+
+```text
+arn:aws:s3:::<state-bucket>/main/terraform.tfstate
+arn:aws:s3:::<state-bucket>/main/terraform.tfstate.tflock
+```
+
+The state object needs `s3:GetObject` and `s3:PutObject`; the lock object also
+needs `s3:DeleteObject`. Add KMS permissions when the backend bucket uses a
+customer-managed key.
+
+### Check regional and application prerequisites
+
+Before the first deployment:
+
+1. Choose a region present in the AgentCore VPC AZ map in
+   `terraform/modules/compute/agentcore/main.tf`, or explicitly configure its
+   supported AZ IDs.
+2. Confirm the selected Bedrock inference profile is available there. Bedrock
+   API keys are regional; enable the OpenAI models in that region when using
+   Codex.
+3. Check regional quotas for VPCs, elastic IPs/NAT gateways, Neptune,
+   Fargate/ECS, Lambda, ECR, and Bedrock AgentCore, plus account quotas for IAM
+   roles and CloudFront resources.
+4. Use a distinct custom hostname, or leave the main demo on its generated
+   CloudFront hostname. A CloudFront alias cannot belong to both deployments.
+5. After deployment, configure the new region's users, agent credentials,
+   source-control credentials, and tracker credentials. OAuth providers must
+   accept the main demo's distinct callback URL; some providers require a
+   separate OAuth application.
+
 ## Protect release tags
 
 Open **Settings → Rules → Rulesets**, create a tag ruleset for `v*`, and set
@@ -94,7 +204,7 @@ For an existing provider, verify that its client ID list includes
 
 ## Create the deployment role
 
-Create a trust policy scoped to this repository and the `demo` GitHub
+Create a trust policy scoped to this repository and the `demo-release` GitHub
 Environment. The environment condition is important: pull requests and jobs
 that do not pass the environment's protection rules cannot assume the role.
 
@@ -113,7 +223,7 @@ cat > /tmp/collaborative-demo-github-trust.json <<EOF
     "Condition": {
       "StringEquals": {
         "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-        "token.actions.githubusercontent.com:sub": "repo:aws-samples/sample-collaborative-ai-dlc:environment:demo"
+        "token.actions.githubusercontent.com:sub": "repo:aws-samples/sample-collaborative-ai-dlc:environment:demo-release"
       }
     }
   }]
@@ -202,16 +312,17 @@ and policy management, `iam:PassRole`, Lambda, API Gateway, Cognito, EC2,
 Elastic Load Balancing, ECS, ECR, S3, DynamoDB, Neptune, CloudFront, CloudWatch,
 EventBridge, SQS, Secrets Manager, Systems Manager, and Bedrock AgentCore.
 
-Do not attach `AdministratorAccess` as a bootstrap policy. Keep deployment
-disabled until a reviewed customer-managed policy is available; an approval
-mistake must not grant the workflow unrestricted control of the account.
+A reviewed customer-managed policy is recommended. AWS-managed
+`AdministratorAccess` gives the workflow unrestricted control of the account;
+existing demo accounts that deliberately retain it should treat that as an
+accepted risk and attach the AWS-managed policy ARN deliberately.
 
 ## Verify before enabling automatic deployment
 
-Before publishing the first release, confirm that the `demo` environment has
+Before publishing the first release, confirm that the `demo-release` environment has
 the required reviewers, self-review prevention, administrator bypass disabled,
 and the `main` deployment branch rule. Also confirm that the `v*` tag ruleset
-is active and the deployment role has the reviewed customer-managed policy.
+is active and the deployment role has the deliberately selected deployment policy.
 
 Every published release then waits for an independent approval, creates a
 Terraform plan, applies that exact saved plan, deploys the frontend, and

--- a/docs/development/demo-deployment.md
+++ b/docs/development/demo-deployment.md
@@ -132,13 +132,11 @@ GitHub Environment subject:
 }
 ```
 
-Attach the reviewed Terraform deployment policy used by the release demo. If
-that policy restricts `aws:RequestedRegion` or contains region-qualified ARNs,
-add the main demo's application region. IAM and CloudFront permissions remain
-account-global. A reviewed least-privilege policy remains recommended. Existing
-demo accounts that deliberately mirror AWS-managed `AdministratorAccess` must
-use its AWS-owned ARN (`arn:aws:iam::aws:policy/AdministratorAccess`) and treat
-the unrestricted account access as an accepted risk.
+Use the same deployment policy as the release demo, described in
+[Grant deployment permissions](#grant-deployment-permissions), on the separate
+main-demo role. If a customer-managed policy restricts `aws:RequestedRegion` or
+contains region-qualified ARNs, add the main demo's application region. IAM and
+CloudFront permissions remain account-global.
 
 Grant the role access to the chosen backend bucket and only the new state
 objects (plus `s3:GetBucketLocation` and `s3:ListBucket` on the bucket):
@@ -298,8 +296,29 @@ If the bucket uses a customer-managed KMS key, also grant the role
 
 ## Grant deployment permissions
 
-Attach the customer-managed policy currently used for manual Terraform
-deployments:
+The maintained demo account currently attaches AWS-managed
+`AdministratorAccess` (`arn:aws:iam::aws:policy/AdministratorAccess`) to both
+deployment roles:
+
+| GitHub Environment | IAM role                            |
+| ------------------ | ----------------------------------- |
+| `demo-release`     | `CollaborativeDemoGitHubDeploy`     |
+| `demo-main`        | `CollaborativeMainDemoGitHubDeploy` |
+
+Each role trusts only its corresponding GitHub Environment. The main demo
+mirrors the existing release deployment permissions; it does not require a
+broader policy than the release demo.
+
+This documents the current demo account configuration. `AdministratorAccess`
+is not required simply because Terraform creates IAM roles or CloudFront
+resources. A reviewed customer-managed policy can grant the necessary service
+permissions while restricting role management and `iam:PassRole` to application
+roles. Permissions boundaries on those roles can limit the permissions the
+deployment is allowed to delegate. Developing and validating that policy is
+separate hardening work.
+
+For other accounts, prefer a reviewed customer-managed deployment policy.
+Attach the policy deliberately selected for the account:
 
 ```bash
 aws iam attach-role-policy \
@@ -312,17 +331,18 @@ and policy management, `iam:PassRole`, Lambda, API Gateway, Cognito, EC2,
 Elastic Load Balancing, ECS, ECR, S3, DynamoDB, Neptune, CloudFront, CloudWatch,
 EventBridge, SQS, Secrets Manager, Systems Manager, and Bedrock AgentCore.
 
-A reviewed customer-managed policy is recommended. AWS-managed
-`AdministratorAccess` gives the workflow unrestricted control of the account;
-existing demo accounts that deliberately retain it should treat that as an
-accepted risk and attach the AWS-managed policy ARN deliberately.
+`AdministratorAccess` grants permissions for all AWS actions on all resources,
+including resources unrelated to the deployment. Retaining it in the maintained
+demo account is an explicit permissions choice. Scoped state policies and
+separate project names do not reduce the permissions granted by that policy.
 
 ## Verify before enabling automatic deployment
 
 Before publishing the first release, confirm that the `demo-release` environment has
 the required reviewers, self-review prevention, administrator bypass disabled,
 and the `main` deployment branch rule. Also confirm that the `v*` tag ruleset
-is active and the deployment role has the deliberately selected deployment policy.
+is active and the deployment role has the selected deployment policy, with its
+scope reviewed for the account.
 
 Every published release then waits for an independent approval, creates a
 Terraform plan, applies that exact saved plan, deploys the frontend, and

--- a/docs/development/demo-deployment.md
+++ b/docs/development/demo-deployment.md
@@ -70,6 +70,29 @@ exist. Apply reuses those exact packages, so neither missing files nor changed
 source hashes can invalidate the saved plan. Source changes still produce and
 deploy new content-addressed archives.
 
+## Deployment concurrency
+
+The reusable workflow first resolves `TF_STATE_BUCKET`, `TF_STATE_KEY`, and
+`TF_STATE_REGION` from the selected GitHub Environment in a small configuration
+job. The deployment job uses that captured backend for both Terraform and its
+concurrency group, so configuration changes while it waits cannot make the
+group refer to a different state than Terraform uses.
+
+The concurrency group is a hash of the state bucket and key. Callers using the
+same state share a group even when their target labels or project names differ;
+different state objects can deploy in parallel. Hashing preserves distinctions
+between case-sensitive S3 keys despite GitHub's case-insensitive group names.
+`cancel-in-progress: false` protects an active deployment. GitHub's default
+queue behavior retains the most recent pending deployment for each group.
+
+The configuration job has no GitHub token permissions, does not request AWS
+credentials, and uses `deployment: false` to avoid recording a deployment.
+Environment protection rules still apply to both jobs: when required reviewers
+are configured, approve backend resolution first and deployment afterward.
+Wait timers also apply to both jobs. Environments using custom deployment
+protection GitHub Apps must set `resolve-backend.environment.deployment` to
+`true`, because those rules require a deployment object.
+
 ## Configure the continuous main demo
 
 The main deployment is intentionally a separate target rather than another

--- a/scripts/test/release-tools.test.mjs
+++ b/scripts/test/release-tools.test.mjs
@@ -39,6 +39,39 @@ const run = (file, args, options = {}) =>
 
 const writeJson = (path, value) => writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 
+const resolveDemoBackend = (env = {}) => {
+  const deployment = readFileSync(demoWorkflow, 'utf8');
+  const source = deployment.match(
+    /          node --input-type=module <<'NODE'\n([\s\S]*?)\n          NODE/,
+  )?.[1];
+  assert.ok(source, 'backend resolution must run before deployment concurrency is evaluated');
+  const fixture = mkdtempSync(join(tmpdir(), 'aidlc-demo-backend-'));
+  const outputFile = join(fixture, 'github-output');
+  try {
+    const result = run('node', ['--input-type=module', '-e', source], {
+      env: {
+        TF_STATE_BUCKET: 'demo-state-bucket',
+        TF_STATE_KEY: 'terraform.tfstate',
+        TF_STATE_REGION: 'us-east-1',
+        ...env,
+        GITHUB_OUTPUT: outputFile,
+      },
+    });
+    const lines = existsSync(outputFile)
+      ? readFileSync(outputFile, 'utf8').trimEnd().split('\n')
+      : [];
+    const outputs = Object.fromEntries(
+      lines.map((line) => {
+        const separator = line.indexOf('=');
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+    );
+    return { ...result, outputs };
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+};
+
 test('current release metadata is internally consistent', () => {
   const version = JSON.parse(readFileSync(join(root, 'package.json'))).version;
   const checked = run('node', ['scripts/release.mjs', 'check', version]);
@@ -107,6 +140,91 @@ test('release and main deployments use isolated protected environments and GitHu
         deployment.indexOf('- name: Apply infrastructure'),
     'Lambda packages must be built before the final saved plan is applied',
   );
+});
+
+test('demo deployments use the resolved backend for both concurrency and Terraform', () => {
+  const deployment = readFileSync(demoWorkflow, 'utf8');
+  assert.doesNotMatch(deployment, /^concurrency:/m);
+  assert.match(deployment, /  resolve-backend:[\s\S]*?permissions: \{\}/);
+  assert.match(deployment, /  resolve-backend:[\s\S]*?deployment: false/);
+  assert.match(deployment, /  deploy:\n    needs: resolve-backend/);
+  assert.match(
+    deployment,
+    /concurrency:\n      group: \$\{\{ needs\.resolve-backend\.outputs\.concurrency_group \}\}\n      cancel-in-progress: false/,
+  );
+  for (const [name, field] of [
+    ['TF_STATE_BUCKET', 'bucket'],
+    ['TF_STATE_KEY', 'key'],
+    ['TF_STATE_REGION', 'region'],
+  ]) {
+    assert.ok(
+      deployment.includes(
+        `      ${name}: \${{ fromJSON(needs.resolve-backend.outputs.backend).${field} }}`,
+      ),
+      `Terraform must use the captured ${field}`,
+    );
+  }
+  assert.match(deployment, /printf 'use_lockfile = true\\n'/);
+});
+
+test('demo concurrency follows state identity independently of caller labels and region', () => {
+  const baseline = resolveDemoBackend();
+  assert.equal(baseline.status, 0, baseline.stderr);
+  assert.match(baseline.outputs.concurrency_group, /^deploy-demo-[0-9a-f]{64}$/);
+  assert.deepEqual(JSON.parse(baseline.outputs.backend), {
+    bucket: 'demo-state-bucket',
+    key: 'terraform.tfstate',
+    region: 'us-east-1',
+  });
+
+  const renamedCaller = resolveDemoBackend({
+    DEPLOY_TARGET: 'another-caller',
+    TF_PROJECT_NAME: 'another-project',
+    TF_STATE_REGION: 'eu-central-1',
+  });
+  assert.equal(renamedCaller.status, 0, renamedCaller.stderr);
+  assert.equal(renamedCaller.outputs.concurrency_group, baseline.outputs.concurrency_group);
+  assert.equal(JSON.parse(renamedCaller.outputs.backend).region, 'eu-central-1');
+
+  for (const env of [
+    { TF_STATE_BUCKET: 'other-state-bucket' },
+    { TF_STATE_KEY: 'main/terraform.tfstate' },
+    { TF_STATE_KEY: 'Terraform.tfstate' },
+  ]) {
+    const differentState = resolveDemoBackend(env);
+    assert.equal(differentState.status, 0, differentState.stderr);
+    assert.notEqual(differentState.outputs.concurrency_group, baseline.outputs.concurrency_group);
+  }
+});
+
+test('demo backend outputs preserve special keys and distinguish ambiguous bucket/key joins', () => {
+  const key = 'state/"quoted"\\key\nconcurrency_group=injected.tfstate';
+  const specialKey = resolveDemoBackend({ TF_STATE_KEY: key });
+  assert.equal(specialKey.status, 0, specialKey.stderr);
+  assert.deepEqual(Object.keys(specialKey.outputs).toSorted(), ['backend', 'concurrency_group']);
+  assert.equal(JSON.parse(specialKey.outputs.backend).key, key);
+  assert.match(specialKey.outputs.concurrency_group, /^deploy-demo-[0-9a-f]{64}$/);
+
+  const first = resolveDemoBackend({
+    TF_STATE_BUCKET: 'demo-state',
+    TF_STATE_KEY: 'one-terraform.tfstate',
+  });
+  const second = resolveDemoBackend({
+    TF_STATE_BUCKET: 'demo-state-one',
+    TF_STATE_KEY: 'terraform.tfstate',
+  });
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(second.status, 0, second.stderr);
+  assert.notEqual(first.outputs.concurrency_group, second.outputs.concurrency_group);
+});
+
+test('demo backend resolution rejects missing configuration before publishing outputs', () => {
+  for (const name of ['TF_STATE_BUCKET', 'TF_STATE_KEY', 'TF_STATE_REGION']) {
+    const result = resolveDemoBackend({ [name]: '' });
+    assert.notEqual(result.status, 0);
+    assert.ok(result.stderr.includes(`GitHub Environment variable ${name} is required.`));
+    assert.deepEqual(result.outputs, {});
+  }
 });
 
 test('deployment scripts enforce locked dependencies without install hooks', () => {

--- a/scripts/test/release-tools.test.mjs
+++ b/scripts/test/release-tools.test.mjs
@@ -27,6 +27,7 @@ const destroyTerraform = join(root, 'scripts/destroy.sh');
 const generateEnv = join(root, 'scripts/generate-env.sh');
 const releaseWorkflow = join(root, '.github/workflows/release.yml');
 const demoWorkflow = join(root, '.github/workflows/deploy-demo.yml');
+const mainDemoWorkflow = join(root, '.github/workflows/deploy-main.yml');
 const yjsDockerfile = join(root, 'lambda/yjs-server/Dockerfile');
 
 const run = (file, args, options = {}) =>
@@ -44,17 +45,33 @@ test('current release metadata is internally consistent', () => {
   assert.equal(checked.status, 0, checked.stderr);
 });
 
-test('release deployment uses the protected demo environment and GitHub OIDC', () => {
+test('release and main deployments use isolated protected environments and GitHub OIDC', () => {
   const release = readFileSync(releaseWorkflow, 'utf8');
   const deployment = readFileSync(demoWorkflow, 'utf8');
+  const mainDeployment = readFileSync(mainDemoWorkflow, 'utf8');
 
   assert.match(release, /uses: \.\/\.github\/workflows\/deploy-demo\.yml/);
   assert.match(release, /ref: v\$\{\{ inputs\.version \}\}/);
   assert.doesNotMatch(release, /apply:/);
 
-  assert.match(deployment, /name: demo/);
+  assert.match(mainDeployment, /push:\n    branches:\n      - main/);
+  assert.match(mainDeployment, /uses: \.\/\.github\/workflows\/deploy-demo\.yml/);
+  assert.match(mainDeployment, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(mainDeployment, /ref_type: commit/);
+  assert.match(mainDeployment, /deployment_target: main/);
+  assert.match(mainDeployment, /github_environment: demo-main/);
+  assert.match(mainDeployment, /terraform_project_name: collaborative-ai-dlc-main/);
+  assert.doesNotMatch(mainDeployment, /apply:/);
+
+  assert.match(deployment, /github_environment:[\s\S]*?default: demo-release/);
+  assert.match(deployment, /name: \$\{\{ inputs\.github_environment \|\| 'demo-release' \}\}/);
   assert.match(deployment, /id-token: write/);
   assert.match(deployment, /TF_ENVIRONMENT: prod/);
+  assert.match(
+    deployment,
+    /TF_PROJECT_NAME: \$\{\{ inputs\.terraform_project_name \|\| 'collaborative-ai-dlc' \}\}/,
+  );
+  assert.match(deployment, /printf 'project_name  = %s\\n'/);
   assert.match(deployment, /TF_RECREATE_MISSING_LAMBDA_PACKAGE: 'false'/);
   assert.match(deployment, /role-to-assume: \$\{\{ vars\.AWS_ROLE_ARN \}\}/);
   assert.match(deployment, /TF_STATE_BUCKET: \$\{\{ vars\.TF_STATE_BUCKET \}\}/);
@@ -64,14 +81,17 @@ test('release deployment uses the protected demo environment and GitHub OIDC', (
   assert.match(deployment, /AIDLC_SKIP_NPM_CI: '1'/);
   assert.match(deployment, /deploy-terraform\.sh "\$TF_ENVIRONMENT"/);
   assert.match(deployment, /deploy-frontend\.sh "\$TF_ENVIRONMENT"/);
-  assert.match(deployment, /git merge-base --is-ancestor "\$tag_commit" "\$main_commit"/);
+  assert.match(deployment, /case "\$DEPLOY_REF_TYPE" in/);
+  assert.match(deployment, /release-tag\)/);
+  assert.match(deployment, /commit\)/);
+  assert.match(deployment, /git merge-base --is-ancestor "\$deploy_commit" "\$main_commit"/);
   assert.equal(deployment.match(/--phase plan/g)?.length, 2);
   assert.doesNotMatch(deployment, /inputs\.apply|plan-only/);
   assert.doesNotMatch(deployment, /AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY/);
   assert.ok(
     deployment.indexOf('git merge-base --is-ancestor') <
       deployment.indexOf('aws-actions/configure-aws-credentials'),
-    'release ancestry must be verified before AWS credentials are configured',
+    'source ancestry must be verified before AWS credentials are configured',
   );
   assert.ok(
     deployment.indexOf('docker/setup-qemu-action') <


### PR DESCRIPTION
## Problem / Motivation

Published releases deploy to the demo account, but commits on `main` do not have a continuously updated environment. Reusing the release workflow and Terraform identifiers unchanged would collide on remote state and account-global IAM/CloudFront names.

## Why it matters

Without an isolated main environment, changes are only exercised in the shared deployment after a release is published. A second stack also needs explicit state, namespace, OIDC, and hostname isolation to avoid replacing or taking ownership of release resources.

## What changed

- Generalized the reusable demo workflow to validate either annotated release tags or immutable commit SHAs before requesting AWS credentials.
- Renamed the release workflow target to GitHub Environment `demo-release`.
- Added a `Deploy Main Demo` workflow that deploys `${{ github.sha }}` on every push to `main` using GitHub Environment `demo-main`.
- Kept Terraform `environment = "prod"` for production behavior while setting `project_name = "collaborative-ai-dlc-main"` for account-global name isolation.
- Added a backend-resolution job and deployment concurrency keyed by the actual Terraform state bucket/key. Terraform consumes the same captured backend; deployment summaries retain per-target attribution.
- Documented the `eu-central-1` main stack, `main/terraform.tfstate`, OIDC role trust, state access, quotas, credentials, OAuth callbacks, and hostname requirements.
- Documented the existing `AdministratorAccess` policy on the separate release/main deployment roles, with a reviewed narrower policy recommended as separate hardening work.
- Extended release workflow regression coverage for release/main isolation, backend concurrency, case-sensitive state keys, safe output encoding, and missing backend configuration.

## Tests

- `node --test scripts/test/*.test.mjs` — 51/51 passed.
- Focused release/main deployment regression passed after rebasing onto `origin/main`.
- Oxfmt check passed for all changed files.
- Both workflow files parsed successfully as YAML.
- Oxlint completed with 0 errors (existing repository warnings only).
- Secretlint passed.
- Full Vitest startup reached the existing Gremlin Testcontainers global setup, then stopped because no local container runtime is available.

## Manual verification

AWS and GitHub resources are intentionally not mutated by this PR. Before merge, configure the `demo-main` GitHub Environment and its environment-scoped OIDC role/state variables as documented. The existing release role must trust `environment:demo-release`.

Backend resolution and deployment both reference the selected GitHub Environment, so required reviewers and wait timers apply to each job. The resolver uses `deployment: false`; environments with custom deployment protection GitHub Apps must use `deployment: true` there, as documented.

## Screenshots / video

N/A — CI workflow and operator documentation changes only; there is no rendered UI delta.

Closes #440