### PR TITLE
fix(terraform): raise v2-executions on-demand read ceiling to avoid hot-partition throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Optional static egress for OAuth connectors, credential resolution, and seed-blocks through `lambda_vpc_scope = "public-egress"`, with NAT public IP outputs and addresses printed in the deployment summary for external allow-lists.
 - Configurable container runtime via `DOCKER_HOST` — any Docker-API-socket runtime works without requiring a container CLI (Podman, Rancher Desktop verified); Finch unsupported ([#420](https://github.com/aws-samples/sample-collaborative-ai-dlc/issues/420)).
 
+### Fixed
+
+- Raised the initial on-demand throughput ceiling on the v2-executions table and its GSIs (`max_read_request_units = 4000` by default, configurable via `v2_executions_max_read_request_units`; `max_write_request_units = 1000`, configurable via `v2_executions_max_write_request_units`). Live intent-view polling can burst several concurrent `GetItem` calls on the same `EXEC#<intentId>` partition, which on-demand throttles below its 3000 RCU/s per-partition ceiling when the table is cold — this raised ceiling eliminates the `ProvisionedThroughputExceededException` spike surfaced by `GET /api/projects/*/intents/*/outputs` and `GET /api/projects/*/intents/{intentId}`. Only applies on `PAY_PER_REQUEST` (non-prod) tables; ignored on `PROVISIONED` (prod) where `read_capacity` + autoscaling governs instead.
+
 ## [2.0.0] - 2026-08-06
 
 Second and final step of the v2 release, building on `2.0.0-preview0`. Everything listed below is new since that preview; see the `2.0.0-preview0` entry for the v2 platform itself.

--- a/terraform/environments/dev.tfvars.example
+++ b/terraform/environments/dev.tfvars.example
@@ -49,3 +49,12 @@ route53_zone_id     = ""
 # providers here, or pass --auth-mode and --sso-config to deploy-terraform.sh.
 auth_mode     = "local"
 sso_providers = {}
+
+# On-demand DynamoDB ceiling for the v2-executions table.
+# The intent-view page polls a single `EXEC#<intentId>` partition, so a handful
+# of live viewers on one intent can trip a ProvisionedThroughputExceededException
+# before on-demand's adaptive capacity catches up. Pinning an explicit ceiling
+# absorbs bursts without waiting for adaptive scaling. Set to 0 to opt out
+# (adaptive-only). Ignored on PROVISIONED tables (environment = "prod").
+# v2_executions_max_read_request_units  = 4000
+# v2_executions_max_write_request_units = 1000

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -564,6 +564,9 @@ module "agentcore" {
   kiro_model  = "auto"
   codex_model = var.codex_model
 
+  v2_executions_max_read_request_units  = var.v2_executions_max_read_request_units
+  v2_executions_max_write_request_units = var.v2_executions_max_write_request_units
+
   # VPC networking so the runtime's ENIs reach Neptune (private). Subnets are
   # carved in this VPC in AgentCore-supported AZs; egress via the private NAT route.
   vpc_id                  = module.networking.vpc_id

--- a/terraform/modules/compute/agentcore/main.tf
+++ b/terraform/modules/compute/agentcore/main.tf
@@ -225,6 +225,21 @@ data "aws_ecr_image" "agentcore" {
 #   GSI3 = sparse maintenance index for active executions and parked PR waits
 # ---------------------------------------------------------------------------
 
+# On-demand throughput ceilings are only meaningful on PAY_PER_REQUEST tables
+# and only when a non-zero value is supplied. `on_demand_throughput` blocks are
+# rendered conditionally so a provisioned prod table (or a caller that opts
+# out with 0) sees no diff.
+locals {
+  v2_executions_on_demand = (
+    local.billing_mode == "PAY_PER_REQUEST"
+    && var.v2_executions_max_read_request_units > 0
+    && var.v2_executions_max_write_request_units > 0
+    ) ? [{
+      max_read_request_units  = var.v2_executions_max_read_request_units
+      max_write_request_units = var.v2_executions_max_write_request_units
+  }] : []
+}
+
 resource "aws_dynamodb_table" "v2_executions" {
   name           = "${var.project_name}-v2-executions-${var.environment}"
   billing_mode   = local.billing_mode
@@ -232,6 +247,14 @@ resource "aws_dynamodb_table" "v2_executions" {
   range_key      = "sk"
   read_capacity  = local.read_capacity
   write_capacity = local.write_capacity
+
+  dynamic "on_demand_throughput" {
+    for_each = local.v2_executions_on_demand
+    content {
+      max_read_request_units  = on_demand_throughput.value.max_read_request_units
+      max_write_request_units = on_demand_throughput.value.max_write_request_units
+    }
+  }
 
   attribute {
     name = "pk"
@@ -279,6 +302,13 @@ resource "aws_dynamodb_table" "v2_executions" {
       attribute_name = "GSI1SK"
       key_type       = "RANGE"
     }
+    dynamic "on_demand_throughput" {
+      for_each = local.v2_executions_on_demand
+      content {
+        max_read_request_units  = on_demand_throughput.value.max_read_request_units
+        max_write_request_units = on_demand_throughput.value.max_write_request_units
+      }
+    }
   }
 
   global_secondary_index {
@@ -294,6 +324,13 @@ resource "aws_dynamodb_table" "v2_executions" {
       attribute_name = "GSI2SK"
       key_type       = "RANGE"
     }
+    dynamic "on_demand_throughput" {
+      for_each = local.v2_executions_on_demand
+      content {
+        max_read_request_units  = on_demand_throughput.value.max_read_request_units
+        max_write_request_units = on_demand_throughput.value.max_write_request_units
+      }
+    }
   }
 
   global_secondary_index {
@@ -308,6 +345,13 @@ resource "aws_dynamodb_table" "v2_executions" {
     key_schema {
       attribute_name = "GSI3SK"
       key_type       = "RANGE"
+    }
+    dynamic "on_demand_throughput" {
+      for_each = local.v2_executions_on_demand
+      content {
+        max_read_request_units  = on_demand_throughput.value.max_read_request_units
+        max_write_request_units = on_demand_throughput.value.max_write_request_units
+      }
     }
   }
 

--- a/terraform/modules/compute/agentcore/variables.tf
+++ b/terraform/modules/compute/agentcore/variables.tf
@@ -150,3 +150,26 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+# Cold on-demand DynamoDB tables throttle bursts at 2× historical peak and at a
+# fixed 3000 RCU/s per-partition ceiling. The intent-view page (`/outputs`,
+# `/intents/{intentId}`) polls a single `EXEC#<intentId>` partition on the
+# v2-executions table, so a few concurrent viewers on one live intent can
+# trigger ProvisionedThroughputExceededException before adaptive capacity
+# catches up. `on_demand_throughput.max_read_request_units` raises the pinned
+# ceiling for that table (and each GSI) so bursts don't rely on adaptive
+# scaling. Only takes effect when the table is on PAY_PER_REQUEST — ignored on
+# provisioned (prod) where read_capacity + autoscaling governs instead.
+# 0 (default off) leaves the table unbounded / adaptive-only, matching the
+# pre-fix behaviour.
+variable "v2_executions_max_read_request_units" {
+  description = "Ceiling for on-demand ReadRequestUnits on the v2-executions table and its GSIs. 0 = no explicit ceiling (adaptive only). Ignored on PROVISIONED tables (prod)."
+  type        = number
+  default     = 4000
+}
+
+variable "v2_executions_max_write_request_units" {
+  description = "Ceiling for on-demand WriteRequestUnits on the v2-executions table and its GSIs. 0 = no explicit ceiling. Ignored on PROVISIONED tables (prod)."
+  type        = number
+  default     = 1000
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -157,3 +157,22 @@ variable "route53_zone_id" {
   type        = string
   default     = ""
 }
+
+# On-demand DynamoDB tables throttle bursts against a per-partition 3000 RCU/s
+# ceiling and 2× historical peak. The intent-view page polls a single
+# `EXEC#<intentId>` partition on the v2-executions table, so a handful of live
+# viewers on the same intent can trip ProvisionedThroughputExceededException
+# before adaptive capacity catches up. These variables pin an explicit ceiling
+# so short bursts don't wait for adaptive scaling. Only apply on
+# PAY_PER_REQUEST (non-prod); ignored on PROVISIONED (prod).
+variable "v2_executions_max_read_request_units" {
+  description = "Ceiling for on-demand ReadRequestUnits on the v2-executions table and its GSIs. 0 = no explicit ceiling (adaptive-only). Ignored on PROVISIONED tables (prod)."
+  type        = number
+  default     = 4000
+}
+
+variable "v2_executions_max_write_request_units" {
+  description = "Ceiling for on-demand WriteRequestUnits on the v2-executions table and its GSIs. 0 = no explicit ceiling. Ignored on PROVISIONED tables (prod)."
+  type        = number
+  default     = 1000
+}


### PR DESCRIPTION
## Symptom

A ~2h capture on a live deployment showed **2,861 API-Gateway 5xxs** concentrated on `intents/*` endpoints:

| count | endpoint |
|---|---|
| 1,443 | \`GET /api/projects/{projectId}/intents/{intentId}/outputs\` |
| 1,086 | \`GET /api/projects/{projectId}/intents/{intentId}\` |
| 262 | \`POST /api/projects/{projectId}/intents/{intentId}/realtime-token\` |
| 32 | \`GET /api/projects/{projectId}/intents/{intentId}/graph\` |
| 26 | \`GET /api/projects/{projectId}/intents/metrics\` |

Alongside, **7,609 DynamoDB `ReadThrottleEvents`** in the same window. The intents Lambda's outer catch now (post-#442) exposes the underlying error:

```
ProvisionedThroughputExceededException: The level of configured
  provisioned throughput for the table was exceeded.
    at Object.getExecution (...)
    at BufferedInvokeProcessor.handler (...)
resource: '/api/projects/{projectId}/intents/{intentId}/realtime-token',
httpMethod: 'POST',
```

## Root cause

Reads hit a single hot partition on \`collaborative-ai-dlc-v2-executions\` (\`pk = EXEC#<intentId>\`) whenever the intent-view page polls a live intent. The table is on \`PAY_PER_REQUEST\` for non-prod environments, which enforces a **3,000 RCU/s per-partition ceiling** and rejects sustained bursts above **2× historical peak** while adaptive capacity catches up. A handful of concurrent viewers on the same live intent (each polling \`/outputs\` and \`/intents/{id}\` on refresh) exceeds those thresholds; the AWS SDK retries a few times, then the exception bubbles to the handler as a 500.

The table itself is small (~269 items / 236 KB) — this is not a capacity problem, purely bursty concurrent reads on one partition key.

## Fix

Configurable \`on_demand_throughput\` on the \`v2-executions\` table and each of its three GSIs, defaulting to:

- \`max_read_request_units = 4000\`
- \`max_write_request_units = 1000\`

Exposed at the root as:

- \`v2_executions_max_read_request_units\` (default 4000; \`0\` opts out, adaptive-only)
- \`v2_executions_max_write_request_units\` (default 1000; \`0\` opts out)

Blocks are rendered conditionally so they are a **no-op on \`PROVISIONED\` (prod)** tables — \`read_capacity\` + autoscaling continues to govern there unchanged.

## Related

Complementary to #442, which made the underlying error diagnosable by binding the caught exception in the intents Lambda handler.

## Test plan

- [x] \`terraform init -backend=false\` — clean.
- [x] \`terraform validate\` at repo root — \`Success! The configuration is valid.\`
- [x] \`terraform validate\` on the changed module (\`terraform/modules/compute/agentcore\`) — \`Success!\`
- [x] \`terraform fmt -recursive -check\` — clean.
- [x] No changes to Lambda code, IAM, or any resource beyond the DynamoDB table + GSIs.

## Changelog

Entry added under \`[Unreleased] → Fixed\`.