### PR TITLE
fix(terraform): use DynamoDB on-demand in all environments

### DIFF
--- a/terraform/modules/compute/agentcore/main.tf
+++ b/terraform/modules/compute/agentcore/main.tf
@@ -71,9 +71,11 @@ locals {
   credential_broker_function_arn = "arn:${local.partition}:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:${var.project_name}-credential-broker-${var.environment}"
   source_control_function_arn    = "arn:${local.partition}:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:${var.project_name}-source-control-${var.environment}"
 
-  billing_mode   = var.environment == "prod" ? "PROVISIONED" : "PAY_PER_REQUEST"
-  read_capacity  = var.environment == "prod" ? 5 : null
-  write_capacity = var.environment == "prod" ? 5 : null
+  # Keep billing independent from the environment name. Capacity attributes set to
+  # null are omitted by Terraform when PAY_PER_REQUEST is active.
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = null
+  write_capacity = null
 
   # ── AgentCore VPC networking (region-agnostic AZ selection) ──────────────────
   # AgentCore Runtime VPC mode only accepts subnets in specific AZs per region,

--- a/terraform/modules/data/dynamodb/main.tf
+++ b/terraform/modules/data/dynamodb/main.tf
@@ -1,7 +1,9 @@
 locals {
-  billing_mode   = var.environment == "prod" ? "PROVISIONED" : "PAY_PER_REQUEST"
-  read_capacity  = var.environment == "prod" ? 5 : null
-  write_capacity = var.environment == "prod" ? 5 : null
+  # Keep billing independent from the environment name. Capacity attributes set to
+  # null are omitted by Terraform when PAY_PER_REQUEST is active.
+  billing_mode   = "PAY_PER_REQUEST"
+  read_capacity  = null
+  write_capacity = null
 }
 
 resource "aws_dynamodb_table" "sessions" {


### PR DESCRIPTION
## Problem

Production deployments select `PROVISIONED` DynamoDB billing with fixed 5 read/write capacity units solely because `environment == "prod"`. That capacity is causing throttling under bursty workloads, while non-prod already uses on-demand billing.

## What changed

- Set the shared data-module DynamoDB billing mode to `PAY_PER_REQUEST` for every environment.
- Set the AgentCore `v2-executions` table and all three GSIs to the same unconditional on-demand policy.
- Leave read/write capacity attributes null so Terraform omits them under `PAY_PER_REQUEST`.
- Add no throughput ceilings, autoscaling controls, or capacity tuning.
- Preserve all non-DynamoDB environment-tier behavior, including NAT redundancy, runtime sizing, retention, and deletion protection.

PR #443 was closed in favor of this simpler policy.

## Validation

- `terraform fmt -check -recursive`
- `terraform validate` with Terraform 1.15.0 and the same temporary local-backend override used by CI
- Static audit: all 15 repository-owned DynamoDB tables resolve to `PAY_PER_REQUEST`; no `PROVISIONED` Terraform mode remains
- `npm run lint` (0 errors)
- `npm run format:check`
- `npm run test:release` (47/47 passing)
- Pre-commit hook, including secretlint, Terraform formatting, audit, and changed-test selection

The full Vitest suite requires a container runtime for its Gremlin global setup; this host has none, so that suite is left to mandatory CI. The Terraform-only staged-test selection passed with no affected JS tests.

Closes #444