### PR TITLE
fix(intents): log the caught error object in the handler catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Optional static egress for OAuth connectors, credential resolution, and seed-blocks through `lambda_vpc_scope = "public-egress"`, with NAT public IP outputs and addresses printed in the deployment summary for external allow-lists.
 - Configurable container runtime via `DOCKER_HOST` — any Docker-API-socket runtime works without requiring a container CLI (Podman, Rancher Desktop verified); Finch unsupported ([#420](https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/420)).
 
+### Fixed
+
+- Intents Lambda's outer error handler discarded the caught exception (`catch {}` bound nothing, and the log statement was a static `'intents handler error'` string), so every 500 arrived in CloudWatch as an identical opaque line and 500s on `/api/projects/*/intents/*` were undiagnosable in production. The catch now binds the error and logs its `message`, `name`, `code`, `stack`, plus API-Gateway request context (`resource`, `httpMethod`, `projectId`, `intentId`). The 500 response contract is unchanged.
+
 ## [2.0.0] - 2026-08-06
 
 Second and final step of the v2 release, building on `2.0.0-preview0`. Everything listed below is new since that preview; see the `2.0.0-preview0` entry for the v2 platform itself.

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -4509,8 +4509,22 @@ export const handler = async (event) => {
     }
 
     return response(405, { error: 'Method not allowed' });
-  } catch {
-    console.error('intents handler error');
+  } catch (error) {
+    // Bind the caught exception and log it with request context. Prior form
+    // was `catch {}` + a static `console.error('intents handler error')`, so
+    // every 500 in CloudWatch was an identical opaque string with no stack
+    // and no way to distinguish the offending path. The 500 response
+    // contract is preserved — the body still exposes only a generic message.
+    console.error('intents handler error', {
+      message: error?.message,
+      name: error?.name,
+      code: error?.code,
+      stack: error?.stack,
+      resource: event?.resource,
+      httpMethod: event?.httpMethod,
+      projectId: event?.pathParameters?.projectId,
+      intentId: event?.pathParameters?.intentId,
+    });
     return response(500, { error: 'Internal server error' });
   } finally {
     if (conn) {

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -2421,6 +2421,66 @@ describe('POST /start', () => {
     expect(JSON.parse(retry.body).status).toBe('CREATED');
   });
 
+  it('outer catch logs the exception and request context, not a static string', async () => {
+    // Regression test for the diagnostic contract of the top-level handler
+    // catch. The 500 body must stay generic (public contract), but the
+    // console.error payload must carry the actual Error's message/name/code/
+    // stack plus API-Gateway request context so operators can trace which
+    // path failed. A later refactor that drops this shape must fail here.
+    const sub = `u-${randomUUID()}`;
+    const projectId = await seedV2Project(sub);
+    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+
+    // Force the outer catch by making the orchestrator invoke throw with a
+    // distinctive error we can assert on.
+    class OrchestratorInvokeError extends Error {
+      constructor() {
+        super('invoke failed — orchestrator handoff blew up');
+        this.name = 'OrchestratorInvokeError';
+        this.code = 'ORCHESTRATOR_HANDOFF_FAILED';
+      }
+    }
+    lambdaMock
+      .on(InvokeCommand, { FunctionName: 'orchestrator-test' })
+      .rejectsOnce(new OrchestratorInvokeError());
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const res = await handler({
+        httpMethod: 'POST',
+        path: `/projects/${projectId}/intents/${intent.id}/start`,
+        resource: '/projects/{projectId}/intents/{intentId}/start',
+        pathParameters: { projectId, intentId: intent.id },
+        body: JSON.stringify({ agentCli: 'kiro' }),
+        ...claims(sub),
+      });
+      // Public 500 contract is unchanged.
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body)).toEqual({ error: 'Internal server error' });
+
+      // Diagnostic payload must reach console.error.
+      const call = errorSpy.mock.calls.find(([msg]) => msg === 'intents handler error');
+      expect(call, 'expected console.error to be called with the diagnostic tag').toBeDefined();
+      const [, ctx] = call;
+      expect(ctx).toEqual(
+        expect.objectContaining({
+          message: 'invoke failed — orchestrator handoff blew up',
+          name: 'OrchestratorInvokeError',
+          code: 'ORCHESTRATOR_HANDOFF_FAILED',
+          resource: '/projects/{projectId}/intents/{intentId}/start',
+          httpMethod: 'POST',
+          projectId,
+          intentId: intent.id,
+        }),
+      );
+      // Stack must be present and reference the caught error's class.
+      expect(typeof ctx.stack).toBe('string');
+      expect(ctx.stack).toContain('OrchestratorInvokeError');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('pins the starter personal credential over space and platform', async () => {
     const sub = `u-${randomUUID()}`;
     const projectId = await seedV2Project(sub);


### PR DESCRIPTION
## Summary

The outer `catch` in the intents Lambda handler used the bare-catch form (`catch {}`) and logged only a static `console.error('intents handler error')`, discarding the caught exception. Every 500 on any `/api/projects/*/intents/*` endpoint appeared in CloudWatch as an identical opaque string — no stack, no code, no path context — so an entire class of production 500s was undiagnosable.

Bind the caught exception and log its `message`, `name`, `code`, and `stack`, plus API-Gateway request context (`resource`, `httpMethod`, `projectId`, `intentId`). The 500 response body is unchanged, so the public contract is preserved.

Before:

\`\`\`
2026-09-07T15:20:00.706Z <rid> ERROR intents handler error
\`\`\`

After:

\`\`\`
2026-09-07T15:20:00.706Z <rid> ERROR intents handler error {
  message: '...', name: '...', code: '...', stack: '...',
  resource: '/api/projects/{projectId}/intents/{intentId}',
  httpMethod: 'GET', projectId: '...', intentId: '...'
}
\`\`\`

Motivation: on a real deployment I observed 1,638 500s over a ~45-minute window, all of which rendered as the same log line, forcing a diff of the source to even identify which catch block was firing. This lets operators see the actual failure without needing to re-run against a debugger.

## Test plan

- [x] `lambda/intents` vitest suite: **213/213 passing**.
- [x] `node --check lambda/intents/index.js` — clean.
- [x] `oxfmt --check` — clean.
- [x] `oxlint` — clean.
- [x] Confirmed 500 body remains `{"error":"Internal server error"}` (unchanged public contract).

Change scope: a single `catch (error) {}` binding + a richer `console.error` payload. Same file, same handler, no new imports.

## Changelog

Entry added under `[Unreleased] → Fixed`.