### PR TITLE
fix(agentcore): disable repository hooks for Git operations

### DIFF
--- a/lambda/agentcore/git-engine.js
+++ b/lambda/agentcore/git-engine.js
@@ -128,6 +128,34 @@ const sanitizedGitEnv = (overrides = {}) => {
 // argv-based git runner: captures stdout/stderr, resolves { exitCode, stdout,
 // stderr }, never rejects (spawn errors → exitCode null). Mirrors
 // cli/spawn.js#captureChild but is git-scoped and dependency-free.
+// Engine-owned git invocations must NEVER execute the cloned repository's hooks.
+//
+// Two reasons, both observed in production:
+//
+//  1. CORRECTNESS. A repo using husky + lint-staged installs hooks that shell
+//     out to npm/npx. The runtime deliberately never installs the checkout's
+//     dependencies (see the inode-budget notes in workspace.js), so the hook
+//     exits non-zero and the commit fails — losing a stage's completed work for
+//     a reason unrelated to that work. Seen as a `git_commit_failed` whose only
+//     detail was npm's "Unknown project config" warnings.
+//
+//  2. SECURITY. Repo hooks are arbitrary, untrusted code. They would run inside
+//     the agent runtime, and pushes carry a short-lived credential in the
+//     environment — a `pre-push` hook could read it, abort the push, and surface
+//     the value in the error detail. Running customer hooks is an attack
+//     surface, not a safeguard.
+//
+// `--no-verify` is NOT sufficient: it covers `pre-commit` and `commit-msg` only,
+// leaving `prepare-commit-msg` able to abort a commit and `pre-push` able to run
+// on every push. Setting `core.hooksPath` to a directory with no hooks disables
+// EVERY hook for the invocation, uniformly, and without mutating the
+// repository's own configuration (unlike `git config core.hooksPath`).
+//
+// Applied here, in the single choke point every engine git call passes through,
+// so operations added later inherit the policy automatically.
+export const NO_HOOKS_PATH = '/dev/null';
+const hooksDisabledArgs = () => ['-c', `core.hooksPath=${NO_HOOKS_PATH}`];
+
 export const runGit = (args, { cwd, env = {}, spawnFn = spawn } = {}) =>
   new Promise((resolve) => {
     let settled = false;
@@ -137,7 +165,7 @@ export const runGit = (args, { cwd, env = {}, spawnFn = spawn } = {}) =>
         resolve(v);
       }
     };
-    const child = spawnFn('git', args, {
+    const child = spawnFn('git', [...hooksDisabledArgs(), ...args], {
       cwd,
       shell: false,
       env: sanitizedGitEnv(env),

--- a/lambda/agentcore/git-engine.js
+++ b/lambda/agentcore/git-engine.js
@@ -45,8 +45,8 @@ const DEFAULT_COMMITTER = {
 // GitHub App identity returned by the broker. Implemented via
 // `-c author.name/author.email` (git >=2.22):
 // unlike `--author` it works for `merge` too, and unlike GIT_AUTHOR_* env it
-// survives sanitizedGitEnv (which must keep stripping ambient overrides so
-// the agent can't spoof authorship).
+// survives the shared runner's environment sanitization (which strips ambient
+// overrides so the agent can't spoof authorship).
 //
 // Fields are sanitized to a valid git ident (no newlines/angle brackets); an
 // unusable identity falls back to the engine-only identity — attribution is
@@ -109,22 +109,6 @@ export const ensureRuntimeExcludes = async ({ dir }) => {
   }
 };
 
-// Ambient GIT_* environment variables redirect git to a DIFFERENT repository
-// (GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE) or override the engine identity
-// (GIT_AUTHOR_*/GIT_COMMITTER_*). Any process that spawns the engine from
-// inside a git hook (or any git-managed context) would leak them in — strip
-// them so engine git is deterministic regardless of the caller's environment.
-const AMBIENT_GIT_ENV =
-  /^GIT_(DIR|WORK_TREE|INDEX_FILE|OBJECT_DIRECTORY|ALTERNATE_OBJECT_DIRECTORIES|COMMON_DIR|PREFIX|NAMESPACE|CEILING_DIRECTORIES|AUTHOR_|COMMITTER_)/;
-
-const sanitizedGitEnv = (overrides = {}) => {
-  const env = {};
-  for (const [k, v] of Object.entries(process.env)) {
-    if (!AMBIENT_GIT_ENV.test(k)) env[k] = v;
-  }
-  return { ...env, ...overrides };
-};
-
 // argv-based git runner: captures stdout/stderr, resolves { exitCode, stdout,
 // stderr }, never rejects (spawn errors → exitCode null). Mirrors
 // cli/spawn.js#captureChild but is git-scoped and dependency-free.
@@ -158,10 +142,9 @@ export { NO_HOOKS_PATH };
 export const runGit = async (args, { cwd, env = {}, spawnFn } = {}) => {
   const { exitCode, stdout, stderr } = await runGitCommand('git', args, {
     cwd,
-    env: sanitizedGitEnv(env),
+    env,
     spawnFn,
     captureOutput: true,
-    inheritEnv: false,
   });
   return { exitCode, stdout, stderr };
 };

--- a/lambda/agentcore/git-engine.js
+++ b/lambda/agentcore/git-engine.js
@@ -23,10 +23,10 @@
 // failure fails the stage only when THIS stage created commits that did not
 // reach the remote (new work at risk = the documented v2 loss mode).
 
-import { spawn } from 'node:child_process';
 import { mkdir, readFile, writeFile, rm, statfs } from 'node:fs/promises';
 import path from 'node:path';
 import { buildCloneUrl } from '../shared/git-providers.js';
+import { NO_HOOKS_PATH, runGitCommand } from './git-runner.js';
 import {
   resolveGitCommitter as defaultResolveGitCommitter,
   withGitCredential as defaultWithGitCredential,
@@ -151,37 +151,20 @@ const sanitizedGitEnv = (overrides = {}) => {
 // EVERY hook for the invocation, uniformly, and without mutating the
 // repository's own configuration (unlike `git config core.hooksPath`).
 //
-// Applied here, in the single choke point every engine git call passes through,
-// so operations added later inherit the policy automatically.
-export const NO_HOOKS_PATH = '/dev/null';
-const hooksDisabledArgs = () => ['-c', `core.hooksPath=${NO_HOOKS_PATH}`];
+// Applied by git-runner.js, the single production Git process choke point used
+// by both the engine and workspace paths.
+export { NO_HOOKS_PATH };
 
-export const runGit = (args, { cwd, env = {}, spawnFn = spawn } = {}) =>
-  new Promise((resolve) => {
-    let settled = false;
-    const settle = (v) => {
-      if (!settled) {
-        settled = true;
-        resolve(v);
-      }
-    };
-    const child = spawnFn('git', [...hooksDisabledArgs(), ...args], {
-      cwd,
-      shell: false,
-      env: sanitizedGitEnv(env),
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let stdout = '';
-    let stderr = '';
-    child.stdout?.on('data', (c) => {
-      stdout += c.toString();
-    });
-    child.stderr?.on('data', (c) => {
-      stderr += c.toString();
-    });
-    child.on('error', () => settle({ exitCode: null, stdout, stderr }));
-    child.on('close', (exitCode) => settle({ exitCode, stdout, stderr }));
+export const runGit = async (args, { cwd, env = {}, spawnFn } = {}) => {
+  const { exitCode, stdout, stderr } = await runGitCommand('git', args, {
+    cwd,
+    env: sanitizedGitEnv(env),
+    spawnFn,
+    captureOutput: true,
+    inheritEnv: false,
   });
+  return { exitCode, stdout, stderr };
+};
 
 // Token-free remote URL — what `.git/config` holds at rest.
 export const cleanRemoteUrl = (repo, gitProvider) => buildCloneUrl(gitProvider, repo, '');

--- a/lambda/agentcore/git-runner.js
+++ b/lambda/agentcore/git-runner.js
@@ -21,9 +21,26 @@ export const withGitHooksDisabled = (runner) => {
   );
 };
 
+// Inherited GIT_* variables can redirect Git to another repository/index or
+// override the engine identity. Strip those ambient values for both engine and
+// workspace commands, then apply explicit per-command overrides (credentials,
+// isolated test configuration, etc.) without mutating either input.
+const AMBIENT_GIT_ENV =
+  /^GIT_(DIR|WORK_TREE|INDEX_FILE|OBJECT_DIRECTORY|ALTERNATE_OBJECT_DIRECTORIES|COMMON_DIR|PREFIX|NAMESPACE|CEILING_DIRECTORIES|AUTHOR_|COMMITTER_)/;
+
+const sanitizedGitEnv = (overrides, inheritEnv) => {
+  const env = {};
+  if (inheritEnv) {
+    for (const [key, value] of Object.entries(process.env)) {
+      if (!AMBIENT_GIT_ENV.test(key)) env[key] = value;
+    }
+  }
+  return { ...env, ...overrides };
+};
+
 // The single production choke point for AgentCore-owned Git processes. Engine
 // operations request captured output; workspace operations inherit output. Both
-// receive the same command-scoped hook override before this one spawn call.
+// receive the same hook override and ambient environment sanitization.
 export const runGitCommand = markHooksDisabled(
   (
     command,
@@ -45,7 +62,7 @@ export const runGitCommand = markHooksDisabled(
         child = spawnFn(command, [...HOOKS_DISABLED_ARGS, ...args], {
           cwd,
           shell: false,
-          env: inheritEnv ? { ...process.env, ...env } : env,
+          env: sanitizedGitEnv(env, inheritEnv),
           stdio: captureOutput ? ['ignore', 'pipe', 'pipe'] : ['ignore', 'inherit', 'inherit'],
         });
       } catch {

--- a/lambda/agentcore/git-runner.js
+++ b/lambda/agentcore/git-runner.js
@@ -1,0 +1,65 @@
+import { spawn } from 'node:child_process';
+
+// AgentCore-owned Git commands must never execute hooks from a checked-out
+// repository. Apply the override per invocation so repository and global Git
+// configuration remain untouched.
+export const NO_HOOKS_PATH = '/dev/null';
+export const HOOKS_DISABLED_ARGS = Object.freeze(['-c', `core.hooksPath=${NO_HOOKS_PATH}`]);
+
+const HOOKS_DISABLED_RUNNER = Symbol('hooks-disabled-git-runner');
+const markHooksDisabled = (runner) =>
+  Object.defineProperty(runner, HOOKS_DISABLED_RUNNER, { value: true });
+
+// Preserve injected test-runner contracts while ensuring they observe the same
+// command-scoped hook policy as the production process runner. Wrapping is
+// idempotent so callers can safely pass an already protected runner through
+// multiple orchestration layers.
+export const withGitHooksDisabled = (runner) => {
+  if (runner[HOOKS_DISABLED_RUNNER]) return runner;
+  return markHooksDisabled((command, args, ...runnerArgs) =>
+    runner(command, [...HOOKS_DISABLED_ARGS, ...args], ...runnerArgs),
+  );
+};
+
+// The single production choke point for AgentCore-owned Git processes. Engine
+// operations request captured output; workspace operations inherit output. Both
+// receive the same command-scoped hook override before this one spawn call.
+export const runGitCommand = markHooksDisabled(
+  (
+    command,
+    args,
+    { cwd, env = {}, spawnFn = spawn, captureOutput = false, inheritEnv = true } = {},
+  ) =>
+    new Promise((resolve) => {
+      let settled = false;
+      let stdout = '';
+      let stderr = '';
+      const settle = (exitCode) => {
+        if (settled) return;
+        settled = true;
+        resolve({ code: exitCode, exitCode, stdout, stderr });
+      };
+
+      let child;
+      try {
+        child = spawnFn(command, [...HOOKS_DISABLED_ARGS, ...args], {
+          cwd,
+          shell: false,
+          env: inheritEnv ? { ...process.env, ...env } : env,
+          stdio: captureOutput ? ['ignore', 'pipe', 'pipe'] : ['ignore', 'inherit', 'inherit'],
+        });
+      } catch {
+        settle(null);
+        return;
+      }
+
+      child.stdout?.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr?.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+      child.on('error', () => settle(null));
+      child.on('close', (exitCode) => settle(exitCode));
+    }),
+);

--- a/lambda/agentcore/test/git-engine.test.js
+++ b/lambda/agentcore/test/git-engine.test.js
@@ -155,6 +155,102 @@ describe('commitAll', () => {
   });
 });
 
+// The engine must never execute the CLONED REPO's hooks. Two reasons:
+// correctness (hooks that shell out to npm cannot work — the runtime never
+// installs the checkout's dependencies, so a stage lost completed work to a
+// husky/lint-staged pre-commit) and security (hooks are arbitrary untrusted code
+// and pushes carry a credential in the environment).
+//
+// `--no-verify` is insufficient: it covers pre-commit and commit-msg only. These
+// cases pin the hooks via `core.hooksPath` — the strongest form, because it
+// proves the engine's own `-c core.hooksPath` overrides a hooksPath the
+// repository configured for itself, not just the default `.git/hooks`.
+describe('engine git ignores repository hooks', () => {
+  // Install a hook that records that it ran and then fails the operation.
+  const installHook = async (work, name, { viaConfig = false, body } = {}) => {
+    const dir = viaConfig ? path.join(work, '.custom-hooks') : path.join(work, '.git', 'hooks');
+    await mkdir(dir, { recursive: true });
+    const marker = path.join(work, `${name}-ran.txt`);
+    await writeFile(
+      path.join(dir, name),
+      body ?? `#!/bin/sh\necho ran > "${marker}"\necho "${name} rejected" >&2\nexit 1\n`,
+      { mode: 0o755 },
+    );
+    if (viaConfig) await git(['config', 'core.hooksPath', dir], work);
+    return marker;
+  };
+  const ran = async (marker) => {
+    try {
+      await readFile(marker, 'utf8');
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  for (const hook of ['pre-commit', 'commit-msg', 'prepare-commit-msg']) {
+    it(`commits with a failing ${hook} hook configured via core.hooksPath`, async () => {
+      const { work } = await initRemoteAndClone();
+      const marker = await installHook(work, hook, { viaConfig: true });
+      await writeFile(path.join(work, 'agent-work.txt'), 'artifacts the agent produced\n');
+
+      const res = await commitAll({ dir: work, message: 'aidlc(functional-design): e1' });
+
+      expect(res.committed).toBe(true);
+      expect(res.sha).toMatch(/^[0-9a-f]{40}$/);
+      expect(await ran(marker)).toBe(false);
+      const show = await git(['show', '--stat', '--format='], work);
+      expect(show.stdout).toContain('agent-work.txt');
+    });
+  }
+
+  it('does not leave a dirty tree when prepare-commit-msg would abort', async () => {
+    // prepare-commit-msg is the gap --no-verify left open: it can abort a commit,
+    // which previously returned commit_failed with the work still uncommitted.
+    const { work } = await initRemoteAndClone();
+    await installHook(work, 'prepare-commit-msg', { viaConfig: true });
+    await writeFile(path.join(work, 'agent-work.txt'), 'work\n');
+
+    const res = await commitAll({ dir: work, message: 'aidlc(x): e1' });
+
+    expect(res.committed).toBe(true);
+    expect(res.dirty).toBeFalsy();
+    const status = await git(['status', '--porcelain'], work);
+    expect(status.stdout.trim()).toBe('');
+  });
+
+  it('does not run pre-push, so a hook cannot read the push credential', async () => {
+    // A pre-push hook runs with the push environment, which carries
+    // AIDLC_GIT_PASSWORD. If it executed it could exfiltrate the token, abort the
+    // push, and surface the value in the returned error detail.
+    const { work, remote } = await initRemoteAndClone();
+    const leak = path.join(work, 'leaked-credential.txt');
+    await installHook(work, 'pre-push', {
+      viaConfig: true,
+      body: `#!/bin/sh\nprintf '%s' "$AIDLC_GIT_PASSWORD" > "${leak}"\necho "pre-push rejected" >&2\nexit 1\n`,
+    });
+    await writeFile(path.join(work, 'agent-work.txt'), 'work\n');
+    await commitAll({ dir: work, message: 'aidlc(x): e1' });
+
+    const res = await pushBranch({
+      dir: work,
+      repo: 'o/r',
+      branch: 'main',
+      urls: { clean: remote, tokenized: remote },
+      withGitCredential: async (_o, fn) =>
+        fn({ AIDLC_GIT_PASSWORD: 'super-secret-token', GIT_TERMINAL_PROMPT: '0' }),
+      log: () => {},
+    });
+
+    expect(res.pushed).toBe(true);
+    expect(await ran(leak)).toBe(false);
+    expect(JSON.stringify(res)).not.toContain('super-secret-token');
+    // The commit really reached the remote.
+    const remoteHead = await git(['rev-parse', 'refs/heads/main'], remote);
+    expect(remoteHead.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
+  });
+});
+
 describe('seedInitialCommit', () => {
   it('roots history on the BASE branch and forks the intent branch off it (empty repo)', async () => {
     const { work } = await initRemoteAndClone({ withInitialCommit: false });

--- a/lambda/agentcore/test/git-engine.test.js
+++ b/lambda/agentcore/test/git-engine.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -166,6 +166,14 @@ describe('commitAll', () => {
 // proves the engine's own `-c core.hooksPath` overrides a hooksPath the
 // repository configured for itself, not just the default `.git/hooks`.
 describe('engine git ignores repository hooks', () => {
+  const globalConfig = () => path.join(root, 'global.gitconfig');
+  const isolatedGit = (args, options = {}) =>
+    runGit(args, {
+      ...options,
+      env: { GIT_CONFIG_GLOBAL: globalConfig(), ...options.env },
+    });
+  const isolatedGitAt = (args, cwd) => isolatedGit(args, { cwd });
+
   // Install a hook that records that it ran and then fails the operation.
   const installHook = async (work, name, { viaConfig = false, body } = {}) => {
     const dir = viaConfig ? path.join(work, '.custom-hooks') : path.join(work, '.git', 'hooks');
@@ -176,9 +184,23 @@ describe('engine git ignores repository hooks', () => {
       body ?? `#!/bin/sh\necho ran > "${marker}"\necho "${name} rejected" >&2\nexit 1\n`,
       { mode: 0o755 },
     );
-    if (viaConfig) await git(['config', 'core.hooksPath', dir], work);
+    if (viaConfig) await isolatedGitAt(['config', '--local', 'core.hooksPath', dir], work);
     return marker;
   };
+  const configureGlobalHooksPath = async () => {
+    const dir = path.join(root, 'global-hooks');
+    await mkdir(dir, { recursive: true });
+    await isolatedGitAt(['config', '--global', 'core.hooksPath', dir], root);
+    return dir;
+  };
+  const readHooksPaths = async (work) => ({
+    repository: (
+      await isolatedGitAt(['config', '--local', '--get', 'core.hooksPath'], work)
+    ).stdout.trim(),
+    global: (
+      await isolatedGitAt(['config', '--global', '--get', 'core.hooksPath'], work)
+    ).stdout.trim(),
+  });
   const ran = async (marker) => {
     try {
       await readFile(marker, 'utf8');
@@ -188,18 +210,29 @@ describe('engine git ignores repository hooks', () => {
     }
   };
 
-  for (const hook of ['pre-commit', 'commit-msg', 'prepare-commit-msg']) {
+  for (const hook of ['pre-commit', 'prepare-commit-msg', 'commit-msg']) {
     it(`commits with a failing ${hook} hook configured via core.hooksPath`, async () => {
       const { work } = await initRemoteAndClone();
+      const globalHooks = await configureGlobalHooksPath();
       const marker = await installHook(work, hook, { viaConfig: true });
+      const hooksPathsBefore = await readHooksPaths(work);
+      expect(hooksPathsBefore).toEqual({
+        repository: path.join(work, '.custom-hooks'),
+        global: globalHooks,
+      });
       await writeFile(path.join(work, 'agent-work.txt'), 'artifacts the agent produced\n');
 
-      const res = await commitAll({ dir: work, message: 'aidlc(functional-design): e1' });
+      const res = await commitAll({
+        dir: work,
+        message: 'aidlc(functional-design): e1',
+        git: isolatedGit,
+      });
 
       expect(res.committed).toBe(true);
       expect(res.sha).toMatch(/^[0-9a-f]{40}$/);
       expect(await ran(marker)).toBe(false);
-      const show = await git(['show', '--stat', '--format='], work);
+      expect(await readHooksPaths(work)).toEqual(hooksPathsBefore);
+      const show = await isolatedGitAt(['show', '--stat', '--format='], work);
       expect(show.stdout).toContain('agent-work.txt');
     });
   }
@@ -208,14 +241,21 @@ describe('engine git ignores repository hooks', () => {
     // prepare-commit-msg is the gap --no-verify left open: it can abort a commit,
     // which previously returned commit_failed with the work still uncommitted.
     const { work } = await initRemoteAndClone();
+    await configureGlobalHooksPath();
     await installHook(work, 'prepare-commit-msg', { viaConfig: true });
+    const hooksPathsBefore = await readHooksPaths(work);
     await writeFile(path.join(work, 'agent-work.txt'), 'work\n');
 
-    const res = await commitAll({ dir: work, message: 'aidlc(x): e1' });
+    const res = await commitAll({
+      dir: work,
+      message: 'aidlc(x): e1',
+      git: isolatedGit,
+    });
 
     expect(res.committed).toBe(true);
     expect(res.dirty).toBeFalsy();
-    const status = await git(['status', '--porcelain'], work);
+    expect(await readHooksPaths(work)).toEqual(hooksPathsBefore);
+    const status = await isolatedGitAt(['status', '--porcelain'], work);
     expect(status.stdout.trim()).toBe('');
   });
 
@@ -224,19 +264,27 @@ describe('engine git ignores repository hooks', () => {
     // AIDLC_GIT_PASSWORD. If it executed it could exfiltrate the token, abort the
     // push, and surface the value in the returned error detail.
     const { work, remote } = await initRemoteAndClone();
+    const globalHooks = await configureGlobalHooksPath();
     const leak = path.join(work, 'leaked-credential.txt');
     await installHook(work, 'pre-push', {
       viaConfig: true,
       body: `#!/bin/sh\nprintf '%s' "$AIDLC_GIT_PASSWORD" > "${leak}"\necho "pre-push rejected" >&2\nexit 1\n`,
     });
+    const hooksPathsBefore = await readHooksPaths(work);
+    expect(hooksPathsBefore).toEqual({
+      repository: path.join(work, '.custom-hooks'),
+      global: globalHooks,
+    });
     await writeFile(path.join(work, 'agent-work.txt'), 'work\n');
-    await commitAll({ dir: work, message: 'aidlc(x): e1' });
+    const commit = await commitAll({ dir: work, message: 'aidlc(x): e1', git: isolatedGit });
+    expect(commit.committed).toBe(true);
 
     const res = await pushBranch({
       dir: work,
       repo: 'o/r',
       branch: 'main',
       urls: { clean: remote, tokenized: remote },
+      git: isolatedGit,
       withGitCredential: async (_o, fn) =>
         fn({ AIDLC_GIT_PASSWORD: 'super-secret-token', GIT_TERMINAL_PROMPT: '0' }),
       log: () => {},
@@ -245,9 +293,11 @@ describe('engine git ignores repository hooks', () => {
     expect(res.pushed).toBe(true);
     expect(await ran(leak)).toBe(false);
     expect(JSON.stringify(res)).not.toContain('super-secret-token');
-    // The commit really reached the remote.
-    const remoteHead = await git(['rev-parse', 'refs/heads/main'], remote);
-    expect(remoteHead.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
+    expect(await readHooksPaths(work)).toEqual(hooksPathsBefore);
+    const localHead = await isolatedGitAt(['rev-parse', 'HEAD'], work);
+    expect(localHead.stdout.trim()).toBe(commit.sha);
+    const remoteHead = await isolatedGitAt(['rev-parse', 'refs/heads/main'], remote);
+    expect(remoteHead.stdout.trim()).toBe(localHead.stdout.trim());
   });
 });
 
@@ -1349,7 +1399,6 @@ describe('findRemainingConflictMarkers', () => {
 // including stages that produce no repo work at all.
 
 import { ensureRuntimeExcludes, RUNTIME_EXCLUDES } from '../git-engine.js';
-import { mkdir } from 'node:fs/promises';
 
 const seedRuntimeFiles = async (work) => {
   await mkdir(path.join(work, '.aidlc'), { recursive: true });

--- a/lambda/agentcore/test/git-runner.test.js
+++ b/lambda/agentcore/test/git-runner.test.js
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   HOOKS_DISABLED_ARGS,
   NO_HOOKS_PATH,
@@ -95,6 +95,10 @@ describe('withGitHooksDisabled', () => {
 });
 
 describe('runGitCommand', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   const fakeChild = () => {
     const child = new EventEmitter();
     child.stdout = new EventEmitter();
@@ -102,7 +106,75 @@ describe('runGitCommand', () => {
     return child;
   };
 
+  it('strips ambient repository and identity overrides while preserving credentials and ordinary environment', async () => {
+    const ambient = {
+      GIT_DIR: '/ambient/.git',
+      GIT_WORK_TREE: '/ambient/worktree',
+      GIT_INDEX_FILE: '/ambient/index',
+      GIT_OBJECT_DIRECTORY: '/ambient/objects',
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: '/ambient/alternates',
+      GIT_COMMON_DIR: '/ambient/common',
+      GIT_PREFIX: 'ambient/',
+      GIT_NAMESPACE: 'ambient',
+      GIT_CEILING_DIRECTORIES: '/ambient',
+      GIT_AUTHOR_NAME: 'Ambient Author',
+      GIT_AUTHOR_EMAIL: 'ambient-author@example.test',
+      GIT_AUTHOR_DATE: '2000-01-01T00:00:00Z',
+      GIT_COMMITTER_NAME: 'Ambient Committer',
+      GIT_COMMITTER_EMAIL: 'ambient-committer@example.test',
+      GIT_COMMITTER_DATE: '2000-01-01T00:00:00Z',
+    };
+    for (const [key, value] of Object.entries(ambient)) vi.stubEnv(key, value);
+    vi.stubEnv('AIDLC_GIT_RUNNER_TEST', 'inherited');
+    const env = {
+      GIT_ASKPASS: '/tmp/test-askpass',
+      GIT_TERMINAL_PROMPT: '0',
+      AIDLC_GIT_USERNAME: 'test-user',
+      AIDLC_GIT_PASSWORD: 'test-credential-sentinel',
+    };
+    const originalOverrides = { ...env };
+    const child = fakeChild();
+    const spawnFn = vi.fn(() => child);
+
+    const resultPromise = runGitCommand('git', ['clone', 'remote', '/workspace'], {
+      env,
+      spawnFn,
+    });
+    child.emit('close', 0);
+
+    await expect(resultPromise).resolves.toMatchObject({ code: 0 });
+    const options = spawnFn.mock.calls[0][2];
+    expect(options.stdio).toEqual(['ignore', 'inherit', 'inherit']);
+    expect(options.env).toMatchObject({
+      ...env,
+      PATH: process.env.PATH,
+      AIDLC_GIT_RUNNER_TEST: 'inherited',
+    });
+    for (const [key, value] of Object.entries(ambient)) {
+      expect(options.env).not.toHaveProperty(key);
+      expect(process.env[key]).toBe(value);
+    }
+    expect(env).toEqual(originalOverrides);
+  });
+
+  it('preserves explicit per-command Git overrides after sanitizing the inherited environment', async () => {
+    vi.stubEnv('GIT_INDEX_FILE', '/ambient/index');
+    const child = fakeChild();
+    const spawnFn = vi.fn(() => child);
+
+    const resultPromise = runGitCommand('git', ['status'], {
+      env: { GIT_INDEX_FILE: '/explicit/index' },
+      spawnFn,
+    });
+    child.emit('close', 0);
+
+    await resultPromise;
+    expect(spawnFn.mock.calls[0][2].env.GIT_INDEX_FILE).toBe('/explicit/index');
+    expect(process.env.GIT_INDEX_FILE).toBe('/ambient/index');
+  });
+
   it('owns process spawning and captures output for engine callers', async () => {
+    vi.stubEnv('AIDLC_GIT_RUNNER_TEST', 'must-not-be-inherited');
     const child = fakeChild();
     const spawnFn = vi.fn(() => child);
     const env = { PATH: '/usr/bin', GIT_TERMINAL_PROMPT: '0' };

--- a/lambda/agentcore/test/git-runner.test.js
+++ b/lambda/agentcore/test/git-runner.test.js
@@ -1,0 +1,145 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  HOOKS_DISABLED_ARGS,
+  NO_HOOKS_PATH,
+  runGitCommand,
+  withGitHooksDisabled,
+} from '../git-runner.js';
+
+describe('withGitHooksDisabled', () => {
+  it('prepends the hook override before the requested Git arguments', () => {
+    const runner = vi.fn();
+    const runGit = withGitHooksDisabled(runner);
+    const args = ['checkout', '--detach', 'abc123'];
+
+    runGit('git', args);
+
+    expect(runner).toHaveBeenCalledWith('git', [
+      '-c',
+      'core.hooksPath=/dev/null',
+      'checkout',
+      '--detach',
+      'abc123',
+    ]);
+    expect(args).toEqual(['checkout', '--detach', 'abc123']);
+  });
+
+  it('applies hook suppression exactly once to each command invocation', () => {
+    const runner = vi.fn();
+    const runGit = withGitHooksDisabled(runner);
+
+    runGit('git', ['status']);
+    runGit('git', ['commit', '-m', 'message']);
+
+    expect(runner).toHaveBeenCalledTimes(2);
+    for (const [, args] of runner.mock.calls) {
+      expect(args.slice(0, 2)).toEqual(HOOKS_DISABLED_ARGS);
+      expect(args.filter((arg) => arg === '-c')).toHaveLength(1);
+      expect(args.filter((arg) => arg === `core.hooksPath=${NO_HOOKS_PATH}`)).toHaveLength(1);
+    }
+    expect(runner.mock.calls[0][1]).toEqual([...HOOKS_DISABLED_ARGS, 'status']);
+    expect(runner.mock.calls[1][1]).toEqual([...HOOKS_DISABLED_ARGS, 'commit', '-m', 'message']);
+  });
+
+  it('forwards options, environment, and additional runner arguments by identity', () => {
+    const runner = vi.fn();
+    const runGit = withGitHooksDisabled(runner);
+    const options = {
+      cwd: '/workspace',
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    };
+    const signal = new AbortController().signal;
+
+    runGit('git', ['fetch', 'origin'], options, signal);
+
+    expect(runner).toHaveBeenCalledOnce();
+    expect(runner.mock.calls[0][2]).toBe(options);
+    expect(runner.mock.calls[0][2].env).toBe(options.env);
+    expect(runner.mock.calls[0][3]).toBe(signal);
+  });
+
+  it('invokes only the injected runner', () => {
+    const injectedRunner = vi.fn();
+    const runGit = withGitHooksDisabled(injectedRunner);
+
+    runGit('custom-git', ['rev-parse', 'HEAD']);
+
+    expect(injectedRunner).toHaveBeenCalledOnce();
+    expect(injectedRunner).toHaveBeenCalledWith('custom-git', [
+      ...HOOKS_DISABLED_ARGS,
+      'rev-parse',
+      'HEAD',
+    ]);
+  });
+
+  it('does not double-wrap the production process runner', () => {
+    expect(withGitHooksDisabled(runGitCommand)).toBe(runGitCommand);
+  });
+
+  it('propagates synchronous errors without wrapping them', () => {
+    const error = new Error('runner failed');
+    const runGit = withGitHooksDisabled(() => {
+      throw error;
+    });
+
+    expect(() => runGit('git', ['status'])).toThrow(error);
+  });
+
+  it('preserves the injected runner return value exactly', () => {
+    const result = Promise.resolve({ stdout: 'abc123\n', exitCode: 0 });
+    const runGit = withGitHooksDisabled(() => result);
+
+    expect(runGit('git', ['rev-parse', 'HEAD'])).toBe(result);
+  });
+});
+
+describe('runGitCommand', () => {
+  const fakeChild = () => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    return child;
+  };
+
+  it('owns process spawning and captures output for engine callers', async () => {
+    const child = fakeChild();
+    const spawnFn = vi.fn(() => child);
+    const env = { PATH: '/usr/bin', GIT_TERMINAL_PROMPT: '0' };
+    const resultPromise = runGitCommand('git', ['status', '--porcelain'], {
+      cwd: '/workspace',
+      env,
+      spawnFn,
+      captureOutput: true,
+      inheritEnv: false,
+    });
+
+    child.stdout.emit('data', Buffer.from(' M file.js\n'));
+    child.stderr.emit('data', Buffer.from('warning\n'));
+    child.emit('close', 0);
+
+    await expect(resultPromise).resolves.toEqual({
+      code: 0,
+      exitCode: 0,
+      stdout: ' M file.js\n',
+      stderr: 'warning\n',
+    });
+    expect(spawnFn).toHaveBeenCalledOnce();
+    expect(spawnFn).toHaveBeenCalledWith('git', [...HOOKS_DISABLED_ARGS, 'status', '--porcelain'], {
+      cwd: '/workspace',
+      shell: false,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  });
+
+  it('resolves spawn failures as a null exit result', async () => {
+    const spawnFn = vi.fn(() => {
+      throw new Error('spawn failed');
+    });
+
+    await expect(
+      runGitCommand('git', ['status'], { spawnFn, captureOutput: true }),
+    ).resolves.toEqual({ code: null, exitCode: null, stdout: '', stderr: '' });
+  });
+});

--- a/lambda/agentcore/test/init-ws.test.js
+++ b/lambda/agentcore/test/init-ws.test.js
@@ -1,4 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { spawn } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
 import gremlin from 'gremlin';
 import { PartitionStrategy } from 'gremlin/lib/process/traversal-strategy.js';
 import { initWs, ensureIntentVertex } from '../commands/init-ws.js';
@@ -8,6 +13,7 @@ import {
   ensureWorkspaceSource as ensureWorkspaceSourceImpl,
   trustGitDirectory,
 } from '../workspace.js';
+import { HOOKS_DISABLED_ARGS } from '../git-runner.js';
 
 const TEST_SECRET = ['broker', 'credential'].join('-');
 const withTestCredential = async (context, operation) =>
@@ -26,10 +32,20 @@ const credentialContext = {
   withGitCredential: withTestCredential,
   trustDirectory: async () => true,
 };
-const checkoutRepo = (args) => checkoutRepoImpl({ ...credentialContext, ...args });
-const checkoutRepos = (args) => checkoutReposImpl({ ...credentialContext, ...args });
-const ensureWorkspaceSource = (args) =>
-  ensureWorkspaceSourceImpl({ ...credentialContext, ...args });
+const logicalGitRunner =
+  (runner) =>
+  (command, args, ...runnerArgs) => {
+    expect(args.slice(0, HOOKS_DISABLED_ARGS.length)).toEqual(HOOKS_DISABLED_ARGS);
+    return runner(command, args.slice(HOOKS_DISABLED_ARGS.length), ...runnerArgs);
+  };
+const workspaceDeps = (args) => ({
+  ...credentialContext,
+  ...args,
+  ...(args.runner ? { runner: logicalGitRunner(args.runner) } : {}),
+});
+const checkoutRepo = (args) => checkoutRepoImpl(workspaceDeps(args));
+const checkoutRepos = (args) => checkoutReposImpl(workspaceDeps(args));
+const ensureWorkspaceSource = (args) => ensureWorkspaceSourceImpl(workspaceDeps(args));
 
 const PARTITION = 'agentcore-init-ws';
 let conn;
@@ -815,6 +831,218 @@ describe('workspace checkout (mocked git runner)', () => {
   });
 });
 
+describe('workspace checkout hook isolation (real local repositories)', () => {
+  const PASSWORD_SENTINEL = 'workspace-hook-regression-sentinel';
+  const CLEAN_URL = 'https://github.com/local/repository.git';
+  let root;
+
+  const gitEnvironment = (overrides = {}) => {
+    const env = { ...process.env };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('GIT_')) delete env[key];
+    }
+    return {
+      ...env,
+      HOME: root,
+      XDG_CONFIG_HOME: path.join(root, 'xdg'),
+      GIT_CONFIG_GLOBAL: path.join(root, 'global.gitconfig'),
+      GIT_CONFIG_NOSYSTEM: '1',
+      AIDLC_GIT_PASSWORD: '',
+      ...overrides,
+    };
+  };
+
+  const runFixtureGit = (args, { cwd = root, env = {} } = {}) =>
+    new Promise((resolve) => {
+      const child = spawn('git', args, {
+        cwd,
+        env: gitEnvironment(env),
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+      child.on('error', (error) => resolve({ code: null, stdout, stderr, error }));
+      child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+
+  const gitOk = async (args, options) => {
+    const result = await runFixtureGit(args, options);
+    expect(result.code, result.stderr).toBe(0);
+    return result;
+  };
+
+  const createLocalRemote = async ({ trackedPostCheckout } = {}) => {
+    const remote = path.join(root, `remote-${Math.random().toString(16).slice(2)}`);
+    await gitOk(['init', '-b', 'main', remote]);
+    await writeFile(path.join(remote, 'README.md'), 'local fixture\n');
+    if (trackedPostCheckout) {
+      const hooksDir = path.join(remote, '.githooks');
+      await mkdir(hooksDir, { recursive: true });
+      await writeFile(path.join(hooksDir, 'post-checkout'), trackedPostCheckout, { mode: 0o755 });
+    }
+    await gitOk(['add', '-A'], { cwd: remote });
+    await gitOk(
+      ['-c', 'user.name=Workspace Test', '-c', 'user.email=workspace@test', 'commit', '-m', 'seed'],
+      { cwd: remote },
+    );
+    return { remote, url: pathToFileURL(remote).href };
+  };
+
+  const hookBody = (marker) =>
+    `#!/bin/sh\nprintf '%s' "\${AIDLC_GIT_PASSWORD:-<unset>}" > "${marker}"\necho 'post-checkout rejected' >&2\nexit 97\n`;
+
+  const workspaceRunner =
+    ({ remoteUrl, password = '', commands }) =>
+    async (command, args, options = {}) => {
+      expect(command).toBe('git');
+      commands.push([...args]);
+      const localArgs = args.map((arg) => (arg === CLEAN_URL ? remoteUrl : arg));
+      return runFixtureGit(localArgs, {
+        cwd: options.cwd ?? root,
+        env: { AIDLC_GIT_PASSWORD: password, ...options.env },
+      });
+    };
+
+  const readLocalHooksPath = async (repo) =>
+    runFixtureGit(['config', '--local', '--get', 'core.hooksPath'], { cwd: repo });
+
+  const expectMissing = async (file) => {
+    await expect(readFile(file, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+  };
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'init-ws-hooks-'));
+    await writeFile(path.join(root, 'global.gitconfig'), '');
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('suppresses a configured failing post-checkout hook during warm reuse without mutating hook config', async () => {
+    const marker = path.join(root, 'warm-hook-observed.txt');
+    const { url } = await createLocalRemote();
+    const work = path.join(root, 'warm-work');
+    await gitOk(['clone', url, work]);
+    await gitOk(['branch', 'next'], { cwd: work });
+    const hooksDir = path.join(work, '.configured-hooks');
+    await mkdir(hooksDir, { recursive: true });
+    await writeFile(path.join(hooksDir, 'post-checkout'), hookBody(marker), { mode: 0o755 });
+    await gitOk(['config', '--local', 'core.hooksPath', hooksDir], { cwd: work });
+
+    // Prove the fixture is live: an ordinary checkout runs the failing hook.
+    const unprotected = await runFixtureGit(['checkout', 'next'], { cwd: work });
+    expect(unprotected.code).not.toBe(0);
+    expect(await readFile(marker, 'utf8')).toBe('<unset>');
+    await rm(marker, { force: true });
+
+    const hooksPathBefore = await readLocalHooksPath(work);
+    const repositoryBefore = await readFile(path.join(work, '.git', 'config'), 'utf8');
+    const globalBefore = await readFile(path.join(root, 'global.gitconfig'), 'utf8');
+    const commands = [];
+    const result = await checkoutRepoImpl({
+      ...credentialContext,
+      repo: 'local/repository',
+      branch: 'main',
+      targetDir: work,
+      runner: workspaceRunner({ remoteUrl: url, password: PASSWORD_SENTINEL, commands }),
+      trustDirectory: async () => true,
+    });
+
+    expect(result).toMatchObject({ cloned: true, reused: true, branchOk: true });
+    expect((await gitOk(['branch', '--show-current'], { cwd: work })).stdout.trim()).toBe('main');
+    await expectMissing(marker);
+    expect((await readLocalHooksPath(work)).stdout).toBe(hooksPathBefore.stdout);
+    expect(await readFile(path.join(work, '.git', 'config'), 'utf8')).toBe(repositoryBefore);
+    expect(await readFile(path.join(root, 'global.gitconfig'), 'utf8')).toBe(globalBefore);
+    expect(commands.length).toBeGreaterThan(0);
+    for (const args of commands) {
+      expect(args.slice(0, HOOKS_DISABLED_ARGS.length)).toEqual(HOOKS_DISABLED_ARGS);
+    }
+  }, 30_000);
+
+  it('suppresses an inherited global hook path targeting a tracked hook during fresh clone', async () => {
+    const marker = path.join(root, 'fresh-hook-observed.txt');
+    const { url } = await createLocalRemote({ trackedPostCheckout: hookBody(marker) });
+    await gitOk(['config', '--global', 'core.hooksPath', '.githooks']);
+
+    // Without the command-scoped override, clone discovers the newly checked
+    // out tracked hook through the inherited global path and the hook rejects.
+    const unprotectedTarget = path.join(root, 'unprotected-clone');
+    const unprotected = await runFixtureGit(['clone', url, unprotectedTarget]);
+    expect(unprotected.code).not.toBe(0);
+    expect(await readFile(marker, 'utf8')).toBe('<unset>');
+    await rm(marker, { force: true });
+    await rm(unprotectedTarget, { recursive: true, force: true });
+
+    const globalBefore = await readFile(path.join(root, 'global.gitconfig'), 'utf8');
+    const target = path.join(root, 'protected-clone');
+    const commands = [];
+    const result = await checkoutRepoImpl({
+      ...credentialContext,
+      repo: 'local/repository',
+      branch: 'main',
+      targetDir: target,
+      runner: workspaceRunner({ remoteUrl: url, commands }),
+      withGitCredential: async (_context, operation) =>
+        operation({
+          env: {
+            AIDLC_GIT_PASSWORD: PASSWORD_SENTINEL,
+            GIT_TERMINAL_PROMPT: '0',
+          },
+        }),
+      trustDirectory: async () => true,
+    });
+
+    expect(result).toMatchObject({ cloned: true, branchOk: true });
+    await expectMissing(marker);
+    expect((await readLocalHooksPath(target)).code).not.toBe(0);
+    expect(await readFile(path.join(root, 'global.gitconfig'), 'utf8')).toBe(globalBefore);
+    expect(commands.length).toBeGreaterThan(0);
+    for (const args of commands) {
+      expect(args.slice(0, HOOKS_DISABLED_ARGS.length)).toEqual(HOOKS_DISABLED_ARGS);
+    }
+  }, 30_000);
+
+  it('proves a normal clone does not transfer remote-local config or .git hooks', async () => {
+    const marker = path.join(root, 'remote-local-hook-observed.txt');
+    const { remote, url } = await createLocalRemote();
+    await gitOk(['config', '--local', 'core.hooksPath', '.git/hooks'], { cwd: remote });
+    await gitOk(['config', '--local', 'workspace.remote-only', 'true'], { cwd: remote });
+    await writeFile(path.join(remote, '.git', 'hooks', 'post-checkout'), hookBody(marker), {
+      mode: 0o755,
+    });
+    const remoteConfigBefore = await readFile(path.join(remote, '.git', 'config'), 'utf8');
+
+    const target = path.join(root, 'ordinary-clone');
+    const cloned = await runFixtureGit(['clone', url, target], {
+      env: { AIDLC_GIT_PASSWORD: PASSWORD_SENTINEL },
+    });
+
+    expect(cloned.code, cloned.stderr).toBe(0);
+    await expectMissing(marker);
+    expect((await readLocalHooksPath(target)).code).not.toBe(0);
+    expect(
+      (
+        await runFixtureGit(['config', '--local', '--get', 'workspace.remote-only'], {
+          cwd: target,
+        })
+      ).code,
+    ).not.toBe(0);
+    await expect(access(path.join(target, '.git', 'hooks', 'post-checkout'))).rejects.toMatchObject(
+      { code: 'ENOENT' },
+    );
+    expect(await readFile(path.join(remote, '.git', 'config'), 'utf8')).toBe(remoteConfigBefore);
+  }, 30_000);
+});
+
 describe('ensureWorkspaceSource (self-heal a wiped checkout)', () => {
   const noMkdir = async () => {};
   // A stat that reports `.git` present for the given set of target dirs.
@@ -944,7 +1172,9 @@ describe('trustGitDirectory', () => {
       return { code: args.includes('--get-all') ? 1 : 0 };
     };
 
-    await expect(trustGitDirectory({ targetDir: '/ws/acme/api', runner })).resolves.toBe(true);
+    await expect(
+      trustGitDirectory({ targetDir: '/ws/acme/api', runner: logicalGitRunner(runner) }),
+    ).resolves.toBe(true);
     expect(commands).toEqual([
       'git config --global --fixed-value --get-all safe.directory /ws/acme/api',
       'git config --global --add safe.directory /ws/acme/api',
@@ -958,7 +1188,9 @@ describe('trustGitDirectory', () => {
       return { code: 0 };
     };
 
-    await expect(trustGitDirectory({ targetDir: '/ws/acme/api', runner })).resolves.toBe(true);
+    await expect(
+      trustGitDirectory({ targetDir: '/ws/acme/api', runner: logicalGitRunner(runner) }),
+    ).resolves.toBe(true);
     expect(commands).toEqual([
       'git config --global --fixed-value --get-all safe.directory /ws/acme/api',
     ]);

--- a/lambda/agentcore/test/pr-363-v2-reproduction.test.js
+++ b/lambda/agentcore/test/pr-363-v2-reproduction.test.js
@@ -1,0 +1,283 @@
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { commitAll, pushBranch, runGit } from '../git-engine.js';
+import { HOOKS_DISABLED_ARGS } from '../git-runner.js';
+import { checkoutRepo } from '../workspace.js';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+const CLEAN_REPOSITORY_URL = 'https://github.com/owner/repo.git';
+const PASSWORD_SENTINEL = ['workspace', 'password', 'sentinel'].join('-');
+let root;
+
+const git = (args, cwd) => runGit(args, { cwd });
+
+const fixtureGitEnvironment = (overrides = {}) => {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_')) delete env[key];
+  }
+  return {
+    ...env,
+    HOME: root,
+    XDG_CONFIG_HOME: path.join(root, 'xdg'),
+    GIT_CONFIG_GLOBAL: path.join(root, 'global.gitconfig'),
+    GIT_CONFIG_NOSYSTEM: '1',
+    AIDLC_GIT_PASSWORD: '',
+    ...overrides,
+  };
+};
+
+const runFixtureGit = (args, { cwd = root, env = {} } = {}) =>
+  new Promise((resolve) => {
+    let settled = false;
+    const settle = (result) => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
+      }
+    };
+    const child = spawn('git', args, {
+      cwd,
+      env: fixtureGitEnvironment(env),
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => settle({ code: null, stdout, stderr, error }));
+    child.on('close', (code) => settle({ code, stdout, stderr }));
+  });
+
+const fixtureGitOk = async (args, options) => {
+  const result = await runFixtureGit(args, options);
+  expect(result.code, result.stderr).toBe(0);
+  return result;
+};
+
+const initRemoteAndClone = async () => {
+  const remote = path.join(root, 'remote.git');
+  const seed = path.join(root, 'seed');
+  const work = path.join(root, 'work');
+  await git(['init', '--bare', '-b', 'main', remote], root);
+  await git(['init', '-b', 'main', seed], root);
+  await writeFile(path.join(seed, 'README.md'), 'seed\n');
+  await git(['add', '-A'], seed);
+  await git(['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-m', 'seed'], seed);
+  await git(['push', remote, 'main'], seed);
+  await git(['clone', remote, work], root);
+  return { remote, seed, work };
+};
+
+const installHook = async (work, name, body) => {
+  const dir = path.join(work, '.custom-hooks');
+  const marker = path.join(work, `${name}-ran.txt`);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, name), body(marker), { mode: 0o755 });
+  await git(['config', 'core.hooksPath', dir], work);
+  return marker;
+};
+
+const postCheckoutHook = (marker) =>
+  `#!/bin/sh\nprintf '%s' "\${AIDLC_GIT_PASSWORD:-<unset>}" > "${marker}"\nprintf 'post-checkout rejected: %s\\n' "\${AIDLC_GIT_PASSWORD:-<unset>}" >&2\nexit 97\n`;
+
+const workspaceRunner =
+  ({ remoteUrl, records, env = {} }) =>
+  async (command, args, options = {}) => {
+    expect(command).toBe('git');
+    const localArgs = args.map((arg) => (arg === CLEAN_REPOSITORY_URL ? remoteUrl : arg));
+    const result = await runFixtureGit(localArgs, {
+      cwd: options.cwd ?? root,
+      env: { ...env, ...options.env },
+    });
+    records.push({ args: [...args], stdout: result.stdout, stderr: result.stderr });
+    return result;
+  };
+
+const expectWorkspaceCommandsProtected = (records) => {
+  expect(records.length).toBeGreaterThan(0);
+  for (const record of records) {
+    expect(record.args.slice(0, HOOKS_DISABLED_ARGS.length)).toEqual(HOOKS_DISABLED_ARGS);
+    expect(record.args.join('\0')).not.toContain(PASSWORD_SENTINEL);
+    expect(record.stdout).not.toContain(PASSWORD_SENTINEL);
+    expect(record.stderr).not.toContain(PASSWORD_SENTINEL);
+  }
+};
+
+const expectMissing = async (file) => {
+  await expect(readFile(file, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+};
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), 'pr-363-v2-'));
+  await writeFile(path.join(root, 'global.gitconfig'), '');
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('PR #363 behavior on pinned v2', () => {
+  it('suppresses prepare-commit-msg and commits completed stage work', async () => {
+    const { work } = await initRemoteAndClone();
+    const before = (await git(['rev-parse', 'HEAD'], work)).stdout.trim();
+    const marker = await installHook(
+      work,
+      'prepare-commit-msg',
+      (file) => `#!/bin/sh\necho ran > "${file}"\necho "prepare-commit-msg rejected" >&2\nexit 1\n`,
+    );
+    await writeFile(path.join(work, 'agent-work.txt'), 'completed stage output\n');
+
+    const result = await commitAll({
+      dir: work,
+      message: 'aidlc(functional-design): reproduction',
+      attempts: 1,
+      log: () => {},
+    });
+
+    expect(result).toMatchObject({ committed: true });
+    await expectMissing(marker);
+    expect((await git(['rev-parse', 'HEAD'], work)).stdout.trim()).not.toBe(before);
+    expect((await git(['status', '--porcelain'], work)).stdout).not.toContain('agent-work.txt');
+  });
+
+  it('suppresses pre-push while the short-lived write credential is in the environment', async () => {
+    const { remote, work } = await initRemoteAndClone();
+    const marker = await installHook(
+      work,
+      'pre-push',
+      (file) =>
+        `#!/bin/sh\nif [ "$AIDLC_GIT_PASSWORD" = "reproduction-write-token" ]; then\n  echo credential-present > "${file}"\nelse\n  echo credential-missing > "${file}"\nfi\necho "pre-push rejected" >&2\nexit 1\n`,
+    );
+    await writeFile(path.join(work, 'agent-work.txt'), 'completed stage output\n');
+    const committed = await commitAll({ dir: work, message: 'aidlc(code): reproduction' });
+    expect(committed.committed).toBe(true);
+
+    const result = await pushBranch({
+      dir: work,
+      repo: 'owner/repo',
+      branch: 'main',
+      projectId: 'project-1',
+      executionId: 'execution-1',
+      gitProvider: 'github',
+      attempts: 1,
+      urls: { clean: remote },
+      withGitCredential: async (_request, operation) =>
+        operation({
+          env: {
+            AIDLC_GIT_PASSWORD: 'reproduction-write-token',
+            GIT_TERMINAL_PROMPT: '0',
+          },
+        }),
+      log: () => {},
+    });
+
+    expect(result).toMatchObject({ pushed: true, verified: true });
+    await expectMissing(marker);
+    const localHead = (await git(['rev-parse', 'HEAD'], work)).stdout.trim();
+    const remoteHead = (await git(['rev-parse', 'refs/heads/main'], remote)).stdout.trim();
+    expect(remoteHead).toBe(localHead);
+  });
+
+  it('suppresses an inherited tracked post-checkout hook during credentialed workspace clone', async () => {
+    const { remote, seed } = await initRemoteAndClone();
+    const marker = path.join(root, 'fresh-clone-hook-ran.txt');
+    const hooksDir = path.join(seed, '.githooks');
+    await mkdir(hooksDir, { recursive: true });
+    await writeFile(path.join(hooksDir, 'post-checkout'), postCheckoutHook(marker), {
+      mode: 0o755,
+    });
+    await git(['add', '-A'], seed);
+    await git(
+      ['-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-m', 'add tracked hook'],
+      seed,
+    );
+    await git(['push', remote, 'main'], seed);
+    await fixtureGitOk(['config', '--global', 'core.hooksPath', '.githooks']);
+
+    const remoteUrl = pathToFileURL(remote).href;
+    const unprotectedTarget = path.join(root, 'unprotected-clone');
+    const unprotected = await runFixtureGit(['clone', remoteUrl, unprotectedTarget]);
+    expect(unprotected.code).not.toBe(0);
+    expect(unprotected.stderr).not.toContain(PASSWORD_SENTINEL);
+    expect(await readFile(marker, 'utf8')).toBe('<unset>');
+    await rm(marker, { force: true });
+    await rm(unprotectedTarget, { recursive: true, force: true });
+
+    const records = [];
+    const targetDir = path.join(root, 'protected-clone');
+    const result = await checkoutRepo({
+      repo: 'owner/repo',
+      branch: 'main',
+      gitProvider: 'github',
+      projectId: 'project-1',
+      executionId: 'execution-1',
+      targetDir,
+      runner: workspaceRunner({ remoteUrl, records }),
+      withGitCredential: async (_request, operation) =>
+        operation({
+          env: {
+            AIDLC_GIT_PASSWORD: PASSWORD_SENTINEL,
+            GIT_TERMINAL_PROMPT: '0',
+          },
+        }),
+      trustDirectory: async () => true,
+    });
+
+    expect(result).toMatchObject({ cloned: true, branchOk: true });
+    await expectMissing(marker);
+    expect(await readFile(path.join(targetDir, '.git', 'config'), 'utf8')).not.toContain(
+      PASSWORD_SENTINEL,
+    );
+    expectWorkspaceCommandsProtected(records);
+  });
+
+  it('retains the contributor-only post-checkout failure and suppresses it during warm reuse', async () => {
+    const { remote, work } = await initRemoteAndClone();
+    await git(['branch', 'next'], work);
+    const marker = await installHook(work, 'post-checkout', postCheckoutHook);
+
+    // This is the decisive contributor-only baseline: checkout switches the
+    // branch, but the configured hook rejects it and observes the environment.
+    const unprotected = await runFixtureGit(['checkout', 'next'], { cwd: work });
+    expect(unprotected.code).not.toBe(0);
+    expect(unprotected.stderr).not.toContain(PASSWORD_SENTINEL);
+    expect(await readFile(marker, 'utf8')).toBe('<unset>');
+    await git(['checkout', 'main'], work);
+    await rm(marker, { force: true });
+
+    const records = [];
+    const result = await checkoutRepo({
+      repo: 'owner/repo',
+      branch: 'next',
+      gitProvider: 'github',
+      projectId: 'project-1',
+      executionId: 'execution-1',
+      targetDir: work,
+      runner: workspaceRunner({
+        remoteUrl: pathToFileURL(remote).href,
+        records,
+        env: { AIDLC_GIT_PASSWORD: PASSWORD_SENTINEL },
+      }),
+      trustDirectory: async () => true,
+    });
+
+    expect(result).toMatchObject({ cloned: true, reused: true, branchOk: true });
+    await expectMissing(marker);
+    expect((await git(['branch', '--show-current'], work)).stdout.trim()).toBe('next');
+    expect(await readFile(path.join(work, '.git', 'config'), 'utf8')).not.toContain(
+      PASSWORD_SENTINEL,
+    );
+    expectWorkspaceCommandsProtected(records);
+  });
+});

--- a/lambda/agentcore/test/workspace.test.js
+++ b/lambda/agentcore/test/workspace.test.js
@@ -1,8 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, mkdir, rm, writeFile, lstat, readlink, readFile, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { redirectHeavyDirs } from '../workspace.js';
+import { pathToFileURL } from 'node:url';
+import { checkoutRepo, redirectHeavyDirs } from '../workspace.js';
+import { runGit } from '../git-engine.js';
+import { HOOKS_DISABLED_ARGS } from '../git-runner.js';
 
 // redirectHeavyDirs (2026-07 ENOSPC incident #2): node_modules must live on
 // container-local disk, never on the session mount — the mount's write/backup
@@ -27,7 +30,96 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await rm(root, { recursive: true, force: true });
+});
+
+describe('checkoutRepo Git isolation', () => {
+  it('passes the protected runner to custom directory-trust callbacks', async () => {
+    const runner = vi.fn(async () => ({ code: 0 }));
+    const trustDirectory = async ({ runner: trustRunner }) => {
+      const result = await trustRunner('git', ['config', '--global', '--get', 'safe.directory']);
+      return result.code === 0;
+    };
+
+    const result = await checkoutRepo({
+      repo: 'acme/api',
+      targetDir: ws,
+      branch: 'main',
+      runner,
+      trustDirectory,
+      statFn: async () => ({ isDirectory: () => true }),
+      readGitConfig: async () => '',
+    });
+
+    expect(result).toMatchObject({ cloned: true, reused: true, branchOk: true });
+    expect(runner).toHaveBeenCalledTimes(3);
+    for (const [, args] of runner.mock.calls) {
+      expect(args.slice(0, HOOKS_DISABLED_ARGS.length)).toEqual(HOOKS_DISABLED_ARGS);
+      expect(args.filter((arg) => arg === 'core.hooksPath=/dev/null')).toHaveLength(1);
+    }
+  });
+
+  it.each([false, true])(
+    'ignores ambient repository overrides with the production runner (warm checkout: %s)',
+    async (warm) => {
+      vi.stubEnv('GIT_CONFIG_GLOBAL', path.join(root, 'global.gitconfig'));
+      vi.stubEnv('GIT_CONFIG_NOSYSTEM', '1');
+      const git = async (args, cwd = root) => {
+        const result = await runGit(args, { cwd });
+        expect(result.exitCode, result.stderr).toBe(0);
+        return result.stdout.trim();
+      };
+      const remote = path.join(root, 'remote');
+      const cleanUrl = 'https://github.com/acme/api.git';
+      await git(['init', '-b', 'main', remote]);
+      await writeFile(path.join(remote, 'README.md'), 'seed\n');
+      await git(['add', '-A'], remote);
+      await git(
+        [
+          '-c',
+          'user.name=Workspace Test',
+          '-c',
+          'user.email=workspace@test',
+          'commit',
+          '-m',
+          'seed',
+        ],
+        remote,
+      );
+      const seed = await git(['rev-parse', 'HEAD'], remote);
+      await git(['config', '--global', `url.${pathToFileURL(remote).href}.insteadOf`, cleanUrl]);
+      if (warm) await git(['clone', cleanUrl, ws]);
+
+      const ambient = {
+        GIT_DIR: path.join(root, 'bogus.git'),
+        GIT_WORK_TREE: path.join(root, 'bogus-worktree'),
+        GIT_INDEX_FILE: path.join(root, 'bogus-index'),
+      };
+      for (const [key, value] of Object.entries(ambient)) vi.stubEnv(key, value);
+      const withGitCredential = vi.fn(async (_context, operation) =>
+        operation({ env: { GIT_TERMINAL_PROMPT: '0' } }),
+      );
+
+      const result = await checkoutRepo({
+        repo: 'acme/api',
+        targetDir: ws,
+        branch: 'aidlc/test',
+        withGitCredential,
+      });
+
+      expect(result).toMatchObject({ cloned: true, branchOk: true });
+      expect(Boolean(result.reused)).toBe(warm);
+      expect(withGitCredential).toHaveBeenCalledTimes(warm ? 0 : 1);
+      expect(await git(['branch', '--show-current'], ws)).toBe('aidlc/test');
+      expect(await git(['rev-parse', 'HEAD'], ws)).toBe(seed);
+      expect(await git(['config', '--local', '--get', 'remote.origin.url'], ws)).toBe(cleanUrl);
+      expect(await git(['config', '--global', '--get-all', 'safe.directory'])).toBe(ws);
+      await expect(stat(ambient.GIT_INDEX_FILE)).rejects.toMatchObject({ code: 'ENOENT' });
+      for (const [key, value] of Object.entries(ambient)) expect(process.env[key]).toBe(value);
+    },
+    30_000,
+  );
 });
 
 describe('redirectHeavyDirs', () => {

--- a/lambda/agentcore/workspace.js
+++ b/lambda/agentcore/workspace.js
@@ -69,7 +69,7 @@ export const checkoutRepo = async ({
 }) => {
   const runner = withGitHooksDisabled(injectedRunner);
   await ensureDir(targetDir);
-  if (!(await trustDirectory({ targetDir, runner: injectedRunner }))) {
+  if (!(await trustDirectory({ targetDir, runner }))) {
     return {
       repo,
       targetDir,

--- a/lambda/agentcore/workspace.js
+++ b/lambda/agentcore/workspace.js
@@ -6,34 +6,23 @@
 // temporary GIT_ASKPASS environment, never argv or the remote URL. Multi-repo lays out under
 // <workspaceDir>/<owner>/<repo>; single-repo clones into <workspaceDir> directly.
 
-import { spawn } from 'node:child_process';
 import { mkdir, stat, readdir, rm, symlink, lstat, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { buildCloneUrl } from '../shared/git-providers.js';
 import { withGitCredential as defaultWithGitCredential } from './git-auth.js';
+import { runGitCommand, withGitHooksDisabled } from './git-runner.js';
 
 // Provider-aware clone-URL builder — the single source of truth for the per-
 // provider auth scheme (GitHub `x-access-token:`, GitLab `oauth2:`) and host.
 // Reusing it keeps the checkout on the shared registry rather than
 // re-deriving the GitHub-only scheme here. Defaults to github for legacy/blank.
-const run = (command, args, { cwd, env = {}, spawnFn = spawn } = {}) =>
-  new Promise((resolve) => {
-    const child = spawnFn(command, args, {
-      cwd,
-      shell: false,
-      env: { ...process.env, ...env },
-      stdio: ['ignore', 'inherit', 'inherit'],
-    });
-    child.on('error', () => resolve({ code: null }));
-    child.on('close', (code) => resolve({ code }));
-  });
-
 const cloneUrl = (repo, gitProvider) => buildCloneUrl(gitProvider, repo, '');
 
 // Managed-session storage can restore a checkout with an owner that differs
 // from the runtime node user. Trust only the exact repository root selected by
 // the validated project configuration; never opt out globally with '*'.
-export const trustGitDirectory = async ({ targetDir, runner = run }) => {
+export const trustGitDirectory = async ({ targetDir, runner: injectedRunner = runGitCommand }) => {
+  const runner = withGitHooksDisabled(injectedRunner);
   const existing = await runner(
     'git',
     ['config', '--global', '--fixed-value', '--get-all', 'safe.directory', targetDir],
@@ -70,7 +59,7 @@ export const checkoutRepo = async ({
   projectId,
   executionId,
   targetDir,
-  runner = run,
+  runner: injectedRunner = runGitCommand,
   withGitCredential = defaultWithGitCredential,
   ensureDir = (d) => mkdir(d, { recursive: true }),
   statFn = stat,
@@ -78,8 +67,9 @@ export const checkoutRepo = async ({
   readGitConfig = (d) => readFile(path.join(d, '.git', 'config'), 'utf8'),
   trustDirectory = trustGitDirectory,
 }) => {
+  const runner = withGitHooksDisabled(injectedRunner);
   await ensureDir(targetDir);
-  if (!(await trustDirectory({ targetDir, runner }))) {
+  if (!(await trustDirectory({ targetDir, runner: injectedRunner }))) {
     return {
       repo,
       targetDir,
@@ -235,7 +225,7 @@ export const checkoutRepos = async ({
   projectId,
   executionId,
   workspaceDir,
-  runner = run,
+  runner = runGitCommand,
   withGitCredential,
   ensureDir,
   trustDirectory = trustGitDirectory,
@@ -402,7 +392,7 @@ export const ensureWorkspaceSource = async ({
   projectId,
   executionId,
   workspaceDir,
-  runner = run,
+  runner = runGitCommand,
   withGitCredential,
   ensureDir,
   statFn = stat,


### PR DESCRIPTION
## Problem / Motivation

AgentCore-owned Git operations currently execute repository-controlled hooks. Hooks that depend on unavailable checkout dependencies can reject engine commits after a stage has produced work, while credential-bearing operations such as push can expose the short-lived Git credential to arbitrary repository hook code.

## Why it matters

A failing `prepare-commit-msg` can leave completed stage work uncommitted, and a malicious `pre-push` or `post-checkout` hook can observe credentials inside the AgentCore runtime. The existing `--no-verify` approach is incomplete because it does not suppress every hook.

## What changed

- Preserved Olivier Rossant's PR #363 implementation as the contributor-authored first commit.
- Added one shared AgentCore Git process runner that applies `-c core.hooksPath=/dev/null` per invocation and strips inherited repository/index and author/committer `GIT_*` overrides for both engine and workspace commands. Explicit credential and per-command environment overrides remain supported; repository and user Git configuration remain untouched.
- Routed both `git-engine.js` and `workspace.js` clone, checkout, branch, commit, merge, fetch, and push paths through the shared policy while preserving injection and return contracts. Directory-trust callbacks receive the wrapped runner as well.
- Strengthened the pre-push regression to require the remote head to equal the exact local commit.
- Added warm-workspace and fresh-clone regressions, including the reviewed nuance that ordinary clones do not inherit remote-local Git config or `.git/hooks`; fresh-clone exposure requires an inherited/global hook path targeting tracked checkout content.

## Attribution

The first commit retains Olivier Rossant as author and records the original PR #363 commit via the cherry-pick provenance line. The subsequent commits are the maintainer-owned completion covering the separate workspace Git path and shared environment sanitization.

## Tests

- 308/308 across nine focused suites: shared runner, Git engine, credential handling, workspace, init-ws, lane, conflict resolution, run-stage, and decisive PR #363 reproductions. Graph-backed tests ran with the normal Docker setup.
- 345/345 across 12 affected suites selected by the normal pre-commit hook.
- New regressions reproduced the unprotected trust callback and ambient-environment failures in both fresh and warm checkouts before the fixes, then passed afterward. Coverage also verifies credential preservation, explicit environment overrides, and non-mutation of the parent environment.
- Existing real-Git regressions cover `pre-commit`, `commit-msg`, `prepare-commit-msg`, credential-bearing `pre-push`, warm `post-checkout`, inherited fresh-clone `post-checkout`, configuration non-mutation, and exact remote SHA delivery.
- oxfmt, oxlint, secretlint, and `git diff --check`: clean for the review changes.
- The advisory pre-commit dependency audit reports existing findings (one high-severity `js-yaml` finding and two moderate findings); no dependencies changed in this PR.

## Manual verification

Reviewed every changed hunk and searched production AgentCore sources for direct Git process execution. The only direct `spawn('git', ...)` calls outside the shared runner are test fixture helpers. Current `main` has no changed-path overlap since the branch base, and its merge tree is conflict-free.

## Related work

Supersedes #363 after this replacement's required checks and automated review are green. Do not close #363 before that condition is met.

no linked issue: this PR replaces and credits an existing pull request rather than resolving a separately tracked issue.
