### PR TITLE
fix(sensors): harden provenance and diagnostics

### DIFF
--- a/frontend/src/components/intent/SensorChips.tsx
+++ b/frontend/src/components/intent/SensorChips.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { redactRenderedDiagnostic } from '@/components/intent/SensorDiagnostics';
 import type { IntentSensorRun, SensorDetail } from '@/services/intents';
 
 // Sensor result → chip styling. `held: true` marks a blocking failure — the
@@ -30,12 +31,14 @@ export function summarizeSensorDetail(detail: SensorDetail | null): string | nul
   const missing = Array.isArray(detail.artifacts)
     ? detail.artifacts.filter((a) => a?.reason === 'not found in graph').map((a) => a.artifact)
     : [];
-  if (missing.length) return `missing: ${missing.join(', ')}`;
-  if (Array.isArray(detail.unreferenced) && detail.unreferenced.length) {
-    return `unreferenced: ${detail.unreferenced.join(', ')}`;
+  if (missing.length) {
+    return redactRenderedDiagnostic(`missing: ${missing.join(', ')}`);
   }
-  if (detail.error) return String(detail.error);
-  if (detail.reason) return String(detail.reason);
+  if (Array.isArray(detail.unreferenced) && detail.unreferenced.length) {
+    return redactRenderedDiagnostic(`unreferenced: ${detail.unreferenced.join(', ')}`);
+  }
+  if (detail.error) return redactRenderedDiagnostic(detail.error);
+  if (detail.reason) return redactRenderedDiagnostic(detail.reason);
   return null;
 }
 

--- a/frontend/src/components/intent/SensorDiagnostics.test.tsx
+++ b/frontend/src/components/intent/SensorDiagnostics.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { SensorDetail } from '@/services/intents';
+import { SENSOR_DIAGNOSTIC_LIMITS, SensorDiagnostics } from './SensorDiagnostics';
+
+describe('SensorDiagnostics', () => {
+  it('bounds diagnostic text, paths, and sample files before rendering', () => {
+    const reason = `reason: ${'r'.repeat(1_000)} reason-tail`;
+    const stderr = `stderr: ${'e'.repeat(5_000)} stderr-tail`;
+    const longPath = `src/${'p'.repeat(700)}/secret-tail.ts`;
+
+    const { container } = render(
+      <SensorDiagnostics
+        sensorId="lint"
+        detail={{
+          harnessFailures: [
+            {
+              reason,
+              stderr,
+              sampleFiles: [longPath],
+            },
+          ],
+          files: [{ file: longPath, result: 'INCONCLUSIVE' }],
+        }}
+      />,
+    );
+
+    const renderedReason = screen.getByText(/^reason:/).textContent ?? '';
+    expect(renderedReason).toHaveLength(SENSOR_DIAGNOSTIC_LIMITS.reasonChars);
+    expect(renderedReason.endsWith('… [truncated]')).toBe(true);
+    expect(renderedReason).not.toContain('reason-tail');
+
+    const renderedStderr = container.querySelector('pre')?.textContent ?? '';
+    expect(renderedStderr).toHaveLength(SENSOR_DIAGNOSTIC_LIMITS.diagnosticTextChars);
+    expect(renderedStderr.endsWith('… [truncated]')).toBe(true);
+    expect(renderedStderr).not.toContain('stderr-tail');
+
+    expect(screen.queryByText(/secret-tail\.ts/)).not.toBeInTheDocument();
+    expect(container.textContent).toContain('… [truncated]');
+  });
+
+  it('reports backend omissions and every frontend count cap deterministically', () => {
+    const harnessFailures = Array.from({ length: 22 }, (_, index) => ({
+      reason: `failure-${index}`,
+      sampleFiles:
+        index === 0 ? Array.from({ length: 7 }, (__, fileIndex) => `sample-${fileIndex}.ts`) : [],
+    }));
+    const files = Array.from({ length: 103 }, (_, index) => ({
+      file: `file-${index}.ts`,
+      result: 'FAIL',
+    }));
+
+    render(
+      <SensorDiagnostics
+        sensorId="lint"
+        detail={{
+          harnessFailures,
+          files,
+          filesOmitted: 37,
+          omissionReason: 'diagnostic byte budget reached',
+        }}
+      />,
+    );
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(
+      SENSOR_DIAGNOSTIC_LIMITS.harnessFailures + SENSOR_DIAGNOSTIC_LIMITS.fileResults,
+    );
+    expect(screen.getByText(/2 additional samples hidden/)).toBeInTheDocument();
+    expect(screen.getByText(/37 file results omitted/)).toHaveTextContent(
+      'diagnostic byte budget reached',
+    );
+    expect(screen.getByText(/2 additional harness failure groups hidden/)).toBeInTheDocument();
+    expect(screen.getByText(/3 additional file results hidden/)).toBeInTheDocument();
+    expect(screen.queryByText('failure-20')).not.toBeInTheDocument();
+    expect(screen.queryByText('file-100.ts')).not.toBeInTheDocument();
+    expect(screen.getByText(/Samples:/)).toHaveTextContent(
+      'sample-0.ts, sample-1.ts, sample-2.ts, sample-3.ts, sample-4.ts',
+    );
+    expect(screen.queryByText(/sample-5\.ts/)).not.toBeInTheDocument();
+  });
+
+  it('redacts credential-shaped legacy content at the display boundary', () => {
+    const secrets = {
+      authorization: 'secret-value',
+      password: 'hunter2',
+      accessKey: 'AKIAABCDEFGHIJKLMNOP',
+      githubToken: `ghp_${'a'.repeat(20)}`,
+      userInfo: 'alice:password',
+      credentialPath: '/home/alice/.aws/credentials',
+    };
+    const detail: SensorDetail = {
+      harnessFailures: [
+        {
+          reason: `Authorization: Token ${secrets.authorization}`,
+          stderr: [
+            `password=${secrets.password}`,
+            secrets.accessKey,
+            secrets.githubToken,
+            `https://${secrets.userInfo}@example.com/repo.git`,
+            secrets.credentialPath,
+          ].join('\n'),
+        },
+      ],
+      files: [
+        {
+          file: 'src/index.ts',
+          detail: { reason: `api_key=${secrets.authorization}` },
+        },
+      ],
+      filesOmitted: 1,
+      omissionReason: `access_token=${secrets.authorization}`,
+    };
+
+    const { container } = render(
+      <SensorDiagnostics sensorId={`sensor password=${secrets.password}`} detail={detail} />,
+    );
+
+    for (const secret of Object.values(secrets)) {
+      expect(container.textContent).not.toContain(secret);
+    }
+    expect(container.textContent).toContain('[REDACTED]');
+    expect(
+      screen.getByLabelText('Bounded diagnostics for sensor password=[REDACTED]'),
+    ).toBeVisible();
+  });
+
+  it.each([
+    ['null detail', null],
+    ['empty detail', {}],
+    ['empty diagnostic arrays', { harnessFailures: [], files: [] }],
+    ['non-positive omission count', { filesOmitted: 0 }],
+  ] satisfies [string, SensorDetail | null][])('renders nothing for %s', (_name, detail) => {
+    const { container } = render(<SensorDiagnostics sensorId="lint" detail={detail} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('exposes a named diagnostics container, semantic lists, and omission notes', () => {
+    render(
+      <SensorDiagnostics
+        sensorId="lint-sensor"
+        detail={{
+          harnessFailures: [{ reason: 'tool unavailable' }],
+          files: [{ file: 'src/index.ts', result: 'INCONCLUSIVE' }],
+          filesOmitted: 4,
+        }}
+      />,
+    );
+
+    const diagnostics = screen.getByLabelText('Bounded diagnostics for lint-sensor');
+    expect(diagnostics).toBeVisible();
+    expect(within(diagnostics).getByText('Harness diagnostics')).toBeVisible();
+    expect(within(diagnostics).getAllByRole('list')).toHaveLength(2);
+    expect(within(diagnostics).getAllByRole('listitem')).toHaveLength(2);
+    expect(within(diagnostics).getByRole('note')).toHaveTextContent(
+      '4 file results omitted — omission reason unavailable.',
+    );
+  });
+});

--- a/frontend/src/components/intent/SensorDiagnostics.tsx
+++ b/frontend/src/components/intent/SensorDiagnostics.tsx
@@ -1,0 +1,228 @@
+import { Badge } from '@/components/ui/badge';
+import type { SensorDetail, SensorFileDiagnostic, SensorHarnessFailure } from '@/services/intents';
+
+const REDACTED = '[REDACTED]';
+const TRUNCATION_MARKER = '… [truncated]';
+
+export const SENSOR_DIAGNOSTIC_LIMITS = Object.freeze({
+  harnessFailures: 20,
+  fileResults: 100,
+  sampleFiles: 5,
+  inlineTextChars: 512,
+  reasonChars: 256,
+  diagnosticTextChars: 4096,
+  pathChars: 512,
+  omissionReasonChars: 256,
+  redactionLookaheadChars: 1024,
+});
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+// Sensor details are redacted before persistence. Keep a second, deliberately
+// conservative display boundary for old rows and mixed-version deployments:
+// only allowlisted fields are rendered, credential-shaped text is masked, and
+// even malformed legacy strings are processed and rendered within fixed caps.
+export function redactRenderedDiagnostic(
+  value: unknown,
+  maxLength: number = SENSOR_DIAGNOSTIC_LIMITS.inlineTextChars,
+): string | null {
+  if (typeof value !== 'string') return null;
+  const requestedLimit = Number.isSafeInteger(maxLength)
+    ? maxLength
+    : SENSOR_DIAGNOSTIC_LIMITS.inlineTextChars;
+  const boundedLength = Math.min(
+    SENSOR_DIAGNOSTIC_LIMITS.diagnosticTextChars,
+    Math.max(TRUNCATION_MARKER.length, requestedLimit),
+  );
+  // Slice before regex processing so a malicious legacy payload cannot make
+  // rendering perform unbounded work. The lookahead lets a credential beginning
+  // at the visible boundary be consumed and redacted before the final trim.
+  const text = value
+    .slice(0, boundedLength + SENSOR_DIAGNOSTIC_LIMITS.redactionLookaheadChars)
+    .trim();
+  if (!text) return null;
+  const redacted = text
+    .replace(
+      /(\bauthorization\b["']?\s*[:=]\s*["']?)(?:[^\s,;"']+\s+)?[^\s,;"']+/gi,
+      `$1${REDACTED}`,
+    )
+    .replace(
+      /(\b(?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|password|passwd|secret|credential)\b["']?\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      `$1${REDACTED}`,
+    )
+    .replace(/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, REDACTED)
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g, REDACTED)
+    .replace(/(\b[a-z][a-z0-9+.-]*:\/\/)([^/\s@]+)@/gi, `$1${REDACTED}@`)
+    .replace(
+      /(?:\/(?:home|root|runtime|var\/run)\/[^\s:'"`]*(?:\.aws\/credentials|git-askpass|credential)[^\s:'"`]*)/gi,
+      REDACTED,
+    );
+  if (redacted.length <= boundedLength) return redacted;
+  return `${redacted.slice(0, boundedLength - TRUNCATION_MARKER.length)}${TRUNCATION_MARKER}`;
+}
+
+function positiveCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+
+function safeExitCode(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) ? value : null;
+}
+
+function plural(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`;
+}
+
+function HarnessFailure({ failure }: { failure: SensorHarnessFailure }) {
+  const reason =
+    redactRenderedDiagnostic(failure.reason, SENSOR_DIAGNOSTIC_LIMITS.reasonChars) ??
+    'Harness failure';
+  const result = redactRenderedDiagnostic(failure.result, 64);
+  const stderr = redactRenderedDiagnostic(
+    failure.stderr,
+    SENSOR_DIAGNOSTIC_LIMITS.diagnosticTextChars,
+  );
+  const fileCount = positiveCount(failure.fileCount);
+  const exitCode = safeExitCode(failure.exitCode);
+  const rawSampleFiles = Array.isArray(failure.sampleFiles) ? failure.sampleFiles : [];
+  const sampleFiles = rawSampleFiles
+    .slice(0, SENSOR_DIAGNOSTIC_LIMITS.sampleFiles)
+    .map((file) => redactRenderedDiagnostic(file, SENSOR_DIAGNOSTIC_LIMITS.pathChars))
+    .filter((file): file is string => Boolean(file));
+  const sampleFilesOmitted = Math.max(0, rawSampleFiles.length - sampleFiles.length);
+
+  return (
+    <li className="rounded border border-agent-waiting/20 bg-background/60 p-2">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="font-medium text-foreground">{reason}</span>
+        {result && <Badge variant="outline">{result}</Badge>}
+        {fileCount && <span>{plural(fileCount, 'file')}</span>}
+        {exitCode !== null && <span>exit {exitCode}</span>}
+      </div>
+      {sampleFiles.length > 0 && (
+        <p className="mt-1 break-all font-mono text-[10px]">Samples: {sampleFiles.join(', ')}</p>
+      )}
+      {sampleFilesOmitted > 0 && (
+        <p className="mt-1 text-[10px]">
+          {plural(sampleFilesOmitted, 'additional sample')} hidden — frontend display limit.
+        </p>
+      )}
+      {stderr && (
+        <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/60 p-2 font-mono text-[10px] leading-relaxed text-foreground">
+          {stderr}
+        </pre>
+      )}
+    </li>
+  );
+}
+
+function FileDiagnostic({ entry }: { entry: SensorFileDiagnostic }) {
+  const file =
+    redactRenderedDiagnostic(entry.file, SENSOR_DIAGNOSTIC_LIMITS.pathChars) ?? 'Unknown file';
+  const result = redactRenderedDiagnostic(entry.result, 64);
+  const reason = redactRenderedDiagnostic(
+    entry.detail?.reason,
+    SENSOR_DIAGNOSTIC_LIMITS.reasonChars,
+  );
+  const stderr = redactRenderedDiagnostic(
+    entry.detail?.stderr,
+    SENSOR_DIAGNOSTIC_LIMITS.diagnosticTextChars,
+  );
+  const exitCode = safeExitCode(entry.detail?.exitCode);
+
+  return (
+    <li className="rounded border bg-background/60 p-2">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="break-all font-mono text-[10px] text-foreground">{file}</span>
+        {result && <Badge variant="outline">{result}</Badge>}
+        {entry.timedOut === true && <span>timed out</span>}
+        {exitCode !== null && <span>exit {exitCode}</span>}
+        {reason && <span>{reason}</span>}
+      </div>
+      {stderr && (
+        <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/60 p-2 font-mono text-[10px] leading-relaxed text-foreground">
+          {stderr}
+        </pre>
+      )}
+    </li>
+  );
+}
+
+export function SensorDiagnostics({
+  detail,
+  sensorId,
+}: {
+  detail: SensorDetail | null;
+  sensorId: string;
+}) {
+  if (!detail || typeof detail !== 'object') return null;
+
+  const rawHarnessFailures = Array.isArray(detail.harnessFailures) ? detail.harnessFailures : [];
+  const harnessFailures = rawHarnessFailures
+    .slice(0, SENSOR_DIAGNOSTIC_LIMITS.harnessFailures)
+    .filter(isRecord) as SensorHarnessFailure[];
+  const harnessFailuresOmitted = Math.max(0, rawHarnessFailures.length - harnessFailures.length);
+
+  const rawFiles = Array.isArray(detail.files) ? detail.files : [];
+  const files = rawFiles
+    .slice(0, SENSOR_DIAGNOSTIC_LIMITS.fileResults)
+    .filter(isRecord) as unknown as SensorFileDiagnostic[];
+  const fileResultsHidden = Math.max(0, rawFiles.length - files.length);
+
+  const filesOmitted = positiveCount(detail.filesOmitted);
+  const omissionReason = redactRenderedDiagnostic(
+    detail.omissionReason,
+    SENSOR_DIAGNOSTIC_LIMITS.omissionReasonChars,
+  );
+  if (
+    harnessFailures.length === 0 &&
+    files.length === 0 &&
+    filesOmitted === null &&
+    harnessFailuresOmitted === 0 &&
+    fileResultsHidden === 0
+  ) {
+    return null;
+  }
+
+  const safeSensorId = redactRenderedDiagnostic(sensorId, 128) ?? 'sensor';
+  return (
+    <div
+      className="mt-1.5 space-y-1.5 rounded-md border border-dashed px-2.5 py-2 text-[11px] text-muted-foreground"
+      aria-label={`Bounded diagnostics for ${safeSensorId}`}
+    >
+      <p className="font-medium text-foreground">Harness diagnostics</p>
+      {harnessFailures.length > 0 && (
+        <ul className="space-y-1">
+          {harnessFailures.map((failure, index) => (
+            <HarnessFailure key={`harness-${index}`} failure={failure} />
+          ))}
+        </ul>
+      )}
+      {files.length > 0 && (
+        <ul className="space-y-1">
+          {files.map((entry, index) => (
+            <FileDiagnostic key={`file-${index}`} entry={entry} />
+          ))}
+        </ul>
+      )}
+      {filesOmitted !== null && (
+        <p className="rounded bg-muted/60 px-2 py-1" role="note">
+          {plural(filesOmitted, 'file result')} omitted —{' '}
+          {omissionReason ?? 'omission reason unavailable'}.
+        </p>
+      )}
+      {harnessFailuresOmitted > 0 && (
+        <p className="rounded bg-muted/60 px-2 py-1" role="note">
+          {plural(harnessFailuresOmitted, 'additional harness failure group')} hidden — frontend
+          display limit.
+        </p>
+      )}
+      {fileResultsHidden > 0 && (
+        <p className="rounded bg-muted/60 px-2 py-1" role="note">
+          {plural(fileResultsHidden, 'additional file result')} hidden — frontend display limit.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/intent/StageDetail.tsx
+++ b/frontend/src/components/intent/StageDetail.tsx
@@ -11,6 +11,7 @@ import {
   sensorNeedsAttention,
   summarizeSensorDetail,
 } from '@/components/intent/SensorChips';
+import { SensorDiagnostics } from '@/components/intent/SensorDiagnostics';
 import {
   ArrowDownLeft,
   ArrowUpRight,
@@ -357,10 +358,13 @@ export function StageDetail({ row }: { row: IntentStageRow }) {
                     run.held ? 'text-agent-error' : 'text-muted-foreground',
                   )}
                 >
-                  <span className="font-medium">{run.sensorId}</span>{' '}
-                  <span className="uppercase">{run.result}</span>
-                  {run.held && <span className="font-semibold"> · blocking</span>}
-                  {explain && <span> — {explain}</span>}
+                  <div>
+                    <span className="font-medium">{run.sensorId}</span>{' '}
+                    <span className="uppercase">{run.result}</span>
+                    {run.held && <span className="font-semibold"> · blocking</span>}
+                    {explain && <span> — {explain}</span>}
+                  </div>
+                  <SensorDiagnostics detail={run.detail} sensorId={run.sensorId} />
                 </li>
               ))}
             </ul>

--- a/frontend/src/components/intent/UnitLaneBoard.test.tsx
+++ b/frontend/src/components/intent/UnitLaneBoard.test.tsx
@@ -358,6 +358,7 @@ describe('UnitLaneBoardView', () => {
           requestedByName: 'Reviewer',
           stageInstanceId: 'stage-1',
           output: 'Handled the empty-token case.',
+          changedFileProvenance: { state: 'known', files: ['src/auth.ts'] },
           changedFiles: ['src/auth.ts'],
           verification: 'npm test passed',
           commitSha: 'abcdef123456',

--- a/frontend/src/services/intents.ts
+++ b/frontend/src/services/intents.ts
@@ -330,8 +330,32 @@ export interface IntentSensorRun {
   timestamp: string;
 }
 
+// A single bounded harness failure group. The backend redacts and de-duplicates
+// these entries before persistence; the UI renders only these allowlisted fields.
+export interface SensorHarnessFailure {
+  reason?: string;
+  result?: string;
+  exitCode?: number | null;
+  stderr?: string | null;
+  fileCount?: number;
+  sampleFiles?: string[];
+}
+
+export interface SensorFileDiagnostic {
+  file: string;
+  result?: string;
+  timedOut?: boolean;
+  detail?: {
+    reason?: string;
+    exitCode?: number | null;
+    stderr?: string | null;
+    [key: string]: unknown;
+  };
+}
+
 // Loosely-typed sensor verdict detail — the fields any evaluator may emit. All
-// optional; the UI reads whichever are present.
+// optional; the UI reads whichever are present. Script sensors additionally
+// expose a backend-bounded, pre-redacted diagnostic summary.
 export interface SensorDetail {
   artifacts?: { artifact: string; reason?: string; id?: string | null }[];
   unreferenced?: string[];
@@ -339,6 +363,10 @@ export interface SensorDetail {
   reason?: string;
   error?: string;
   findings_count?: number;
+  harnessFailures?: SensorHarnessFailure[];
+  files?: SensorFileDiagnostic[];
+  filesOmitted?: number;
+  omissionReason?: string;
   [key: string]: unknown;
 }
 
@@ -635,6 +663,10 @@ export interface UnitReviewComment {
 
 export type FeedbackBatchState = 'QUEUED' | 'RUNNING' | 'SUCCEEDED' | 'FAILED';
 
+export type ChangedFileProvenance =
+  | { state: 'known'; files: string[] }
+  | { state: 'unknown'; reason: string; detail?: string };
+
 export interface IntentFeedbackBatch {
   sectionIndex: number;
   unitSlug: string;
@@ -645,6 +677,7 @@ export interface IntentFeedbackBatch {
   requestedByName: string | null;
   stageInstanceId: string | null;
   output: string | null;
+  changedFileProvenance: ChangedFileProvenance | null;
   changedFiles: string[] | null;
   verification: string | null;
   commitSha: string | null;

--- a/lambda/agentcore/commands/run-stage.js
+++ b/lambda/agentcore/commands/run-stage.js
@@ -88,6 +88,10 @@ import {
   UNIT_FOR_EACH,
 } from '../../shared/v2-execution-plan.js';
 import { credentialProviderForCli } from '../../shared/agent-credentials.js';
+import {
+  mergeChangedFileProvenance,
+  unknownChangedFileProvenance,
+} from '../../shared/changed-file-provenance.js';
 import { pruneOutputArtifactsForUnit } from '../../shared/unit-kind-pruning.js';
 // The typed-extraction registry gates the platform-injected graph-coverage
 // sensor: only stages that produce a registered structured artifact get it.
@@ -551,6 +555,18 @@ const summarizeSensorDetail = (detail) => {
   return '';
 };
 
+// A stage can safely scope sensors only when every repository reported known
+// provenance. One unknown repository widens the whole workspace scan because a
+// failed Git collection may hide a relevant path in any sensor's match set.
+const changedFileProvenanceFromGitResults = (results = []) =>
+  mergeChangedFileProvenance(
+    results.map((result) => ({
+      source: result.repo ?? 'unknown repository',
+      provenance:
+        result.provenance ?? unknownChangedFileProvenance('missing_repository_provenance'),
+    })),
+  );
+
 // Run the stage's deterministic sensors after the agent finishes. Records a
 // SensorRun verdict + broadcasts an `agent.note` per sensor. Returns a
 // human-readable reason string when a BLOCKING sensor held the stage, else null.
@@ -568,6 +584,7 @@ const runStageSensors = async ({
   openGraph,
   loadBlockScript,
   workspaceDir,
+  changedFileProvenance = unknownChangedFileProvenance('not_provided'),
   env,
   spawnFn,
   store,
@@ -593,6 +610,7 @@ const runStageSensors = async ({
       executionId,
       loadBlockScript,
       workspaceDir,
+      changedFileProvenance,
       env,
       spawnFn,
       store,
@@ -633,6 +651,7 @@ const runSensorsWithGraph = async ({
   executionId,
   loadBlockScript,
   workspaceDir,
+  changedFileProvenance = unknownChangedFileProvenance('not_provided'),
   env,
   spawnFn,
   store,
@@ -649,6 +668,7 @@ const runSensorsWithGraph = async ({
     substitutions: {},
     spawnFn,
     childEnv: env,
+    changedFileProvenance,
   });
 
   const verdicts = await runner.runStageSensors({
@@ -2262,6 +2282,8 @@ export const runStage = async (
     repos,
     workspaceDir,
     branch,
+    baseBranch,
+    baseBranches,
     gitProvider,
     repoProviders,
     projectId,
@@ -2478,6 +2500,11 @@ export const runStage = async (
     return fail(stageInstanceId, uncommitted ? 'git_commit_failed' : 'push_failed', detail);
   }
 
+  // Capture this stage's paths before running script sensors. Any repository
+  // whose Git collection failed makes provenance unknown and widens checking.
+  const changedFileProvenance = changedFileProvenanceFromGitResults(gitResult.results);
+  const changedFiles = changedFileProvenance.state === 'known' ? changedFileProvenance.files : null;
+
   // 6. Deterministic sensors — the verification axis that runs AFTER the agent.
   // Graph sensors evaluate the produced artifacts' content in-process; script
   // sensors spawn against the workspace checkout. Advisory verdicts record a
@@ -2497,6 +2524,7 @@ export const runStage = async (
       openGraph,
       loadBlockScript,
       workspaceDir,
+      changedFileProvenance,
       env,
       spawnFn,
       store,
@@ -2629,9 +2657,6 @@ export const runStage = async (
     sectionIndex,
     state: 'SUCCEEDED',
   });
-  const changedFiles = [
-    ...new Set(gitResult.results.flatMap((gitChange) => gitChange.files ?? [])),
-  ].toSorted();
   const commitSha =
     gitResult.results.find((gitChange) => gitChange.committed && gitChange.sha)?.sha ?? null;
   return {
@@ -2641,6 +2666,7 @@ export const runStage = async (
     unitSlug,
     sectionIndex,
     cli,
+    changedFileProvenance,
     changedFiles,
     commitSha,
     verification:
@@ -2662,5 +2688,6 @@ export const __test = {
   isBenignKiroEmptyCompletion,
   buildReviewerPrompt,
   renderReviewerReadScope,
+  changedFileProvenanceFromGitResults,
   SHARED_CONTRACT_ARTIFACTS,
 };

--- a/lambda/agentcore/git-engine.js
+++ b/lambda/agentcore/git-engine.js
@@ -28,6 +28,11 @@ import { mkdir, readFile, writeFile, rm, statfs } from 'node:fs/promises';
 import path from 'node:path';
 import { buildCloneUrl } from '../shared/git-providers.js';
 import {
+  knownChangedFileProvenance,
+  mapKnownChangedFiles,
+  unknownChangedFileProvenance,
+} from '../shared/changed-file-provenance.js';
+import {
   resolveGitCommitter as defaultResolveGitCommitter,
   withGitCredential as defaultWithGitCredential,
 } from './git-auth.js';
@@ -240,6 +245,27 @@ const resolveCommitterFor = async ({
 //     losing a commit is strictly worse than a dependency re-install,
 //   - a terminal failure reports `dirty` (does the tree hold uncommitted
 //     work?) so run-stage can fail the stage when real work is at risk.
+// Parse NUL-delimited porcelain output without Git's path quoting. Under `-z`,
+// rename/copy entries are encoded as `XY destination\0source\0`; preserve both
+// endpoints so project-scoped sensors inspect the source and destination trees.
+export const parsePorcelainZ = (stdout = '') => {
+  const fields = String(stdout).split('\0');
+  const files = [];
+  for (let index = 0; index < fields.length; index += 1) {
+    const entry = fields[index];
+    if (!entry) continue;
+    const status = entry.slice(0, 2);
+    const file = entry.slice(3);
+    if (file) files.push(file);
+    if (status.includes('R') || status.includes('C')) {
+      const source = fields[index + 1];
+      if (source) files.push(source);
+      index += 1;
+    }
+  }
+  return files;
+};
+
 export const commitAll = async ({
   dir,
   message,
@@ -256,31 +282,41 @@ export const commitAll = async ({
   await ensureRuntimeExcludes({ dir });
 
   const attemptOnce = async () => {
-    const before = await git(['status', '--porcelain'], { cwd: dir });
-    const files =
+    const before = await git(['status', '--porcelain', '-z'], { cwd: dir });
+    const provenance =
       before.exitCode === 0
-        ? before.stdout
-            .split('\n')
-            .filter(Boolean)
-            .map((line) => line.slice(3).trim().split(' -> ').pop())
-            .filter(Boolean)
-        : [];
+        ? knownChangedFileProvenance(parsePorcelainZ(before.stdout))
+        : unknownChangedFileProvenance('git_status_failed', before.stderr?.trim());
     const add = await git(['add', '-A'], { cwd: dir });
     if (add.exitCode !== 0) {
-      return { committed: false, reason: 'add_failed', detail: add.stderr.trim(), files };
+      return {
+        committed: false,
+        reason: 'add_failed',
+        detail: add.stderr.trim(),
+        provenance,
+      };
     }
     const status = await git(['status', '--porcelain'], { cwd: dir });
     if (status.exitCode === 0 && status.stdout.trim() === '') {
-      return { committed: false, reason: 'clean' };
+      return {
+        committed: false,
+        reason: 'clean',
+        provenance: knownChangedFileProvenance([]),
+      };
     }
     const commit = await git([...gitIdentity(author, committer), 'commit', '-m', message], {
       cwd: dir,
     });
     if (commit.exitCode !== 0) {
-      return { committed: false, reason: 'commit_failed', detail: commit.stderr.trim(), files };
+      return {
+        committed: false,
+        reason: 'commit_failed',
+        detail: commit.stderr.trim(),
+        provenance,
+      };
     }
     const head = await git(['rev-parse', 'HEAD'], { cwd: dir });
-    return { committed: true, sha: head.stdout.trim() || null, files };
+    return { committed: true, sha: head.stdout.trim() || null, provenance };
   };
 
   let last = null;
@@ -432,11 +468,113 @@ export const freeDiskBytes = async ({ dir, statfsFn = statfs }) => {
 export const isAheadOfRemote = async ({ dir, branch, git = runGit }) => {
   const head = await git(['rev-parse', 'HEAD'], { cwd: dir });
   if (head.exitCode !== 0) return false;
-  const remoteRef = await git(['rev-parse', '--verify', `refs/remotes/origin/${branch}`], {
+  const remoteRef = `refs/remotes/origin/${branch}`;
+  const remote = await git(['rev-parse', '--verify', remoteRef], { cwd: dir });
+  if (remote.exitCode !== 0) return true;
+
+  // Equality is insufficient when a cached tracking ref is stale or has
+  // diverged: a remote-only commit must not be mistaken for local unpushed
+  // work. Count only commits reachable from HEAD and not from the tracking ref.
+  // On an unreadable graph, prefer attempting a non-force push over silently
+  // declaring the checkout up to date; the push remains the durability guard.
+  const localOnly = await git(['rev-list', '--count', `${remoteRef}..HEAD`], { cwd: dir });
+  if (localOnly.exitCode !== 0) return true;
+  const count = Number.parseInt(localOnly.stdout.trim(), 10);
+  return Number.isSafeInteger(count) ? count > 0 : true;
+};
+
+// Parse `git diff --name-status -z` output without path quoting. Rename and
+// copy rows contain two paths (`source`, then `destination`); every other row
+// contains one. Flattening the endpoints is intentional: sensor applicability
+// needs to inspect both trees, while provenance does not need the relationship.
+export const parseNameStatusZ = (stdout = '') => {
+  const fields = String(stdout).split('\0');
+  const files = [];
+  for (let index = 0; index < fields.length;) {
+    const status = fields[index++];
+    if (!status) continue;
+    const source = fields[index++];
+    if (source) files.push(source);
+    if (status.startsWith('R') || status.startsWith('C')) {
+      const destination = fields[index++];
+      if (destination) files.push(destination);
+    }
+  }
+  return files;
+};
+
+const verifiedRemoteRef = async ({ dir, ref, git }) => {
+  if (!ref) return null;
+  const resolved = await git(['rev-parse', '--verify', ref], { cwd: dir });
+  return resolved.exitCode === 0 ? ref : null;
+};
+
+// Resolve a local ref that is known to predate the branch's unpushed work.
+// Prefer the target branch's tracking ref. On a never-pushed branch, use the
+// repository's recorded base branch; old payloads fall back to origin/HEAD.
+// We deliberately do not guess main/master because a wrong base can suppress
+// provenance. Returning null widens sensor checking through an unknown result.
+const resolveUnpushedBaseRef = async ({ dir, branch, baseBranch, git }) => {
+  const target = await verifiedRemoteRef({
+    dir,
+    ref: branch ? `refs/remotes/origin/${branch}` : null,
+    git,
+  });
+  if (target) return target;
+
+  const configuredBase = await verifiedRemoteRef({
+    dir,
+    ref: baseBranch ? `refs/remotes/origin/${baseBranch}` : null,
+    git,
+  });
+  if (configuredBase) return configuredBase;
+
+  const symbolicDefault = await git(['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'], {
     cwd: dir,
   });
-  if (remoteRef.exitCode !== 0) return true;
-  return remoteRef.stdout.trim() !== head.stdout.trim();
+  if (symbolicDefault.exitCode !== 0) return null;
+  const defaultRef = symbolicDefault.stdout.trim();
+  if (!defaultRef.startsWith('refs/remotes/origin/')) return null;
+  return verifiedRemoteRef({ dir, ref: defaultRef, git });
+};
+
+// Recover changed paths when a prior stage committed successfully but its push
+// failed. The merge-base-to-HEAD range spans every unpushed commit, including
+// when the target tracking ref is absent. Reducing stale/diverged refs to their
+// merge base excludes remote-only history while retaining all local work.
+// Rename/copy detection stays enabled and both endpoints are parsed explicitly.
+// Paths remain repo-relative until commitAndPushAll returns its final result.
+export const aheadFiles = async ({ dir, branch, baseBranch = null, git = runGit }) => {
+  const baseRef = await resolveUnpushedBaseRef({ dir, branch, baseBranch, git });
+  if (!baseRef) {
+    return unknownChangedFileProvenance(
+      'git_base_ref_missing',
+      baseBranch ? `missing origin/${branch} and origin/${baseBranch}` : `missing origin/${branch}`,
+    );
+  }
+
+  const mergeBase = await git(['merge-base', baseRef, 'HEAD'], { cwd: dir });
+  if (mergeBase.exitCode !== 0 || !mergeBase.stdout.trim()) {
+    return unknownChangedFileProvenance('git_merge_base_failed', mergeBase.stderr?.trim());
+  }
+
+  const diff = await git(
+    [
+      'diff',
+      '--name-status',
+      '-z',
+      '--find-renames',
+      '--find-copies',
+      '--find-copies-harder',
+      mergeBase.stdout.trim(),
+      'HEAD',
+    ],
+    { cwd: dir },
+  );
+  if (diff.exitCode !== 0) {
+    return unknownChangedFileProvenance('git_diff_failed', diff.stderr?.trim());
+  }
+  return knownChangedFileProvenance(parseNameStatusZ(diff.stdout));
 };
 
 // Push HEAD to the branch with v1 pushBranchWithRetry semantics. Returns:
@@ -531,6 +669,12 @@ export const pushBranch = async ({
 // The on-disk target dir for a repo — MUST match workspace.js#repoTargetDir
 // (single repo → workspaceDir; multi → workspaceDir/<owner>/<repo>). Exported
 // for the lane commands (init-lane / merge-lane) that loop repos themselves.
+export const toWorkspaceRelative = (files = [], { url, multi }) => {
+  if (!multi) return [...files];
+  const projectPrefix = `${url}/`;
+  return files.map((file) => (file.startsWith(projectPrefix) ? file : `${projectPrefix}${file}`));
+};
+
 export const repoTargetDir = ({ url, workspaceDir, multi }) =>
   multi ? path.join(workspaceDir, url) : workspaceDir;
 
@@ -1129,6 +1273,8 @@ export const commitAndPushAll = async ({
   repos = [],
   workspaceDir,
   branch,
+  baseBranch = null,
+  baseBranches = null,
   gitProvider,
   repoProviders = null,
   projectId,
@@ -1151,6 +1297,7 @@ export const commitAndPushAll = async ({
       repoProviders?.[url] ||
       gitProvider ||
       'github';
+    const repoBaseBranch = baseBranches?.[url] ?? baseBranch;
     const dir = repoTargetDir({ url, workspaceDir, multi });
     const urls = urlsFor ? urlsFor(url) : {};
     try {
@@ -1171,17 +1318,32 @@ export const commitAndPushAll = async ({
         sleep,
         log,
       });
+      const toWorkspaceProvenance = (provenance) =>
+        mapKnownChangedFiles(provenance, (file) =>
+          toWorkspaceRelative([file], { url, multi }).at(0),
+        );
       if (commit.reason === 'add_failed' || commit.reason === 'commit_failed') {
-        results.push({ repo: url, ...commit, pushed: false });
+        const provenance = toWorkspaceProvenance(commit.provenance);
+        const files = provenance.state === 'known' ? provenance.files : null;
+        results.push({ repo: url, ...commit, provenance, files, pushed: false });
         continue;
       }
       // Skip the network when there is provably nothing to push: no new
       // commit AND the remote-tracking ref matches HEAD. A clean tree with an
       // ahead HEAD still pushes — it retries a previously failed push.
-      if (!commit.committed && !(await isAheadOfRemote({ dir, branch, git }))) {
-        results.push({ repo: url, ...commit, pushed: 'up_to_date' });
+      const ahead = !commit.committed && (await isAheadOfRemote({ dir, branch, git }));
+      if (!commit.committed && !ahead) {
+        const provenance = toWorkspaceProvenance(commit.provenance);
+        const files = provenance.state === 'known' ? provenance.files : null;
+        results.push({ repo: url, ...commit, provenance, files, pushed: 'up_to_date' });
         continue;
       }
+      const repoProvenance =
+        !commit.committed && commit.provenance?.state === 'known'
+          ? await aheadFiles({ dir, branch, baseBranch: repoBaseBranch, git })
+          : commit.provenance;
+      const provenance = toWorkspaceProvenance(repoProvenance);
+      const files = provenance.state === 'known' ? provenance.files : null;
       const push = await pushBranch({
         dir,
         repo: url,
@@ -1195,7 +1357,7 @@ export const commitAndPushAll = async ({
         sleep,
         log,
       });
-      results.push({ repo: url, ...commit, ...push });
+      results.push({ repo: url, ...commit, provenance, files, ...push });
     } catch (err) {
       // Defensive: nothing in this module should throw, but a git layer bug
       // must never take down stage bookkeeping.
@@ -1206,6 +1368,8 @@ export const commitAndPushAll = async ({
         pushed: false,
         reason: 'engine_crashed',
         detail: err?.message,
+        provenance: unknownChangedFileProvenance('engine_crashed', err?.message),
+        files: null,
       });
     }
   }

--- a/lambda/agentcore/sensor-runner.js
+++ b/lambda/agentcore/sensor-runner.js
@@ -25,6 +25,7 @@ import { writeFile, mkdir, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import {
   SENSOR_RESULT,
+  SENSOR_APPLICABILITY,
   sensorKind,
   severityGate,
   validateScriptSpec,
@@ -33,7 +34,12 @@ import {
   evalRequiredSections,
   evalUpstreamCoverage,
   evalGraphCoverage,
+  TOOL_UNAVAILABLE_EXIT,
 } from '../shared/v2-sensor-contract.js';
+import {
+  normalizeChangedFileProvenance,
+  unknownChangedFileProvenance,
+} from '../shared/changed-file-provenance.js';
 
 // Convert a sensor `matches` glob (e.g. `**/*.{ts,tsx}`, `**/aidlc-docs/**`)
 // into a RegExp. Supports the limited syntax the baseline sensors use: `**`,
@@ -73,8 +79,8 @@ const globToRegExp = (glob) => {
 };
 
 // Recursively list workspace files (relative paths), skipping VCS/dependency
-// dirs that would never be a stage's code output. Best-effort: a missing dir
-// yields []. Bounded by `cap` so a huge monorepo can't run the glob unbounded.
+// dirs that would never be a stage's code output. Completeness is part of the
+// result: a read failure or cap hit means absence cannot prove inapplicability.
 const SKIP_DIRS = new Set([
   '.git',
   'node_modules',
@@ -88,29 +94,192 @@ const SKIP_DIRS = new Set([
   '.next',
   'coverage',
 ]);
-const listFiles = async (root, { cap = 5000 } = {}) => {
-  const out = [];
+const MAX_ENUMERATION_FAILURES = 20;
+
+const listFiles = async (root, { cap = 5000, readdirFn = readdir } = {}) => {
+  const limit = Number.isSafeInteger(cap) && cap >= 0 ? cap : 5000;
+  const files = [];
+  const failures = [];
+  let failuresOmitted = 0;
+  let truncated = false;
+
   const walk = async (dir, rel) => {
-    if (out.length >= cap) return;
+    if (truncated) return;
     let entries;
     try {
-      entries = await readdir(dir, { withFileTypes: true });
-    } catch {
+      entries = await readdirFn(dir, { withFileTypes: true });
+    } catch (error) {
+      if (failures.length < MAX_ENUMERATION_FAILURES) {
+        failures.push({
+          directory: rel || '.',
+          code: typeof error?.code === 'string' ? error.code : 'READ_FAILED',
+        });
+      } else {
+        failuresOmitted += 1;
+      }
       return;
     }
-    for (const e of entries) {
-      if (out.length >= cap) return;
-      const childRel = rel ? `${rel}/${e.name}` : e.name;
-      if (e.isDirectory()) {
-        if (SKIP_DIRS.has(e.name)) continue;
-        await walk(path.join(dir, e.name), childRel);
-      } else if (e.isFile()) {
-        out.push(childRel);
+    for (const entry of entries) {
+      if (truncated) return;
+      const childRel = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        await walk(path.join(dir, entry.name), childRel);
+      } else if (entry.isFile()) {
+        if (files.length >= limit) {
+          truncated = true;
+          return;
+        }
+        files.push(childRel);
       }
     }
   };
+
   await walk(root, '');
-  return out;
+  const complete = !truncated && failures.length === 0;
+  return {
+    files,
+    complete,
+    scanned: files.length,
+    cap: limit,
+    ...(truncated ? { reason: 'file_limit_exceeded' } : {}),
+    ...(!truncated && failures.length > 0 ? { reason: 'directory_read_failed' } : {}),
+    ...(failures.length > 0 ? { failures } : {}),
+    ...(failuresOmitted > 0 ? { failuresOmitted } : {}),
+  };
+};
+
+const summarizeEnumeration = ({
+  complete,
+  scanned,
+  cap,
+  reason = null,
+  failures = [],
+  failuresOmitted = 0,
+}) => ({
+  complete,
+  scanned,
+  cap,
+  ...(reason ? { reason } : {}),
+  ...(failures.length > 0 ? { failures } : {}),
+  ...(failuresOmitted > 0 ? { failuresOmitted } : {}),
+});
+
+// Narrow a globbed workspace file list to the paths attributed to this stage.
+// Matching is exact: suffix matching would conflate identically named files in
+// different repositories of a multi-repository workspace. Unknown provenance
+// deliberately widens to every match.
+const scopeToChangedFiles = (files, provenance) => {
+  const normalized = normalizeChangedFileProvenance(provenance);
+  if (normalized.state === 'unknown') return files;
+  if (normalized.files.length === 0) return [];
+  const exact = new Set(normalized.files);
+  return files.filter((file) => exact.has(file));
+};
+
+const projectRootOf = (file, projectRoots) => {
+  let best = '';
+  for (const root of projectRoots) {
+    if (root && file.startsWith(`${root}/`) && root.length > best.length) best = root;
+  }
+  return best;
+};
+
+// Project-scoped analyzers compile an entire project and may report a diagnostic
+// against an untouched consumer. Widen changed-file provenance to every matched
+// file in each affected project so those diagnostics cannot become false PASSes.
+const expandToAffectedProjects = ({ globbed, changed, allFiles, configFile }) => {
+  const rootOfConfig = (file) =>
+    file === configFile ? '' : file.slice(0, -(configFile.length + 1));
+  const isConfig = (file) => file === configFile || file.endsWith(`/${configFile}`);
+  const projectRoots = allFiles.filter(isConfig).map(rootOfConfig);
+  const allRoots = new Set(projectRoots);
+  const globbedSet = new Set(globbed);
+  const affected = new Set();
+
+  for (const file of changed) {
+    if (isConfig(file)) {
+      const root = rootOfConfig(file);
+      allRoots.add(root);
+      affected.add(root);
+    } else if (globbedSet.has(file)) {
+      affected.add(projectRootOf(file, [...allRoots]));
+    } else {
+      // Deleted paths are absent from the workspace walk but still affect the
+      // deepest surviving project root that owned them.
+      affected.add(projectRootOf(file, [...allRoots]));
+    }
+  }
+
+  if (affected.size === 0) return [];
+  const roots = [...allRoots];
+  return globbed.filter((file) => affected.has(projectRootOf(file, roots)));
+};
+
+// Select runnable files and preserve whether that selection was proven or had
+// to be widened. Unknown provenance scans every glob match and stays UNKNOWN so
+// a blocking harness failure cannot be mistaken for an irrelevant check. Only
+// a known provenance set with no relevant files is NOT_APPLICABLE.
+const selectSensorFiles = ({ globbed, provenance, scope, allFiles, configFile, enumeration }) => {
+  const normalized = normalizeChangedFileProvenance(provenance);
+  if (!enumeration?.complete) {
+    return {
+      applicability: SENSOR_APPLICABILITY.UNKNOWN,
+      files: [...globbed],
+      provenance: normalized,
+      selectionComplete: false,
+    };
+  }
+  if (normalized.state === 'unknown') {
+    return {
+      applicability: SENSOR_APPLICABILITY.UNKNOWN,
+      files: [...globbed],
+      provenance: normalized,
+      selectionComplete: true,
+    };
+  }
+
+  const files =
+    scope === 'project'
+      ? expandToAffectedProjects({
+          globbed,
+          changed: normalized.files,
+          allFiles,
+          configFile,
+        })
+      : scopeToChangedFiles(globbed, normalized);
+  return {
+    applicability:
+      files.length > 0 ? SENSOR_APPLICABILITY.APPLICABLE : SENSOR_APPLICABILITY.NOT_APPLICABLE,
+    files,
+    provenance: normalized,
+    selectionComplete: true,
+  };
+};
+
+// Sensor scripts need only executable discovery, a writable package-manager home/temp
+// location, and locale/timezone settings. Build a new object instead of forwarding
+// the AgentCore environment: repository credentials, AWS credentials, provider
+// tokens, MCP secrets, proxy credentials, and unrelated CLI state must never reach
+// deterministic sensor children.
+const SENSOR_ENV_ALLOWLIST = Object.freeze([
+  'PATH',
+  'HOME',
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TZ',
+]);
+
+const sensorChildEnv = (source = {}) => {
+  const env = {};
+  for (const name of SENSOR_ENV_ALLOWLIST) {
+    if (typeof source?.[name] === 'string') env[name] = source[name];
+  }
+  return env;
 };
 
 // Spawn a child and collect stdout/stderr + exit, enforcing a hard timeout.
@@ -122,7 +291,7 @@ const runChild = ({ file, args, timeoutMs, cwd, env, spawnFn = spawn }) =>
     let stderr = '';
     let timedOut = false;
     let settled = false;
-    const child = spawnFn(file, args, { cwd, env, shell: false });
+    const child = spawnFn(file, args, { cwd, env: sensorChildEnv(env), shell: false });
 
     const finish = (exitCode) => {
       if (settled) return;
@@ -153,24 +322,318 @@ const runChild = ({ file, args, timeoutMs, cwd, env, spawnFn = spawn }) =>
     child.on('close', (code) => finish(code));
   });
 
-// Read a sensor's stdout JSON `pass` field if present; falls back to the exit
-// code. Upstream per-sensor scripts exit 0 and carry the verdict in stdout
-// `{"pass": bool, ...}`, so the exit code alone under-reports a clean FAIL.
-const resultFromScript = ({ exitCode, stdout }) => {
-  if (exitCode === 0 && typeof stdout === 'string' && stdout.trim()) {
+const STDERR_BUDGET = 500;
+const DETAIL_BUDGET_BYTES = 120_000;
+const SAMPLE_FILES = 5;
+const REDACTED_DIAGNOSTIC = '[REDACTED]';
+const CREDENTIAL_LABEL =
+  '[A-Za-z0-9_-]*(?:secret|password|passwd|token|credential|private[-_]?key|api[-_]?key|authorization|cookie|signature)[A-Za-z0-9_-]*';
+const JSON_DOUBLE_CREDENTIAL_PATTERN = new RegExp(
+  `(["']${CREDENTIAL_LABEL}["']\\s*:\\s*)"(?:\\\\.|[^"\\\\])*"`,
+  'gi',
+);
+const JSON_SINGLE_CREDENTIAL_PATTERN = new RegExp(
+  `(["']${CREDENTIAL_LABEL}["']\\s*:\\s*)'(?:\\\\.|[^'\\\\])*'`,
+  'gi',
+);
+const ASSIGNED_CREDENTIAL_PATTERN = new RegExp(
+  `(\\b(${CREDENTIAL_LABEL})\\b\\s*[:=]\\s*)(?!\\[REDACTED\\])([^\\s,;}\\][{]+)`,
+  'gi',
+);
+const ARGUMENT_CREDENTIAL_PATTERN = new RegExp(`(--?${CREDENTIAL_LABEL}\\b\\s+)([^\\s]+)`, 'gi');
+const QUERY_CREDENTIAL_PATTERN = new RegExp(`([?&]${CREDENTIAL_LABEL}=)([^&#\\s]+)`, 'gi');
+const SENSITIVE_ENV_NAME =
+  /(?:^|_)(?:secret|password|passwd|token|credentials?|private_key|api_key|authorization|cookie|signature|askpass|netrc|access_key_id)(?:_|$)/i;
+const SENSITIVE_FIELD_NAME =
+  /(?:secret|password|passwd|token|credential|privatekey|apikey|authorization|cookie|signature|askpass|netrc)/i;
+const SENSITIVE_PATH_PATTERN =
+  /(?:~|\/(?:[^/\s"'():]+\/)*)(?:\.aws\/credentials|\.git-credentials|\.netrc|\.npmrc|\.pypirc|\.docker\/config\.json|\.config\/gcloud\/application_default_credentials\.json|run\/secrets\/[^\s"'():]+)/gi;
+
+const sensitiveEnvironmentValues = (source = {}) =>
+  [
+    ...new Set(
+      Object.entries(source)
+        .filter(([name]) => SENSITIVE_ENV_NAME.test(String(name)))
+        .map(([, value]) => (typeof value === 'string' ? value : ''))
+        // Replacing very short values globally would destroy ordinary diagnostics;
+        // labelled forms are still covered by the structural patterns below.
+        .filter((value) => value.length >= 4 && value !== REDACTED_DIAGNOSTIC),
+    ),
+  ].toSorted((a, b) => b.length - a.length);
+
+const credentialField = (key) => {
+  const normalized = String(key).replaceAll(/[-_]/g, '').toLowerCase();
+  return SENSITIVE_FIELD_NAME.test(normalized) || ['setcookie', 'accesskeyid'].includes(normalized);
+};
+
+// Sensor processes execute repository-controlled tooling. Treat every diagnostic
+// as untrusted and redact credentials before it can become a SensorRun, activity
+// note, UI payload, or deduplication key.
+const redactCredentialText = (value, sensitiveValues = []) => {
+  let text = String(value);
+  for (const sensitiveValue of sensitiveValues) {
+    text = text.replaceAll(sensitiveValue, REDACTED_DIAGNOSTIC);
+  }
+  text = text.replace(
+    /-----BEGIN ([A-Z0-9 ]*PRIVATE KEY)-----[\s\S]*?-----END \1-----/g,
+    REDACTED_DIAGNOSTIC,
+  );
+  text = text.replace(
+    /\b((?:authorization|proxy-authorization)\s*[:=])([^\r\n,;]+)/gi,
+    (_match, prefix) => `${prefix} ${REDACTED_DIAGNOSTIC}`,
+  );
+  text = text.replace(
+    /\b(bearer|basic)\s+[A-Za-z0-9._~+/-]{8,}={0,2}/gi,
+    `$1 ${REDACTED_DIAGNOSTIC}`,
+  );
+  text = text.replace(/(\b[a-z][a-z0-9+.-]*:\/\/)([^/\s@]+)@/gi, `$1${REDACTED_DIAGNOSTIC}@`);
+  text = text.replace(JSON_DOUBLE_CREDENTIAL_PATTERN, `$1"${REDACTED_DIAGNOSTIC}"`);
+  text = text.replace(JSON_SINGLE_CREDENTIAL_PATTERN, `$1'${REDACTED_DIAGNOSTIC}'`);
+  text = text.replace(ASSIGNED_CREDENTIAL_PATTERN, `$1${REDACTED_DIAGNOSTIC}`);
+  text = text.replace(ARGUMENT_CREDENTIAL_PATTERN, `$1${REDACTED_DIAGNOSTIC}`);
+  text = text.replace(QUERY_CREDENTIAL_PATTERN, `$1${REDACTED_DIAGNOSTIC}`);
+  text = text.replace(SENSITIVE_PATH_PATTERN, REDACTED_DIAGNOSTIC);
+  text = text.replace(
+    /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b|\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,}|glpat-[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}(?:-[A-Za-z0-9-]{10,})*)\b|\bsk-(?:ant-|proj-)?[A-Za-z0-9_-]{16,}\b|\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g,
+    REDACTED_DIAGNOSTIC,
+  );
+  return text;
+};
+
+const redactDiagnostic = (value, sensitiveValues = [], seen = new WeakMap()) => {
+  if (typeof value === 'string') return redactCredentialText(value, sensitiveValues);
+  if (Array.isArray(value))
+    return value.map((entry) => redactDiagnostic(entry, sensitiveValues, seen));
+  if (!value || typeof value !== 'object') return value;
+  if (seen.has(value)) return seen.get(value);
+
+  const redacted = {};
+  seen.set(value, redacted);
+  for (const [key, entry] of Object.entries(value)) {
+    redacted[key] = credentialField(key)
+      ? entry == null
+        ? entry
+        : REDACTED_DIAGNOSTIC
+      : redactDiagnostic(entry, sensitiveValues, seen);
+  }
+  return redacted;
+};
+
+const tailDiagnostic = (stderr, sensitiveValues = []) => {
+  const text =
+    typeof stderr === 'string' ? redactCredentialText(stderr, sensitiveValues).trim() : '';
+  if (!text) return null;
+  if (text.length <= STDERR_BUDGET) return text;
+  return `…${text.slice(-STDERR_BUDGET)}`;
+};
+
+const OMISSION_REASON = 'detail size budget';
+const jsonByteLength = (value) => Buffer.byteLength(JSON.stringify(value), 'utf8');
+const JSON_KEY_BYTES = Object.freeze({
+  harnessFailures: jsonByteLength('harnessFailures'),
+  files: jsonByteLength('files'),
+  filesOmitted: jsonByteLength('filesOmitted'),
+  omissionReason: jsonByteLength('omissionReason'),
+});
+const OMISSION_REASON_BYTES = jsonByteLength(OMISSION_REASON);
+const jsonArrayByteLength = (count, contentBytes) => 2 + contentBytes + Math.max(0, count - 1);
+
+// Calculate the exact encoded size without repeatedly serializing the growing
+// detail object. Each candidate is serialized once; all subsequent accounting
+// is constant time, so high-cardinality sensor output remains linear.
+const summarizedDetailByteLength = ({
+  harnessFailureCount,
+  harnessFailureBytes,
+  fileCount,
+  fileBytes,
+  filesOmitted,
+}) => {
+  let bytes = 2; // opening and closing object braces
+  let propertyCount = 0;
+  const addProperty = (key, valueBytes) => {
+    if (propertyCount > 0) bytes += 1; // comma between object properties
+    bytes += JSON_KEY_BYTES[key] + 1 + valueBytes; // key, colon, value
+    propertyCount += 1;
+  };
+
+  if (harnessFailureCount > 0) {
+    addProperty('harnessFailures', jsonArrayByteLength(harnessFailureCount, harnessFailureBytes));
+  }
+  if (fileCount > 0) addProperty('files', jsonArrayByteLength(fileCount, fileBytes));
+  if (filesOmitted > 0) {
+    addProperty('filesOmitted', String(filesOmitted).length);
+    addProperty('omissionReason', OMISSION_REASON_BYTES);
+  }
+  return bytes;
+};
+
+// Collapse repeated harness failures and keep the persisted SensorRun detail
+// below the DynamoDB item ceiling. Grouping consumes only the redacted detail:
+// different secret values in otherwise-identical failures collapse together,
+// and no raw credential can be retained in a key or copied into persistence.
+// Candidates retain first-seen order. The byte-accounting pass includes an
+// entry only when the complete final shape (including omission metadata) fits.
+const summarizeFileResults = (fileResults, sensitiveValues = []) => {
+  const groups = new Map();
+  const files = [];
+  for (const entry of fileResults) {
+    const safeDetail = redactDiagnostic(entry.detail, sensitiveValues);
+    const reason = safeDetail?.reason;
+    if (reason === 'script-error' || reason === 'tool-unavailable') {
+      const key = `${reason}|${safeDetail?.exitCode ?? ''}|${safeDetail?.stderr ?? ''}`;
+      const group = groups.get(key) ?? {
+        reason,
+        result: entry.result,
+        exitCode: safeDetail?.exitCode ?? null,
+        stderr: safeDetail?.stderr ?? null,
+        fileCount: 0,
+        sampleFiles: [],
+      };
+      group.fileCount += 1;
+      if (group.sampleFiles.length < SAMPLE_FILES) group.sampleFiles.push(entry.file);
+      groups.set(key, group);
+    } else {
+      files.push({
+        file: entry.file,
+        result: entry.result,
+        timedOut: entry.timedOut,
+        ...(safeDetail ? { detail: safeDetail } : {}),
+      });
+    }
+  }
+
+  const harnessFailures = [...groups.values()];
+  const totalRepresentedFiles =
+    files.length + harnessFailures.reduce((total, group) => total + group.fileCount, 0);
+  const includedHarnessFailures = [];
+  const includedFiles = [];
+  const size = {
+    harnessFailureCount: 0,
+    harnessFailureBytes: 0,
+    fileCount: 0,
+    fileBytes: 0,
+  };
+  let representedFiles = 0;
+
+  const includeWhenBounded = (entry, representedCount, kind) => {
+    const entryBytes = jsonByteLength(entry);
+    const harnessFailure = kind === 'harnessFailure';
+    const projected = {
+      harnessFailureCount: size.harnessFailureCount + (harnessFailure ? 1 : 0),
+      harnessFailureBytes: size.harnessFailureBytes + (harnessFailure ? entryBytes : 0),
+      fileCount: size.fileCount + (harnessFailure ? 0 : 1),
+      fileBytes: size.fileBytes + (harnessFailure ? 0 : entryBytes),
+      filesOmitted: totalRepresentedFiles - representedFiles - representedCount,
+    };
+    if (summarizedDetailByteLength(projected) > DETAIL_BUDGET_BYTES) return;
+
+    Object.assign(size, projected);
+    representedFiles += representedCount;
+    if (harnessFailure) includedHarnessFailures.push(entry);
+    else includedFiles.push(entry);
+  };
+
+  for (const group of harnessFailures) {
+    includeWhenBounded(group, group.fileCount, 'harnessFailure');
+  }
+  for (const file of files) includeWhenBounded(file, 1, 'file');
+
+  const detail = {};
+  if (includedHarnessFailures.length > 0) detail.harnessFailures = includedHarnessFailures;
+  if (includedFiles.length > 0) detail.files = includedFiles;
+  const filesOmitted = totalRepresentedFiles - representedFiles;
+  if (filesOmitted > 0) {
+    detail.filesOmitted = filesOmitted;
+    detail.omissionReason = OMISSION_REASON;
+  }
+  return detail;
+};
+
+// Read the declared verdict protocol. Upstream stdout-json sensors use non-zero
+// exits for harness failures, while custom exit-code sensors retain the classic
+// non-zero-is-FAIL convention. A stdout-json sensor may report PASS or FAIL only
+// by emitting exactly one JSON value with a boolean `pass` field on exit zero.
+const resultFromScript = ({
+  exitCode,
+  stdout,
+  stderr = '',
+  verdictMode = 'exit-code',
+  sensitiveValues = [],
+} = {}) => {
+  const stdoutText = typeof stdout === 'string' ? stdout.trim() : '';
+  const diagnostic = tailDiagnostic(stderr, sensitiveValues);
+  const inconclusive = (reason, extra = {}) => ({
+    result: SENSOR_RESULT.INCONCLUSIVE,
+    detail: redactDiagnostic(
+      {
+        reason,
+        exitCode: exitCode ?? null,
+        stderr: diagnostic,
+        ...extra,
+      },
+      sensitiveValues,
+    ),
+  });
+
+  if (exitCode === 0 && verdictMode === 'stdout-json') {
+    if (!stdoutText) return inconclusive('missing-verdict', { stdout: null });
+
+    let parsed;
     try {
-      const parsed = JSON.parse(stdout.trim().split(/\r?\n/).at(-1));
+      // Parse the complete trimmed stream, not only its final line. This rejects
+      // leading/trailing log output and multiple values instead of silently
+      // accepting a valid-looking fragment as the sensor verdict.
+      parsed = JSON.parse(stdoutText);
+    } catch {
+      return inconclusive('invalid-verdict', {
+        stdout: tailDiagnostic(stdoutText, sensitiveValues),
+      });
+    }
+
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== 'object') {
+      return inconclusive('invalid-verdict', {
+        stdout: tailDiagnostic(stdoutText, sensitiveValues),
+      });
+    }
+    if (typeof parsed.pass !== 'boolean') {
+      return inconclusive('invalid-verdict', {
+        stdout: tailDiagnostic(stdoutText, sensitiveValues),
+      });
+    }
+    return {
+      result: parsed.pass ? SENSOR_RESULT.PASS : SENSOR_RESULT.FAIL,
+      detail: redactDiagnostic(parsed, sensitiveValues),
+    };
+  }
+
+  // Preserve the existing optional JSON verdict behavior for exit-code sensors.
+  // Their declared protocol still permits exit-code fallback when output is
+  // absent or malformed.
+  if (exitCode === 0 && stdoutText) {
+    try {
+      const parsed = JSON.parse(stdoutText.split(/\r?\n/).at(-1));
       if (typeof parsed?.pass === 'boolean') {
         return {
           result: parsed.pass ? SENSOR_RESULT.PASS : SENSOR_RESULT.FAIL,
-          detail: parsed,
+          detail: redactDiagnostic(parsed, sensitiveValues),
         };
       }
     } catch {
-      /* not JSON — fall through to exit-code mapping */
+      /* exit-code sensors fall through to their declared exit-code mapping */
     }
   }
-  return { result: resultFromExit(exitCode), detail: null };
+
+  if (exitCode === TOOL_UNAVAILABLE_EXIT) return inconclusive('tool-unavailable');
+  const nonZero = exitCode !== 0 && exitCode !== 2 && exitCode != null;
+  if (nonZero && verdictMode === 'stdout-json') return inconclusive('script-error');
+
+  return {
+    result: resultFromExit(exitCode),
+    detail:
+      exitCode === 0
+        ? null
+        : redactDiagnostic({ exitCode: exitCode ?? null, stderr: diagnostic }, sensitiveValues),
+  };
 };
 
 // Create the sensor runner. `graph` is the graph-writer (for reading produced
@@ -184,7 +647,10 @@ export const createSensorRunner = ({
   substitutions = {},
   spawnFn = spawn,
   childEnv = process.env,
+  changedFileProvenance = unknownChangedFileProvenance('not_provided'),
+  fileListOptions = {},
 } = {}) => {
+  const sensitiveValues = sensitiveEnvironmentValues(childEnv);
   // Evaluate one `graph` sensor against the artifacts this stage produced. Each
   // produced artifact's content is read from Neptune and fed to the in-process
   // evaluator. The worst result across the produced artifacts wins (a single
@@ -247,25 +713,70 @@ export const createSensorRunner = ({
   };
 
   // Run one `script` sensor: glob the workspace for files the sensor matches,
-  // materialize its script from S3, and spawn it once per matching file. No
-  // match → INCONCLUSIVE (the stage produced no code this sensor inspects).
+  // materialize its script from S3, and spawn it once per selected file.
+  // Known irrelevance records INCONCLUSIVE without holding a blocking stage;
+  // unknown provenance widens to every glob match and remains fail-safe.
   const runScriptSensor = async ({ sensor, stageId }) => {
     const validation = validateScriptSpec(sensor);
     if (!validation.ok) {
-      return { result: SENSOR_RESULT.BLOCKED, detail: { error: validation.error } };
+      return {
+        result: SENSOR_RESULT.BLOCKED,
+        applicability: SENSOR_APPLICABILITY.UNKNOWN,
+        detail: { error: validation.error },
+      };
     }
     const spec = validation.spec;
 
     if (!workspaceDir) {
-      return { result: SENSOR_RESULT.INCONCLUSIVE, detail: { reason: 'no workspace' } };
-    }
-    const matcher = sensor.matches ? globToRegExp(sensor.matches) : null;
-    const all = await listFiles(workspaceDir);
-    const matched = matcher ? all.filter((f) => matcher.test(f)) : all;
-    if (matched.length === 0) {
       return {
         result: SENSOR_RESULT.INCONCLUSIVE,
-        detail: { reason: 'no files match', matches: sensor.matches ?? null },
+        applicability: SENSOR_APPLICABILITY.UNKNOWN,
+        detail: { reason: 'no workspace' },
+      };
+    }
+    const matcher = sensor.matches ? globToRegExp(sensor.matches) : null;
+    const enumeration = await listFiles(workspaceDir, fileListOptions);
+    const all = enumeration.files;
+    const globbed = matcher ? all.filter((file) => matcher.test(file)) : all;
+    const scope = spec.scope;
+    const selection = selectSensorFiles({
+      globbed,
+      provenance: changedFileProvenance,
+      scope,
+      allFiles: all,
+      configFile: spec.projectConfig,
+      enumeration,
+    });
+
+    const { applicability, files: matched, provenance, selectionComplete } = selection;
+    if (!selectionComplete) {
+      return {
+        result: SENSOR_RESULT.INCONCLUSIVE,
+        applicability,
+        detail: {
+          reason: 'workspace enumeration incomplete',
+          matches: sensor.matches ?? null,
+          scope,
+          applicability,
+          provenance,
+          enumeration: summarizeEnumeration(enumeration),
+        },
+      };
+    }
+    if (matched.length === 0) {
+      const reason = globbed.length === 0 ? 'no files match' : 'no changed files match';
+      return {
+        result: SENSOR_RESULT.INCONCLUSIVE,
+        applicability,
+        detail: {
+          reason,
+          matches: sensor.matches ?? null,
+          scope,
+          applicability,
+          provenance,
+          globbed: globbed.length,
+          changed: provenance.state === 'known' ? provenance.files.length : null,
+        },
       };
     }
 
@@ -273,7 +784,11 @@ export const createSensorRunner = ({
     // the spawned interpreter can load it. The block carries the scriptRef.
     const script = await loadBlockScript(sensor).catch(() => '');
     if (!script) {
-      return { result: SENSOR_RESULT.BLOCKED, detail: { error: 'sensor has no script' } };
+      return {
+        result: SENSOR_RESULT.BLOCKED,
+        applicability,
+        detail: { error: 'sensor has no script' },
+      };
     }
     const scriptDir = path.join(workspaceDir, '.aidlc', 'sensors');
     await mkdir(scriptDir, { recursive: true });
@@ -282,6 +797,7 @@ export const createSensorRunner = ({
     const { file, args } = buildScriptArgv(spec, { scriptPath, substitutions });
 
     // One run per matching file (the upstream scripts take a single --file-path).
+    const verdictMode = spec.verdictMode;
     const fileResults = [];
     let worst = SENSOR_RESULT.PASS;
     for (const rel of matched) {
@@ -293,17 +809,33 @@ export const createSensorRunner = ({
         env: childEnv,
         spawnFn,
       });
-      const { result, detail } = resultFromScript(run);
+      const { result, detail } = resultFromScript({ ...run, verdictMode, sensitiveValues });
       fileResults.push({ file: rel, result, timedOut: run.timedOut, detail });
       if (result === SENSOR_RESULT.FAIL) worst = SENSOR_RESULT.FAIL;
       else if (result === SENSOR_RESULT.BLOCKED && worst !== SENSOR_RESULT.FAIL)
         worst = SENSOR_RESULT.BLOCKED;
+      else if (
+        result === SENSOR_RESULT.INCONCLUSIVE &&
+        worst !== SENSOR_RESULT.FAIL &&
+        worst !== SENSOR_RESULT.BLOCKED
+      )
+        worst = SENSOR_RESULT.INCONCLUSIVE;
     }
-    return { result: worst, detail: { files: fileResults } };
+    return {
+      result: worst,
+      applicability,
+      detail: {
+        scope,
+        applicability,
+        provenance,
+        ...summarizeFileResults(fileResults, sensitiveValues),
+      },
+    };
   };
 
   // Run every sensor declared on a stage and return the verdicts. Each verdict:
-  // { sensorId, kind, severity, result, held, detail }. Best-effort per sensor —
+  // { sensorId, kind, severity, result, applicability, held, detail }.
+  // Best-effort per sensor —
   // a thrown sensor becomes a BLOCKED verdict, never a stage crash.
   const runStageSensors = async ({
     sensors = [],
@@ -330,16 +862,22 @@ export const createSensorRunner = ({
             ? await runGraphSensor({ sensor, outputArtifacts, consumes })
             : await runScriptSensor({ sensor, stageId });
       } catch (e) {
-        outcome = { result: SENSOR_RESULT.BLOCKED, detail: { error: e.message } };
+        outcome = {
+          result: SENSOR_RESULT.BLOCKED,
+          applicability: SENSOR_APPLICABILITY.UNKNOWN,
+          detail: { error: e.message },
+        };
       }
-      const { held } = severityGate(outcome.result, sensor.severity);
+      const applicability = outcome.applicability ?? SENSOR_APPLICABILITY.APPLICABLE;
+      const { held } = severityGate(outcome.result, sensor.severity, applicability);
       verdicts.push({
         sensorId: sensor.sensorId,
         kind,
         severity: sensor.severity ?? 'advisory',
         result: outcome.result,
+        applicability,
         held,
-        detail: outcome.detail ?? null,
+        detail: redactDiagnostic(outcome.detail ?? null, sensitiveValues),
       });
     }
     return verdicts;
@@ -348,4 +886,17 @@ export const createSensorRunner = ({
   return { runStageSensors, runGraphSensor, runScriptSensor };
 };
 
-export const __test = { globToRegExp, listFiles, resultFromScript };
+export const __test = {
+  globToRegExp,
+  listFiles,
+  resultFromScript,
+  scopeToChangedFiles,
+  expandToAffectedProjects,
+  selectSensorFiles,
+  projectRootOf,
+  tailDiagnostic,
+  summarizeFileResults,
+  redactCredentialText,
+  redactDiagnostic,
+  sensitiveEnvironmentValues,
+};

--- a/lambda/agentcore/test/git-engine.test.js
+++ b/lambda/agentcore/test/git-engine.test.js
@@ -8,10 +8,13 @@ import {
   scrubRemote,
   commitAll,
   isAheadOfRemote,
+  aheadFiles,
   pushBranch,
   remoteBranchExists,
   commitAndPushAll,
   seedInitialCommit,
+  parsePorcelainZ,
+  toWorkspaceRelative,
 } from '../git-engine.js';
 
 // Real git spawns (~10 per test) can be slow on busy CI machines.
@@ -90,6 +93,66 @@ describe('scrubRemote', () => {
   });
 });
 
+describe('parsePorcelainZ', () => {
+  it('keeps spaces and non-ASCII paths unquoted', () => {
+    expect(parsePorcelainZ(' M src/a b.ts\0?? src/café.ts\0')).toEqual([
+      'src/a b.ts',
+      'src/café.ts',
+    ]);
+  });
+
+  it('preserves both destination and source fields for rename entries', () => {
+    expect(parsePorcelainZ('R  new.ts\0old.ts\0 M other.ts\0')).toEqual([
+      'new.ts',
+      'old.ts',
+      'other.ts',
+    ]);
+  });
+});
+
+describe('toWorkspaceRelative', () => {
+  it('prefixes repo-relative paths in a multi-repository workspace', () => {
+    expect(toWorkspaceRelative(['src/index.ts'], { url: 'acme/shop', multi: true })).toEqual([
+      'acme/shop/src/index.ts',
+    ]);
+  });
+
+  it('leaves single-repository paths unchanged', () => {
+    expect(toWorkspaceRelative(['src/index.ts'], { url: 'acme/shop', multi: false })).toEqual([
+      'src/index.ts',
+    ]);
+  });
+
+  it('normalizes mixed repo- and workspace-relative inputs exactly once and deterministically', () => {
+    const options = { url: 'acme/shop', multi: true };
+    const input = [
+      'src/new.ts',
+      'acme/shop/src/existing.ts',
+      'test/new.test.ts',
+      'acme/shop/test/existing.test.ts',
+    ];
+    const expected = [
+      'acme/shop/src/new.ts',
+      'acme/shop/src/existing.ts',
+      'acme/shop/test/new.test.ts',
+      'acme/shop/test/existing.test.ts',
+    ];
+
+    const first = toWorkspaceRelative(input, options);
+    const second = toWorkspaceRelative(input, options);
+
+    expect(first).toEqual(expected);
+    expect(second).toEqual(expected);
+    expect(toWorkspaceRelative(first, options)).toEqual(expected);
+    expect(input).toEqual([
+      'src/new.ts',
+      'acme/shop/src/existing.ts',
+      'test/new.test.ts',
+      'acme/shop/test/existing.test.ts',
+    ]);
+  });
+});
+
 describe('commitAll', () => {
   it('commits the whole tree with the engine identity and returns the sha', async () => {
     const { work } = await initRemoteAndClone();
@@ -109,7 +172,11 @@ describe('commitAll', () => {
   it('reports clean when there is nothing to commit', async () => {
     const { work } = await initRemoteAndClone();
     const res = await commitAll({ dir: work, message: 'aidlc(x): e1' });
-    expect(res).toEqual({ committed: false, reason: 'clean' });
+    expect(res).toEqual({
+      committed: false,
+      reason: 'clean',
+      provenance: { state: 'known', files: [] },
+    });
   });
 
   it('is immune to ambient GIT_* env (running inside a git hook must not redirect or re-identify)', async () => {
@@ -141,6 +208,53 @@ describe('commitAll', () => {
         else process.env[k] = v;
       }
     }
+  });
+
+  it.each([1, 42, null])(
+    'marks provenance unknown for an arbitrary pre-commit status failure (%s)',
+    async (exitCode) => {
+      const gitWithFailedStatus = vi.fn(async (args) => {
+        const command = args.join(' ');
+        if (command === 'status --porcelain -z') {
+          return { exitCode, stdout: '', stderr: 'status collection interrupted' };
+        }
+        if (command === 'status --porcelain') {
+          return { exitCode: 0, stdout: 'M  src/index.ts\n', stderr: '' };
+        }
+        if (command === 'rev-parse HEAD') {
+          return { exitCode: 0, stdout: `${'a'.repeat(40)}\n`, stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      });
+
+      const result = await commitAll({
+        dir: root,
+        message: 'aidlc(x): e1',
+        git: gitWithFailedStatus,
+      });
+
+      expect(result).toMatchObject({
+        committed: true,
+        provenance: {
+          state: 'unknown',
+          reason: 'git_status_failed',
+          detail: 'status collection interrupted',
+        },
+      });
+    },
+  );
+
+  it('captures filenames with spaces and non-ASCII verbatim', async () => {
+    const { work } = await initRemoteAndClone();
+    await writeFile(path.join(work, 'a file.ts'), 'x\n');
+    await writeFile(path.join(work, 'café.ts'), 'y\n');
+
+    const result = await commitAll({ dir: work, message: 'aidlc(x): e1' });
+
+    expect(result.committed).toBe(true);
+    expect(result.provenance).toMatchObject({ state: 'known' });
+    expect(result.provenance.files).toContain('a file.ts');
+    expect(result.provenance.files).toContain('café.ts');
   });
 
   it('captures untracked, modified AND deleted files (add -A semantics)', async () => {
@@ -573,6 +687,80 @@ describe('commitAndPushAll — the stage-exit hook', () => {
     expect(res.ok).toBe(true);
     expect(res.committed).toBe(false); // THIS call created no commit…
     expect(res.results[0].pushed).toBe(true); // …but the earlier one got pushed
+    expect(res.results[0].files).toEqual(['earlier.js']);
+  });
+
+  it('clean-tree retry uses the base ref to report every commit on a never-pushed branch', async () => {
+    const { work, remote } = await initRemoteAndClone();
+    await git(['checkout', '-b', 'aidlc/i1'], work);
+
+    await writeFile(path.join(work, 'first.ts'), 'export const first = true;\n');
+    await git(['add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'first'], work);
+    await writeFile(path.join(work, 'second.ts'), 'export const second = true;\n');
+    await git(['add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'second'], work);
+
+    expect(
+      (await git(['rev-parse', '--verify', 'refs/remotes/origin/aidlc/i1'], work)).exitCode,
+    ).not.toBe(0);
+
+    const result = await commitAndPushAll({
+      repos: ['o/r'],
+      workspaceDir: work,
+      branch: 'aidlc/i1',
+      baseBranch: 'main',
+      gitProvider: 'github',
+      message: 'aidlc(retry): e1',
+      urlsFor: () => ({ auth: remote, clean: 'https://github.com/o/r.git' }),
+    });
+
+    expect(result).toMatchObject({ ok: true, committed: false });
+    expect(result.results[0]).toMatchObject({
+      committed: false,
+      pushed: true,
+      provenance: { state: 'known', files: ['first.ts', 'second.ts'] },
+      files: ['first.ts', 'second.ts'],
+    });
+    expect(
+      (await git(['rev-parse', '--verify', 'refs/heads/aidlc/i1'], remote)).stdout.trim(),
+    ).toBe(result.results[0].sha);
+  });
+
+  it('clean-tree retry recovers and pushes both endpoints of an earlier rename', async () => {
+    const { work, remote } = await initRemoteAndClone();
+    await writeFile(path.join(work, 'legacy.ts'), 'export const value = true;\n');
+    await git(['add', '-A'], work);
+    await git(
+      ['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'add legacy path'],
+      work,
+    );
+    await git(['push', 'origin', 'main'], work);
+
+    await git(['mv', 'legacy.ts', 'current.ts'], work);
+    const earlier = await commitAll({ dir: work, message: 'aidlc(rename): e1' });
+    expect(earlier.provenance).toEqual({
+      state: 'known',
+      files: ['current.ts', 'legacy.ts'],
+    });
+
+    const result = await commitAndPushAll({
+      repos: ['o/r'],
+      workspaceDir: work,
+      branch: 'main',
+      gitProvider: 'github',
+      message: 'aidlc(retry): e1',
+      urlsFor: () => ({ auth: remote, clean: 'https://github.com/o/r.git' }),
+    });
+
+    expect(result).toMatchObject({ ok: true, committed: false });
+    expect(result.results[0]).toMatchObject({
+      committed: false,
+      pushed: true,
+      provenance: { state: 'known' },
+    });
+    expect(result.results[0].files).toEqual(expect.arrayContaining(['legacy.ts', 'current.ts']));
+    expect(result.results[0].files).toHaveLength(2);
   });
 
   it('push failure with a new commit: ok=false, committed=true (stage-failing condition)', async () => {
@@ -606,7 +794,7 @@ describe('commitAndPushAll — the stage-exit hook', () => {
     expect(res).toEqual({ ok: true, committed: false, results: [] });
   });
 
-  it('multi-repo: each repo commits/pushes in its own subdir; one failure flips ok', async () => {
+  it('multi-repo: normalizes each commit result once; one push failure flips ok', async () => {
     // repo A under <ws>/o/a (healthy), repo B under <ws>/o/b (push fails).
     const ws = path.join(root, 'ws');
     const remoteA = path.join(root, 'a.git');
@@ -633,8 +821,23 @@ describe('commitAndPushAll — the stage-exit hook', () => {
     expect(res.ok).toBe(false);
     expect(res.committed).toBe(true);
     const byRepo = Object.fromEntries(res.results.map((r) => [r.repo, r]));
-    expect(byRepo['o/a']).toMatchObject({ committed: true, pushed: true });
-    expect(byRepo['o/b']).toMatchObject({ committed: true, pushed: false });
+    expect(byRepo['o/a']).toMatchObject({
+      committed: true,
+      pushed: true,
+      provenance: { state: 'known', files: ['o/a/file.txt'] },
+      files: ['o/a/file.txt'],
+    });
+    expect(byRepo['o/b']).toMatchObject({
+      committed: true,
+      pushed: false,
+      provenance: { state: 'known', files: ['o/b/file.txt'] },
+      files: ['o/b/file.txt'],
+    });
+    const reportedFiles = res.results.flatMap((result) => result.files);
+    expect(reportedFiles).toEqual(['o/a/file.txt', 'o/b/file.txt']);
+    expect(reportedFiles).not.toEqual(
+      expect.arrayContaining(['o/a/o/a/file.txt', 'o/b/o/b/file.txt']),
+    );
   });
 
   it('never throws — a crashing git runner becomes an engine_crashed result', async () => {
@@ -1277,7 +1480,11 @@ describe('runtime excludes', () => {
     const { work } = await initRemoteAndClone();
     await seedRuntimeFiles(work);
     const res = await commitAll({ dir: work, message: 'aidlc(workspace-scaffold): e1' });
-    expect(res).toEqual({ committed: false, reason: 'clean' });
+    expect(res).toEqual({
+      committed: false,
+      reason: 'clean',
+      provenance: { state: 'known', files: [] },
+    });
     // The stage-exit hook then skips the network entirely (up_to_date).
     const hook = await commitAndPushAll({
       repos: ['o/r'],
@@ -1375,5 +1582,208 @@ describe('runtime excludes', () => {
     await ensureRuntimeExcludes({ dir: work });
     const again = await readFile(path.join(work, '.git', 'info', 'exclude'), 'utf8');
     expect(again.match(/runtime excludes v3/g)).toHaveLength(1);
+  });
+});
+
+describe('aheadFiles', () => {
+  it('returns known repo-relative files changed between the tracking ref and HEAD', async () => {
+    const { work } = await initRemoteAndClone();
+    await writeFile(path.join(work, 'retry.ts'), 'export const retry = true;\n');
+    await git(['add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'retry'], work);
+
+    expect(await aheadFiles({ dir: work, branch: 'main' })).toEqual({
+      state: 'known',
+      files: ['retry.ts'],
+    });
+  });
+
+  it('falls back to the recorded base branch when the target tracking ref is absent', async () => {
+    const { work } = await initRemoteAndClone();
+    await git(['checkout', '-b', 'aidlc/i1'], work);
+    await writeFile(path.join(work, 'intent.ts'), 'export const intent = true;\n');
+    await git(['add', '-A'], work);
+    await git(
+      ['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'intent work'],
+      work,
+    );
+
+    const targetRef = await git(['rev-parse', '--verify', 'refs/remotes/origin/aidlc/i1'], work);
+    expect(targetRef.exitCode).not.toBe(0);
+    expect(await aheadFiles({ dir: work, branch: 'aidlc/i1', baseBranch: 'main' })).toEqual({
+      state: 'known',
+      files: ['intent.ts'],
+    });
+  });
+
+  it('falls back to origin/HEAD for older payloads without a recorded base branch', async () => {
+    const { work } = await initRemoteAndClone();
+    await git(['checkout', '-b', 'aidlc/legacy'], work);
+    await writeFile(path.join(work, 'legacy.ts'), 'export const legacy = true;\n');
+    await git(['add', '-A'], work);
+    await git(
+      ['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'legacy work'],
+      work,
+    );
+
+    const defaultRef = await git(['symbolic-ref', 'refs/remotes/origin/HEAD'], work);
+    expect(defaultRef.stdout.trim()).toBe('refs/remotes/origin/main');
+    expect(await aheadFiles({ dir: work, branch: 'aidlc/legacy' })).toEqual({
+      state: 'known',
+      files: ['legacy.ts'],
+    });
+  });
+
+  it('aggregates paths across every commit in a multi-commit unpushed range', async () => {
+    const { work } = await initRemoteAndClone();
+    await writeFile(path.join(work, 'first.ts'), 'export const first = true;\n');
+    await git(['add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'first'], work);
+    await writeFile(path.join(work, 'second.ts'), 'export const second = true;\n');
+    await git(['add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'second'], work);
+
+    const provenance = await aheadFiles({ dir: work, branch: 'main' });
+
+    expect(provenance).toEqual({ state: 'known', files: ['first.ts', 'second.ts'] });
+  });
+
+  it('uses the merge base of a divergent stale tracking ref and excludes remote-only paths', async () => {
+    const { remote, work } = await initRemoteAndClone();
+    await git(['checkout', '-b', 'aidlc/diverged'], work);
+    await writeFile(path.join(work, 'local-only.ts'), 'export const local = true;\n');
+    await git(['add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'local work'], work);
+
+    await commitOnRemote(
+      remote,
+      'aidlc/diverged',
+      'remote-only.ts',
+      'export const remote = true;\n',
+    );
+    await git(['fetch', 'origin', 'aidlc/diverged'], work);
+
+    expect(await aheadFiles({ dir: work, branch: 'aidlc/diverged', baseBranch: 'main' })).toEqual({
+      state: 'known',
+      files: ['local-only.ts'],
+    });
+  });
+
+  it('returns a known empty list when HEAD matches the tracking ref', async () => {
+    const { work } = await initRemoteAndClone();
+    expect(await aheadFiles({ dir: work, branch: 'main' })).toEqual({
+      state: 'known',
+      files: [],
+    });
+  });
+
+  it.each([1, 42, null])(
+    'returns unknown provenance with the Git failure reason for an arbitrary diff failure (%s)',
+    async (exitCode) => {
+      const failedGit = async (args) => {
+        const command = args.join(' ');
+        if (command === 'rev-parse --verify refs/remotes/origin/main') {
+          return { exitCode: 0, stdout: `${'a'.repeat(40)}\n`, stderr: '' };
+        }
+        if (command === 'merge-base refs/remotes/origin/main HEAD') {
+          return { exitCode: 0, stdout: `${'a'.repeat(40)}\n`, stderr: '' };
+        }
+        return { exitCode, stdout: '', stderr: 'diff collection interrupted' };
+      };
+      expect(await aheadFiles({ dir: root, branch: 'main', git: failedGit })).toEqual({
+        state: 'unknown',
+        reason: 'git_diff_failed',
+        detail: 'diff collection interrupted',
+      });
+    },
+  );
+});
+
+describe('rename and copy endpoint provenance', () => {
+  it('preserves both endpoints of a staged rename before committing', async () => {
+    const { work } = await initRemoteAndClone();
+    await writeFile(path.join(work, 'old-name.ts'), 'export const renamed = true;\n');
+    await git(['add', '-A'], work);
+    await git(
+      ['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'add old name'],
+      work,
+    );
+    await git(['push', 'origin', 'main'], work);
+    await writeFile(path.join(work, 'new-name.ts'), 'export const renamed = true;\n');
+    await rm(path.join(work, 'old-name.ts'));
+    await git(['add', '-A'], work);
+
+    const result = await commitAll({ dir: work, message: 'aidlc(rename): e1' });
+
+    expect(result.committed).toBe(true);
+    expect(result.provenance).toEqual({
+      state: 'known',
+      files: ['new-name.ts', 'old-name.ts'],
+    });
+  });
+
+  it('recovers both endpoints from unpushed rename and copy history on retry', async () => {
+    const { work } = await initRemoteAndClone();
+    await writeFile(path.join(work, 'source.ts'), 'export const source = true;\n');
+    await git(['add', '-A'], work);
+    await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'add source'], work);
+    await git(['push', 'origin', 'main'], work);
+
+    await writeFile(path.join(work, 'renamed.ts'), 'export const source = true;\n');
+    await rm(path.join(work, 'source.ts'));
+    await writeFile(path.join(work, 'copied.ts'), 'export const source = true;\n');
+    await commitAll({ dir: work, message: 'aidlc(rename-and-copy): e1' });
+
+    const provenance = await aheadFiles({ dir: work, branch: 'main' });
+
+    expect(provenance.state).toBe('known');
+    expect(provenance.files).toEqual(
+      expect.arrayContaining(['source.ts', 'renamed.ts', 'copied.ts']),
+    );
+  });
+
+  it('keeps both projects in a cross-repository move through commitAndPushAll', async () => {
+    const sourceRemote = path.join(root, 'source.git');
+    const destinationRemote = path.join(root, 'destination.git');
+    const sourceSeed = path.join(root, 'source-seed');
+    const destinationSeed = path.join(root, 'destination-seed');
+    for (const [remote, seed, file] of [
+      [sourceRemote, sourceSeed, 'legacy.ts'],
+      [destinationRemote, destinationSeed, 'README.md'],
+    ]) {
+      await git(['init', '--bare', '-b', 'main', remote], root);
+      await git(['init', '-b', 'main', seed], root);
+      await writeFile(path.join(seed, file), 'shared content\n');
+      await git(['add', '-A'], seed);
+      await git(['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'seed'], seed);
+      await git(['push', remote, 'main'], seed);
+    }
+
+    const sourceDir = path.join(root, 'source');
+    const destinationDir = path.join(root, 'destination');
+    await git(['clone', sourceRemote, sourceDir], root);
+    await git(['clone', destinationRemote, destinationDir], root);
+    await writeFile(path.join(destinationDir, 'moved.ts'), 'shared content\n');
+    await rm(path.join(sourceDir, 'legacy.ts'));
+
+    const result = await commitAndPushAll({
+      repos: ['source', 'destination'],
+      workspaceDir: root,
+      branch: 'main',
+      gitProvider: 'github',
+      message: 'aidlc(cross-project-rename): e1',
+      urlsFor: (repo) => ({
+        auth: repo === 'source' ? sourceRemote : destinationRemote,
+        clean: `https://github.com/acme/${repo}.git`,
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+    const byRepo = Object.fromEntries(result.results.map((entry) => [entry.repo, entry]));
+    expect(byRepo.source.files).toEqual(['source/legacy.ts']);
+    expect(byRepo.destination.files).toEqual(['destination/moved.ts']);
+    expect(result.results.flatMap((entry) => entry.files)).toEqual(
+      expect.arrayContaining(['source/legacy.ts', 'destination/moved.ts']),
+    );
   });
 });

--- a/lambda/agentcore/test/run-stage.test.js
+++ b/lambda/agentcore/test/run-stage.test.js
@@ -1,11 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import nodePath from 'node:path';
 import {
   runStage,
   resetKiroCreditRateCache,
   withPlatformSensors,
   __test,
 } from '../commands/run-stage.js';
+import { commitAndPushAll as runCommitAndPushAll, runGit } from '../git-engine.js';
 import { renderRulesDoc } from '../stage-materializer.js';
 import {
   buildExecutionPlan,
@@ -421,6 +425,38 @@ describe('runStage — realtime broadcasts (state mirrors DynamoDB writes)', () 
   });
 });
 
+describe('changedFileProvenanceFromGitResults', () => {
+  const { changedFileProvenanceFromGitResults } = __test;
+
+  it('merges known repository files deterministically', () => {
+    expect(
+      changedFileProvenanceFromGitResults([
+        { repo: 'acme/api', provenance: { state: 'known', files: ['acme/api/b.ts'] } },
+        { repo: 'acme/web', provenance: { state: 'known', files: ['acme/web/a.ts'] } },
+      ]),
+    ).toEqual({ state: 'known', files: ['acme/api/b.ts', 'acme/web/a.ts'] });
+  });
+
+  it('returns unknown with repository and failure reason when any collection failed', () => {
+    expect(
+      changedFileProvenanceFromGitResults([
+        { repo: 'acme/api', provenance: { state: 'known', files: ['acme/api/a.ts'] } },
+        {
+          repo: 'acme/web',
+          provenance: {
+            state: 'unknown',
+            reason: 'git_diff_failed',
+            detail: 'fatal: bad revision',
+          },
+        },
+      ]),
+    ).toEqual({
+      state: 'unknown',
+      reason: 'acme/web: git_diff_failed',
+      detail: 'fatal: bad revision',
+    });
+  });
+});
 describe('mergeLearningRules — feeds the existing resolver at the right precedence', () => {
   const { mergeLearningRules } = __test;
 
@@ -1076,6 +1112,224 @@ describe('runStage — deterministic sensors', () => {
     );
     return proxy;
   };
+
+  it('feeds cross-project rename provenance from commitAndPushAll into stage sensor selection', async () => {
+    const root = await mkdtemp(nodePath.join(tmpdir(), 'run-stage-rename-selection-'));
+    const remote = nodePath.join(root, 'remote.git');
+    const workspaceDir = nodePath.join(root, 'work');
+    const git = (args, cwd) => runGit(args, { cwd });
+
+    try {
+      await git(['init', '--bare', '-b', 'main', remote], root);
+      await git(['init', '-b', 'main', workspaceDir], root);
+      for (const project of ['source', 'destination']) {
+        await mkdir(nodePath.join(workspaceDir, 'packages', project, 'src'), { recursive: true });
+        await writeFile(
+          nodePath.join(workspaceDir, 'packages', project, 'tsconfig.json'),
+          '{"compilerOptions":{}}\n',
+        );
+        await writeFile(
+          nodePath.join(workspaceDir, 'packages', project, 'src', `${project}-consumer.ts`),
+          `export const ${project}Consumer = true;\n`,
+        );
+      }
+      const sourcePath = 'packages/source/src/provider.ts';
+      const destinationPath = 'packages/destination/src/provider.ts';
+      await writeFile(nodePath.join(workspaceDir, sourcePath), 'export const provider = true;\n');
+      await git(['add', '-A'], workspaceDir);
+      await git(
+        ['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'seed projects'],
+        workspaceDir,
+      );
+      await git(['remote', 'add', 'origin', remote], workspaceDir);
+      await git(['push', '-u', 'origin', 'main'], workspaceDir);
+      await git(['mv', sourcePath, destinationPath], workspaceDir);
+
+      const lib = library();
+      lib.stagesById['requirements-analysis'].sensors = ['type-check'];
+      lib.sensorsById = {
+        'type-check': {
+          id: 'type-check',
+          command: 'bun x.ts',
+          runtime: 'bun',
+          severity: 'blocking',
+          matches: '**/*.ts',
+          verdictMode: 'stdout-json',
+          scope: 'project',
+          projectConfig: 'tsconfig.json',
+          scriptRef: { s3Key: 'blocks/scripts/sha256/type-check' },
+        },
+      };
+
+      const inspectedFiles = [];
+      const spawnFn = (command, args) => {
+        const child = new EventEmitter();
+        child.stdin = { end() {} };
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        child.kill = () => {};
+        setImmediate(() => {
+          if (command === 'bun') {
+            inspectedFiles.push(args[args.indexOf('--file-path') + 1]);
+            child.stdout.emit('data', Buffer.from('{"pass":true}'));
+          }
+          child.emit('close', 0);
+        });
+        return child;
+      };
+      const store = spyStore();
+      const result = await runStage(
+        {
+          ...baseArgs,
+          workspaceDir,
+          repos: ['acme/monorepo'],
+          branch: 'main',
+          baseBranch: 'main',
+          gitProvider: 'github',
+        },
+        baseDeps({
+          store,
+          spawnFn,
+          env: { BEDROCK_MODEL: 'us.anthropic.claude-sonnet-4-6', PATH: '/usr/bin:/bin' },
+          loadLibrary: async () => ({ workflow: workflow(), library: lib }),
+          loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+          ensureWorkspaceSource: async () => ({ restored: false, repos: [] }),
+          redirectHeavyDirs: async () => ({ links: [] }),
+          commitAndPushAll: (args) =>
+            runCommitAndPushAll({
+              ...args,
+              urlsFor: () => ({
+                auth: remote,
+                clean: 'https://github.com/acme/monorepo.git',
+              }),
+            }),
+        }),
+      );
+
+      expect(result).toMatchObject({ ok: true, state: 'SUCCEEDED' });
+      const persisted = store.calls.find(
+        ([name, row]) => name === 'recordSensorRun' && row.sensorId === 'type-check',
+      )?.[1];
+      expect(persisted).toMatchObject({
+        result: 'PASS',
+        detail: {
+          scope: 'project',
+          applicability: 'APPLICABLE',
+          provenance: {
+            state: 'known',
+            files: expect.arrayContaining([sourcePath, destinationPath]),
+          },
+        },
+      });
+      expect(persisted.detail.provenance.files).toHaveLength(2);
+      expect(inspectedFiles).toEqual(
+        expect.arrayContaining([
+          'packages/source/src/source-consumer.ts',
+          'packages/destination/src/provider.ts',
+          'packages/destination/src/destination-consumer.ts',
+        ]),
+      );
+      expect(inspectedFiles).toHaveLength(3);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('persists and broadcasts only redacted harness diagnostics', async () => {
+    const workspaceDir = await mkdtemp(nodePath.join(tmpdir(), 'run-stage-sensor-redaction-'));
+    try {
+      await writeFile(nodePath.join(workspaceDir, 'a.ts'), 'export const a = true;');
+      const lib = library();
+      lib.stagesById['requirements-analysis'].sensors = ['type-check'];
+      lib.sensorsById = {
+        'type-check': {
+          id: 'type-check',
+          command: 'bun x.ts',
+          runtime: 'bun',
+          severity: 'advisory',
+          matches: '**/*.ts',
+          verdictMode: 'stdout-json',
+          scriptRef: { s3Key: 'blocks/scripts/sha256/type-check' },
+        },
+      };
+      const store = spyStore();
+      const broadcasts = [];
+      const secretValue = 'opaque-runtime-secret';
+      const credentialPath = '/runtime/private/aws-credentials';
+      const spawnFn = (command) => {
+        const child = new EventEmitter();
+        child.stdin = { end() {} };
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        child.kill = () => {};
+        setImmediate(() => {
+          if (command === 'bun') {
+            child.stderr.emit(
+              'data',
+              Buffer.from(`Authorization: Token ${secretValue}\ncredential file ${credentialPath}`),
+            );
+            child.emit('close', 1);
+          } else {
+            child.emit('close', 0);
+          }
+        });
+        return child;
+      };
+
+      const res = await runStage(
+        { ...baseArgs, workspaceDir },
+        baseDeps({
+          store,
+          spawnFn,
+          broadcast: async (payload) => broadcasts.push(payload),
+          env: {
+            BEDROCK_MODEL: 'us.anthropic.claude-sonnet-4-6',
+            PATH: '/usr/bin:/bin',
+            MCP_SERVER_TOKEN: secretValue,
+            AWS_SHARED_CREDENTIALS_FILE: credentialPath,
+          },
+          loadLibrary: async () => ({ workflow: workflow(), library: lib }),
+          loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+          commitAndPushAll: async () => ({
+            ok: true,
+            committed: true,
+            results: [
+              {
+                repo: 'workspace',
+                committed: true,
+                pushed: true,
+                provenance: { state: 'known', files: ['a.ts'] },
+              },
+            ],
+          }),
+        }),
+      );
+
+      expect(res).toMatchObject({ ok: true, state: 'SUCCEEDED' });
+      const persisted = store.calls.find(
+        ([name, row]) => name === 'recordSensorRun' && row.sensorId === 'type-check',
+      )?.[1];
+      expect(persisted).toMatchObject({
+        result: 'INCONCLUSIVE',
+        detail: {
+          harnessFailures: [
+            expect.objectContaining({
+              stderr: 'Authorization: [REDACTED]\ncredential file [REDACTED]',
+            }),
+          ],
+        },
+      });
+      expect(store.calls).toContainEqual([
+        'appendEvent',
+        expect.objectContaining({ type: 'v2.sensor.flagged' }),
+      ]);
+      const sinkPayload = JSON.stringify({ calls: store.calls, broadcasts });
+      expect(sinkPayload).not.toContain(secretValue);
+      expect(sinkPayload).not.toContain(credentialPath);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
 
   it('an advisory sensor that does not PASS records a verdict but never fails the stage', async () => {
     const deps = baseDeps({

--- a/lambda/agentcore/test/run-stage.test.js
+++ b/lambda/agentcore/test/run-stage.test.js
@@ -1113,37 +1113,49 @@ describe('runStage — deterministic sensors', () => {
     return proxy;
   };
 
-  it('feeds cross-project rename provenance from commitAndPushAll into stage sensor selection', async () => {
+  it('feeds a cross-repository move from commitAndPushAll into project sensor selection', async () => {
     const root = await mkdtemp(nodePath.join(tmpdir(), 'run-stage-rename-selection-'));
-    const remote = nodePath.join(root, 'remote.git');
     const workspaceDir = nodePath.join(root, 'work');
     const git = (args, cwd) => runGit(args, { cwd });
+    const repos = ['acme/source', 'acme/destination'];
+    const remotes = Object.fromEntries(
+      repos.map((repo) => [repo, nodePath.join(root, `${repo.split('/').at(-1)}.git`)]),
+    );
 
     try {
-      await git(['init', '--bare', '-b', 'main', remote], root);
-      await git(['init', '-b', 'main', workspaceDir], root);
-      for (const project of ['source', 'destination']) {
-        await mkdir(nodePath.join(workspaceDir, 'packages', project, 'src'), { recursive: true });
+      for (const repo of repos) {
+        const project = repo.split('/').at(-1);
+        const projectDir = nodePath.join(workspaceDir, repo);
+        await git(['init', '--bare', '-b', 'main', remotes[repo]], root);
+        await mkdir(nodePath.join(projectDir, 'src'), { recursive: true });
+        await git(['init', '-b', 'main', projectDir], root);
+        await writeFile(nodePath.join(projectDir, 'tsconfig.json'), '{"compilerOptions":{}}\n');
         await writeFile(
-          nodePath.join(workspaceDir, 'packages', project, 'tsconfig.json'),
-          '{"compilerOptions":{}}\n',
-        );
-        await writeFile(
-          nodePath.join(workspaceDir, 'packages', project, 'src', `${project}-consumer.ts`),
+          nodePath.join(projectDir, 'src', `${project}-consumer.ts`),
           `export const ${project}Consumer = true;\n`,
         );
+        if (project === 'source') {
+          await writeFile(
+            nodePath.join(projectDir, 'src', 'provider.ts'),
+            'export const provider = true;\n',
+          );
+        }
+        await git(['add', '-A'], projectDir);
+        await git(
+          ['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'seed project'],
+          projectDir,
+        );
+        await git(['remote', 'add', 'origin', remotes[repo]], projectDir);
+        await git(['push', '-u', 'origin', 'main'], projectDir);
       }
-      const sourcePath = 'packages/source/src/provider.ts';
-      const destinationPath = 'packages/destination/src/provider.ts';
-      await writeFile(nodePath.join(workspaceDir, sourcePath), 'export const provider = true;\n');
-      await git(['add', '-A'], workspaceDir);
-      await git(
-        ['-c', 'user.name=test', '-c', 'user.email=t@t', 'commit', '-m', 'seed projects'],
-        workspaceDir,
+
+      const sourcePath = 'acme/source/src/provider.ts';
+      const destinationPath = 'acme/destination/src/provider.ts';
+      await rm(nodePath.join(workspaceDir, sourcePath));
+      await writeFile(
+        nodePath.join(workspaceDir, destinationPath),
+        'export const provider = true;\n',
       );
-      await git(['remote', 'add', 'origin', remote], workspaceDir);
-      await git(['push', '-u', 'origin', 'main'], workspaceDir);
-      await git(['mv', sourcePath, destinationPath], workspaceDir);
 
       const lib = library();
       lib.stagesById['requirements-analysis'].sensors = ['type-check'];
@@ -1182,7 +1194,7 @@ describe('runStage — deterministic sensors', () => {
         {
           ...baseArgs,
           workspaceDir,
-          repos: ['acme/monorepo'],
+          repos,
           branch: 'main',
           baseBranch: 'main',
           gitProvider: 'github',
@@ -1198,9 +1210,9 @@ describe('runStage — deterministic sensors', () => {
           commitAndPushAll: (args) =>
             runCommitAndPushAll({
               ...args,
-              urlsFor: () => ({
-                auth: remote,
-                clean: 'https://github.com/acme/monorepo.git',
+              urlsFor: (repo) => ({
+                auth: remotes[repo],
+                clean: `https://github.com/${repo}.git`,
               }),
             }),
         }),
@@ -1215,21 +1227,18 @@ describe('runStage — deterministic sensors', () => {
         detail: {
           scope: 'project',
           applicability: 'APPLICABLE',
-          provenance: {
-            state: 'known',
-            files: expect.arrayContaining([sourcePath, destinationPath]),
-          },
+          provenance: { state: 'known' },
         },
       });
-      expect(persisted.detail.provenance.files).toHaveLength(2);
-      expect(inspectedFiles).toEqual(
-        expect.arrayContaining([
-          'packages/source/src/source-consumer.ts',
-          'packages/destination/src/provider.ts',
-          'packages/destination/src/destination-consumer.ts',
-        ]),
-      );
-      expect(inspectedFiles).toHaveLength(3);
+      expect(persisted.detail.provenance.files).toEqual([destinationPath, sourcePath]);
+      expect(inspectedFiles).toEqual([
+        'acme/destination/src/destination-consumer.ts',
+        destinationPath,
+        'acme/source/src/source-consumer.ts',
+      ]);
+      expect(
+        inspectedFiles.every((file) => !file.match(/^acme\/(?:source|destination)\/acme\//)),
+      ).toBe(true);
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -1326,6 +1335,210 @@ describe('runStage — deterministic sensors', () => {
       const sinkPayload = JSON.stringify({ calls: store.calls, broadcasts });
       expect(sinkPayload).not.toContain(secretValue);
       expect(sinkPayload).not.toContain(credentialPath);
+    } finally {
+      await rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it('handles the original harness defect through production orchestration with explicit provenance', async () => {
+    const workspaceDir = await mkdtemp(
+      nodePath.join(tmpdir(), 'run-stage-production-sensor-regression-'),
+    );
+    const allFiles = ['src/changed-a.ts', 'src/changed-b.ts', 'src/unrelated.ts'];
+    const changedFiles = allFiles.slice(0, 2);
+    const secrets = ['first-private-value', 'second-private-value'];
+
+    try {
+      await mkdir(nodePath.join(workspaceDir, 'src'), { recursive: true });
+      await Promise.all(
+        allFiles.map((file) =>
+          writeFile(nodePath.join(workspaceDir, file), `export const value = '${file}';\n`),
+        ),
+      );
+
+      const lib = library();
+      lib.stagesById['requirements-analysis'].sensors = ['linter'];
+      lib.sensorsById = {
+        linter: {
+          id: 'linter',
+          command: 'bun x.ts',
+          runtime: 'bun',
+          severity: 'blocking',
+          matches: '**/*.ts',
+          verdictMode: 'stdout-json',
+          scope: 'file',
+          scriptRef: { s3Key: 'blocks/scripts/sha256/linter' },
+        },
+      };
+
+      const runScenario = async ({ provenance, sensorOutcome }) => {
+        const store = spyStore();
+        const broadcasts = [];
+        const inspectedFiles = [];
+        const spawnFn = (command, args) => {
+          const child = new EventEmitter();
+          child.stdin = { end() {} };
+          child.stdout = new EventEmitter();
+          child.stderr = new EventEmitter();
+          child.kill = () => {};
+          setImmediate(() => {
+            let exitCode = 0;
+            if (command === 'bun') {
+              const file = args[args.indexOf('--file-path') + 1];
+              inspectedFiles.push(file);
+              const outcome = sensorOutcome(file, inspectedFiles.length - 1);
+              if (outcome.stdout) child.stdout.emit('data', Buffer.from(outcome.stdout));
+              if (outcome.stderr) child.stderr.emit('data', Buffer.from(outcome.stderr));
+              exitCode = outcome.exitCode;
+            }
+            child.emit('close', exitCode);
+          });
+          return child;
+        };
+
+        const result = await runStage(
+          { ...baseArgs, workspaceDir },
+          baseDeps({
+            store,
+            spawnFn,
+            broadcast: async (payload) => broadcasts.push(payload),
+            env: {
+              BEDROCK_MODEL: 'us.anthropic.claude-sonnet-4-6',
+              PATH: '/usr/bin:/bin',
+              PRIMARY_API_TOKEN: secrets[0],
+              SECONDARY_API_TOKEN: secrets[1],
+            },
+            loadLibrary: async () => ({ workflow: workflow(), library: lib }),
+            loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+            commitAndPushAll: async () => ({
+              ok: true,
+              committed: true,
+              results: [{ repo: 'workspace', committed: true, pushed: true, provenance }],
+            }),
+          }),
+        );
+        const persisted = store.calls.find(
+          ([name, row]) => name === 'recordSensorRun' && row.sensorId === 'linter',
+        )?.[1];
+        return { result, persisted, inspectedFiles, store, broadcasts };
+      };
+
+      const known = await runScenario({
+        provenance: { state: 'known', files: changedFiles },
+        sensorOutcome: (_file, index) => ({
+          exitCode: 127,
+          stderr: `registry rejected ${secrets[index]}`,
+        }),
+      });
+
+      expect(known.result).toMatchObject({ ok: false, reason: 'sensor_blocked' });
+      expect(known.inspectedFiles.toSorted()).toEqual(changedFiles);
+      expect(known.persisted).toMatchObject({
+        result: 'INCONCLUSIVE',
+        held: true,
+        detail: {
+          scope: 'file',
+          applicability: 'APPLICABLE',
+          provenance: { state: 'known', files: changedFiles },
+          harnessFailures: [
+            {
+              reason: 'tool-unavailable',
+              result: 'INCONCLUSIVE',
+              exitCode: 127,
+              stderr: 'registry rejected [REDACTED]',
+              fileCount: 2,
+              sampleFiles: changedFiles,
+            },
+          ],
+        },
+      });
+      const knownSinks = JSON.stringify({ calls: known.store.calls, broadcasts: known.broadcasts });
+      expect(knownSinks).not.toMatch(/first-private-value|second-private-value/);
+
+      const genericFailure = await runScenario({
+        provenance: { state: 'known', files: [changedFiles[0]] },
+        sensorOutcome: () => ({
+          exitCode: 1,
+          stderr: `unable to load config using ${secrets[0]}`,
+        }),
+      });
+
+      expect(genericFailure.result).toMatchObject({ ok: false, reason: 'sensor_blocked' });
+      expect(genericFailure.inspectedFiles).toEqual([changedFiles[0]]);
+      expect(genericFailure.persisted).toMatchObject({
+        result: 'INCONCLUSIVE',
+        held: true,
+        detail: {
+          scope: 'file',
+          applicability: 'APPLICABLE',
+          provenance: { state: 'known', files: [changedFiles[0]] },
+          harnessFailures: [
+            {
+              reason: 'script-error',
+              result: 'INCONCLUSIVE',
+              exitCode: 1,
+              stderr: 'unable to load config using [REDACTED]',
+              fileCount: 1,
+              sampleFiles: [changedFiles[0]],
+            },
+          ],
+        },
+      });
+      const genericFailureSinks = JSON.stringify({
+        calls: genericFailure.store.calls,
+        broadcasts: genericFailure.broadcasts,
+      });
+      expect(genericFailureSinks).not.toContain(secrets[0]);
+
+      const unknown = await runScenario({
+        provenance: {
+          state: 'unknown',
+          reason: 'git_diff_failed',
+          detail: 'fatal: ambiguous revision',
+        },
+        sensorOutcome: () => ({
+          exitCode: 0,
+          stdout: `token=${secrets[0]} not-json`,
+          stderr: '',
+        }),
+      });
+
+      expect(unknown.result).toMatchObject({ ok: false, reason: 'sensor_blocked' });
+      expect(unknown.inspectedFiles.toSorted()).toEqual(allFiles);
+      expect(unknown.persisted).toMatchObject({
+        result: 'INCONCLUSIVE',
+        held: true,
+        detail: {
+          scope: 'file',
+          applicability: 'UNKNOWN',
+          provenance: {
+            state: 'unknown',
+            reason: 'workspace: git_diff_failed',
+            detail: 'fatal: ambiguous revision',
+          },
+        },
+      });
+      expect(unknown.persisted.detail.files).toHaveLength(allFiles.length);
+      expect(unknown.persisted.detail.files.map(({ file }) => file).toSorted()).toEqual(allFiles);
+      expect(unknown.persisted.detail.files).toEqual(
+        expect.arrayContaining(
+          allFiles.map((file) =>
+            expect.objectContaining({
+              file,
+              result: 'INCONCLUSIVE',
+              detail: expect.objectContaining({
+                reason: 'invalid-verdict',
+                stdout: 'token=[REDACTED] not-json',
+              }),
+            }),
+          ),
+        ),
+      );
+      const unknownSinks = JSON.stringify({
+        calls: unknown.store.calls,
+        broadcasts: unknown.broadcasts,
+      });
+      expect(unknownSinks).not.toContain(secrets[0]);
     } finally {
       await rm(workspaceDir, { recursive: true, force: true });
     }

--- a/lambda/agentcore/test/sensor-runner.test.js
+++ b/lambda/agentcore/test/sensor-runner.test.js
@@ -1,11 +1,24 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import { createSensorRunner, __test } from '../sensor-runner.js';
+import {
+  knownChangedFileProvenance,
+  unknownChangedFileProvenance,
+} from '../../shared/changed-file-provenance.js';
 
-const { globToRegExp, resultFromScript } = __test;
+const {
+  globToRegExp,
+  resultFromScript,
+  scopeToChangedFiles,
+  expandToAffectedProjects,
+  tailDiagnostic,
+  summarizeFileResults,
+  redactCredentialText,
+  sensitiveEnvironmentValues,
+} = __test;
 
 describe('globToRegExp', () => {
   it('matches a brace-alternation code glob', () => {
@@ -27,8 +40,373 @@ describe('resultFromScript', () => {
     expect(resultFromScript({ exitCode: 0, stdout: '{"pass":false}' }).result).toBe('FAIL');
     expect(resultFromScript({ exitCode: 0, stdout: '{"pass":true}' }).result).toBe('PASS');
   });
+
+  const oversizedDiagnostic = 'x'.repeat(5_000);
+  it.each([
+    ['empty output', '', 'missing-verdict'],
+    ['malformed JSON', `{"diagnostic":"${oversizedDiagnostic}`, 'invalid-verdict'],
+    [
+      'schema-invalid JSON',
+      JSON.stringify({ pass: 'PASS', diagnostic: oversizedDiagnostic }),
+      'invalid-verdict',
+    ],
+    [
+      'unsupported verdict',
+      JSON.stringify({ verdict: 'SKIP', diagnostic: oversizedDiagnostic }),
+      'invalid-verdict',
+    ],
+  ])('keeps successful stdout-json %s bounded and INCONCLUSIVE', (_label, stdout, reason) => {
+    const outcome = resultFromScript({
+      exitCode: 0,
+      stdout,
+      stderr: 'protocol failure',
+      verdictMode: 'stdout-json',
+    });
+
+    expect(outcome).toMatchObject({
+      result: 'INCONCLUSIVE',
+      detail: { reason, exitCode: 0, stderr: 'protocol failure' },
+    });
+    expect(Buffer.byteLength(JSON.stringify(outcome.detail), 'utf8')).toBeLessThanOrEqual(1_200);
+    expect(outcome.detail.stdout === null || outcome.detail.stdout.length <= 501).toBe(true);
+  });
+
+  it.each([
+    ['missing pass', '{}'],
+    ['non-boolean pass', '{"pass":"PASS"}'],
+    ['trailing output', '{"pass":true}\nunexpected output'],
+  ])('rejects successful stdout-json with %s', (_label, stdout) => {
+    expect(resultFromScript({ exitCode: 0, stdout, verdictMode: 'stdout-json' })).toMatchObject({
+      result: 'INCONCLUSIVE',
+      detail: { reason: 'invalid-verdict' },
+    });
+  });
+
+  it('accepts only boolean pass verdicts in strict stdout-json mode', () => {
+    expect(
+      resultFromScript({
+        exitCode: 0,
+        stdout: '{"pass":true,"findings_count":0}',
+        verdictMode: 'stdout-json',
+      }),
+    ).toEqual({
+      result: 'PASS',
+      detail: { pass: true, findings_count: 0 },
+    });
+    expect(
+      resultFromScript({
+        exitCode: 0,
+        stdout: '{"pass":false,"findings_count":1}',
+        verdictMode: 'stdout-json',
+      }),
+    ).toEqual({
+      result: 'FAIL',
+      detail: { pass: false, findings_count: 1 },
+    });
+  });
+
+  it('bounds invalid stdout-json protocol diagnostics', () => {
+    const stdout = `not-json-${'x'.repeat(5_000)}`;
+    const outcome = resultFromScript({
+      exitCode: 0,
+      stdout,
+      verdictMode: 'stdout-json',
+    });
+
+    expect(outcome.result).toBe('INCONCLUSIVE');
+    expect(outcome.detail.reason).toBe('invalid-verdict');
+    expect(outcome.detail.stdout).toHaveLength(501);
+    expect(outcome.detail.stdout).toBe(`…${stdout.slice(-500)}`);
+  });
+
   it('falls back to the exit code without JSON', () => {
     expect(resultFromScript({ exitCode: 2, stdout: '' }).result).toBe('INCONCLUSIVE');
+  });
+
+  it('classifies tool-unavailable as diagnostic INCONCLUSIVE', () => {
+    const outcome = resultFromScript({
+      exitCode: 127,
+      stdout: '',
+      stderr: 'tsc-unavailable\n',
+      verdictMode: 'stdout-json',
+    });
+    expect(outcome).toEqual({
+      result: 'INCONCLUSIVE',
+      detail: { reason: 'tool-unavailable', exitCode: 127, stderr: 'tsc-unavailable' },
+    });
+  });
+
+  it('classifies a stdout-json harness failure as INCONCLUSIVE', () => {
+    const outcome = resultFromScript({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'unable to load config',
+      verdictMode: 'stdout-json',
+    });
+    expect(outcome.result).toBe('INCONCLUSIVE');
+    expect(outcome.detail).toMatchObject({ reason: 'script-error', exitCode: 1 });
+  });
+
+  it('keeps classic non-zero-is-FAIL behavior for exit-code sensors', () => {
+    expect(
+      resultFromScript({ exitCode: 1, stdout: '', stderr: 'failure', verdictMode: 'exit-code' })
+        .result,
+    ).toBe('FAIL');
+  });
+});
+
+describe('changed-file sensor scoping', () => {
+  it('matches known workspace-relative paths exactly across repositories', () => {
+    expect(
+      scopeToChangedFiles(
+        ['acme/api/src/index.ts', 'acme/web/src/index.ts'],
+        knownChangedFileProvenance(['acme/api/src/index.ts']),
+      ),
+    ).toEqual(['acme/api/src/index.ts']);
+  });
+
+  it('distinguishes proven-empty provenance from an unknown Git failure', () => {
+    const globbed = ['acme/api/src/index.ts', 'acme/web/src/index.ts'];
+    expect(scopeToChangedFiles(globbed, knownChangedFileProvenance([]))).toEqual([]);
+    expect(
+      scopeToChangedFiles(
+        globbed,
+        unknownChangedFileProvenance('git_status_failed', 'fatal: status unavailable'),
+      ),
+    ).toEqual(globbed);
+  });
+
+  it('widens a changed provider to untouched files in the affected project', () => {
+    expect(
+      expandToAffectedProjects({
+        globbed: [
+          'packages/api/src/provider.ts',
+          'packages/api/src/consumer.ts',
+          'packages/web/src/page.ts',
+        ],
+        changed: ['packages/api/src/provider.ts'],
+        allFiles: [
+          'packages/api/tsconfig.json',
+          'packages/api/src/provider.ts',
+          'packages/api/src/consumer.ts',
+          'packages/web/tsconfig.json',
+          'packages/web/src/page.ts',
+        ],
+        configFile: 'tsconfig.json',
+      }),
+    ).toEqual(['packages/api/src/provider.ts', 'packages/api/src/consumer.ts']);
+  });
+
+  it('widens both projects when rename provenance crosses project boundaries', () => {
+    const globbed = [
+      'packages/api/src/api-consumer.ts',
+      'packages/web/src/moved-provider.ts',
+      'packages/web/src/web-consumer.ts',
+      'packages/docs/src/docs.ts',
+    ];
+    const allFiles = [
+      'packages/api/tsconfig.json',
+      'packages/api/src/api-consumer.ts',
+      'packages/web/tsconfig.json',
+      'packages/web/src/moved-provider.ts',
+      'packages/web/src/web-consumer.ts',
+      'packages/docs/tsconfig.json',
+      'packages/docs/src/docs.ts',
+    ];
+
+    expect(
+      expandToAffectedProjects({
+        globbed,
+        changed: ['packages/api/src/original-provider.ts', 'packages/web/src/moved-provider.ts'],
+        allFiles,
+        configFile: 'tsconfig.json',
+      }),
+    ).toEqual([
+      'packages/api/src/api-consumer.ts',
+      'packages/web/src/moved-provider.ts',
+      'packages/web/src/web-consumer.ts',
+    ]);
+  });
+});
+
+describe('sensor diagnostics', () => {
+  it('retains the tail of long stderr', () => {
+    expect(tailDiagnostic(`${'banner\n'.repeat(100)}actual error`)).toContain('actual error');
+    expect(tailDiagnostic('')).toBeNull();
+  });
+
+  it('redacts every Authorization scheme, known sensitive environment values, and credential paths', () => {
+    const sensitiveValues = sensitiveEnvironmentValues({
+      MCP_SERVER_TOKEN: 'opaque-mcp-value',
+      AWS_SHARED_CREDENTIALS_FILE: '/runtime/private/aws-credentials',
+      GIT_ASKPASS: '/runtime/private/git-askpass.sh',
+      TOKENIZERS_PARALLELISM: 'true',
+      UNRELATED_STATE: 'keep-visible',
+    });
+    const raw = [
+      'Authorization: Token scheme-secret-value',
+      'Proxy-Authorization: Digest digest-secret-value',
+      'tool echoed opaque-mcp-value',
+      'credentials at /runtime/private/aws-credentials',
+      'askpass at /runtime/private/git-askpass.sh',
+      'fallback at /home/node/.aws/credentials',
+      'ordinary true keep-visible',
+    ].join('\n');
+
+    const redacted = redactCredentialText(raw, sensitiveValues);
+
+    expect(redacted).toContain('Authorization: [REDACTED]');
+    expect(redacted).toContain('Proxy-Authorization: [REDACTED]');
+    expect(redacted).toContain('tool echoed [REDACTED]');
+    expect(redacted).toContain('credentials at [REDACTED]');
+    expect(redacted).toContain('askpass at [REDACTED]');
+    expect(redacted).toContain('fallback at [REDACTED]');
+    expect(redacted).toContain('ordinary true keep-visible');
+    for (const secret of [
+      'scheme-secret-value',
+      'digest-secret-value',
+      'opaque-mcp-value',
+      '/runtime/private/aws-credentials',
+      '/runtime/private/git-askpass.sh',
+      '/home/node/.aws/credentials',
+    ]) {
+      expect(redacted).not.toContain(secret);
+    }
+  });
+
+  it('deduplicates only after known environment-derived values are redacted', () => {
+    const sensitiveValues = sensitiveEnvironmentValues({
+      PRIMARY_API_TOKEN: 'first-private-value',
+      SECONDARY_API_TOKEN: 'second-private-value',
+    });
+    const detail = summarizeFileResults(
+      [
+        {
+          file: 'src/a.ts',
+          result: 'INCONCLUSIVE',
+          detail: {
+            reason: 'script-error',
+            exitCode: 1,
+            stderr: 'registry rejected first-private-value',
+          },
+        },
+        {
+          file: 'src/b.ts',
+          result: 'INCONCLUSIVE',
+          detail: {
+            reason: 'script-error',
+            exitCode: 1,
+            stderr: 'registry rejected second-private-value',
+          },
+        },
+      ],
+      sensitiveValues,
+    );
+
+    expect(detail.harnessFailures).toEqual([
+      expect.objectContaining({
+        fileCount: 2,
+        stderr: 'registry rejected [REDACTED]',
+        sampleFiles: ['src/a.ts', 'src/b.ts'],
+      }),
+    ]);
+    expect(JSON.stringify(detail)).not.toMatch(/first-private-value|second-private-value/);
+  });
+
+  it('deduplicates repeated harness failures with sample files', () => {
+    const detail = summarizeFileResults(
+      Array.from({ length: 20 }, (_, index) => ({
+        file: `src/file-${index}.ts`,
+        result: 'INCONCLUSIVE',
+        timedOut: false,
+        detail: { reason: 'script-error', exitCode: 1, stderr: 'same error' },
+      })),
+    );
+    expect(detail.harnessFailures).toHaveLength(1);
+    expect(detail.harnessFailures[0]).toMatchObject({ fileCount: 20, exitCode: 1 });
+    expect(detail.harnessFailures[0].sampleFiles).toHaveLength(5);
+  });
+
+  it('bounds mixed high-cardinality details with exact omission counts and stable ordering', () => {
+    const harnessEntries = Array.from({ length: 300 }, (_, index) => ({
+      file: `packages/harness/src/file-${String(index).padStart(4, '0')}.ts`,
+      result: 'INCONCLUSIVE',
+      timedOut: false,
+      detail: {
+        reason: 'script-error',
+        exitCode: 1,
+        stderr: `harness-${index % 3}-${'h'.repeat(300)}`,
+      },
+    }));
+    const fileEntries = Array.from({ length: 4_000 }, (_, index) => ({
+      file: `packages/project-${index % 11}/src/file-${String(index).padStart(4, '0')}.ts`,
+      result: 'FAIL',
+      timedOut: false,
+      detail: {
+        pass: false,
+        errors: [{ code: index, message: `diagnostic-${index}-${'d'.repeat(400)}` }],
+      },
+    }));
+    const entries = [...harnessEntries, ...fileEntries];
+
+    const detail = summarizeFileResults(entries);
+    const repeated = summarizeFileResults(entries);
+    const representedFiles =
+      (detail.files?.length ?? 0) +
+      (detail.harnessFailures?.reduce((total, failure) => total + failure.fileCount, 0) ?? 0);
+
+    expect(Buffer.byteLength(JSON.stringify(detail), 'utf8')).toBeLessThanOrEqual(120_000);
+    expect(detail.harnessFailures?.map((failure) => failure.stderr)).toEqual([
+      `harness-0-${'h'.repeat(300)}`,
+      `harness-1-${'h'.repeat(300)}`,
+      `harness-2-${'h'.repeat(300)}`,
+    ]);
+    expect(detail.harnessFailures?.[0].sampleFiles).toEqual([
+      'packages/harness/src/file-0000.ts',
+      'packages/harness/src/file-0003.ts',
+      'packages/harness/src/file-0006.ts',
+      'packages/harness/src/file-0009.ts',
+      'packages/harness/src/file-0012.ts',
+    ]);
+    expect(detail.files?.slice(0, 3).map((entry) => entry.file)).toEqual([
+      'packages/project-0/src/file-0000.ts',
+      'packages/project-1/src/file-0001.ts',
+      'packages/project-2/src/file-0002.ts',
+    ]);
+    expect(detail.filesOmitted).toBeGreaterThan(0);
+    expect(representedFiles + detail.filesOmitted).toBe(entries.length);
+    expect(detail.omissionReason).toBe('detail size budget');
+    expect(repeated).toEqual(detail);
+  });
+
+  it('processes high-cardinality details with one serialization per candidate before timeout', () => {
+    const entries = Array.from({ length: 20_000 }, (_, index) => ({
+      file: `packages/project-${index % 17}/src/file-${String(index).padStart(5, '0')}.ts`,
+      result: 'FAIL',
+      timedOut: false,
+      detail: {
+        pass: false,
+        errors: [{ code: index, message: `diagnostic-${index}-${'x'.repeat(300)}` }],
+      },
+    }));
+    const stringifySpy = vi.spyOn(JSON, 'stringify');
+    let detail;
+    let serializationCalls;
+    let elapsedMs;
+
+    try {
+      const startedAt = performance.now();
+      detail = summarizeFileResults(entries);
+      elapsedMs = performance.now() - startedAt;
+      serializationCalls = stringifySpy.mock.calls.length;
+    } finally {
+      stringifySpy.mockRestore();
+    }
+
+    expect(serializationCalls).toBe(entries.length);
+    expect(elapsedMs).toBeLessThan(4_000);
+    expect(Buffer.byteLength(JSON.stringify(detail), 'utf8')).toBeLessThanOrEqual(120_000);
+    expect((detail.files?.length ?? 0) + detail.filesOmitted).toBe(entries.length);
   });
 });
 
@@ -207,6 +585,95 @@ describe('runStageSensors — script kind', () => {
     expect(verdicts[0].detail.reason).toBe('no files match');
   });
 
+  it('holds a blocking sensor when a workspace directory cannot be read', async () => {
+    const readError = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+      workspaceDir: ws,
+      changedFileProvenance: knownChangedFileProvenance(['src/a.ts']),
+      fileListOptions: {
+        readdirFn: async () => {
+          throw readError;
+        },
+      },
+    });
+
+    const [verdict] = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'linter',
+          severity: 'blocking',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+
+    expect(verdict).toMatchObject({
+      result: 'INCONCLUSIVE',
+      applicability: 'UNKNOWN',
+      held: true,
+      detail: {
+        reason: 'workspace enumeration incomplete',
+        enumeration: {
+          complete: false,
+          scanned: 0,
+          cap: 5000,
+          reason: 'directory_read_failed',
+          failures: [{ directory: '.', code: 'EACCES' }],
+        },
+      },
+    });
+  });
+
+  it('holds a blocking sensor when the workspace walk reaches its file cap', async () => {
+    await writeFile(path.join(ws, 'a.ts'), 'export const a = true;');
+    await writeFile(path.join(ws, 'b.ts'), 'export const b = true;');
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+      workspaceDir: ws,
+      changedFileProvenance: knownChangedFileProvenance(['missing.ts']),
+      fileListOptions: { cap: 1 },
+      spawnFn: () => {
+        throw new Error('an incomplete selection must not spawn');
+      },
+    });
+
+    const [verdict] = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'linter',
+          severity: 'blocking',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+
+    expect(verdict).toMatchObject({
+      result: 'INCONCLUSIVE',
+      applicability: 'UNKNOWN',
+      held: true,
+      detail: {
+        reason: 'workspace enumeration incomplete',
+        enumeration: {
+          complete: false,
+          scanned: 1,
+          cap: 1,
+          reason: 'file_limit_exceeded',
+        },
+      },
+    });
+  });
+
   it('spawns the materialized script per matching file and reads its verdict', async () => {
     await mkdir(path.join(ws, 'src'), { recursive: true });
     await writeFile(path.join(ws, 'src', 'a.ts'), 'export const x = 1;');
@@ -235,6 +702,280 @@ describe('runStageSensors — script kind', () => {
     });
     expect(verdicts[0]).toMatchObject({ kind: 'script', result: 'PASS', held: false });
     expect(verdicts[0].detail.files[0].file).toBe('src/a.ts');
+  });
+
+  it('runs a blocking sensor across every match when changed-file provenance is unknown', async () => {
+    await mkdir(path.join(ws, 'src'), { recursive: true });
+    await writeFile(path.join(ws, 'src', 'a.ts'), 'export const a = 1;');
+    await writeFile(path.join(ws, 'src', 'b.ts'), 'export const b = 2;');
+    let spawnCalls = 0;
+    const emitPass = fakeSpawn('{"pass":true}');
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+      workspaceDir: ws,
+      changedFileProvenance: unknownChangedFileProvenance(
+        'git_diff_failed',
+        'fatal: revision unavailable',
+      ),
+      spawnFn: (...args) => {
+        spawnCalls += 1;
+        return emitPass(...args);
+      },
+    });
+
+    const [verdict] = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'linter',
+          severity: 'blocking',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          verdictMode: 'stdout-json',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+
+    expect(spawnCalls).toBe(2);
+    expect(verdict).toMatchObject({
+      result: 'PASS',
+      applicability: 'UNKNOWN',
+      held: false,
+      detail: {
+        applicability: 'UNKNOWN',
+        provenance: {
+          state: 'unknown',
+          reason: 'git_diff_failed',
+          detail: 'fatal: revision unavailable',
+        },
+        files: [{ file: 'src/a.ts' }, { file: 'src/b.ts' }],
+      },
+    });
+  });
+
+  it('does not materialize or run a blocking sensor for a definitively inapplicable change set', async () => {
+    await mkdir(path.join(ws, 'src'), { recursive: true });
+    await writeFile(path.join(ws, 'src', 'a.ts'), 'export const a = 1;');
+    let scriptLoads = 0;
+    let spawnCalls = 0;
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => {
+        scriptLoads += 1;
+        return 'SENSOR_SCRIPT_BODY';
+      },
+      workspaceDir: ws,
+      changedFileProvenance: knownChangedFileProvenance(['README.md']),
+      spawnFn: () => {
+        spawnCalls += 1;
+        throw new Error('definitively inapplicable sensors must not spawn');
+      },
+    });
+
+    const [verdict] = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'linter',
+          severity: 'blocking',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          verdictMode: 'stdout-json',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'documentation',
+    });
+
+    expect(scriptLoads).toBe(0);
+    expect(spawnCalls).toBe(0);
+    expect(verdict).toMatchObject({
+      result: 'INCONCLUSIVE',
+      applicability: 'NOT_APPLICABLE',
+      held: false,
+      detail: {
+        reason: 'no changed files match',
+        applicability: 'NOT_APPLICABLE',
+        provenance: { state: 'known', files: ['README.md'] },
+        globbed: 1,
+        changed: 1,
+      },
+    });
+  });
+
+  it('passes only harness-required environment variables to sensor children', async () => {
+    await writeFile(path.join(ws, 'a.ts'), 'export const x = 1;');
+    let spawnOptions;
+    const emitPass = fakeSpawn('{"pass":true}');
+    const captureSpawn = (file, args, options) => {
+      spawnOptions = options;
+      return emitPass(file, args, options);
+    };
+    const requiredEnv = {
+      PATH: '/opt/bun/bin:/usr/bin:/bin',
+      HOME: '/home/node',
+      TMPDIR: '/sensor-tmp',
+      TMP: '/sensor-tmp',
+      TEMP: '/sensor-tmp',
+      LANG: 'C.UTF-8',
+      LC_ALL: 'C.UTF-8',
+      LC_CTYPE: 'C.UTF-8',
+      TZ: 'UTC',
+    };
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+      workspaceDir: ws,
+      spawnFn: captureSpawn,
+      childEnv: {
+        ...requiredEnv,
+        AIDLC_GIT_USERNAME: 'x-access-token',
+        AIDLC_GIT_PASSWORD: 'repository-secret',
+        AWS_ACCESS_KEY_ID: 'access-key',
+        AWS_SECRET_ACCESS_KEY: 'aws-secret',
+        AWS_SESSION_TOKEN: 'session-token',
+        AWS_BEARER_TOKEN_BEDROCK: 'bedrock-token',
+        GITHUB_TOKEN: 'github-token',
+        KIRO_API_KEY: 'kiro-token',
+        MCP_SERVER_TOKEN: 'mcp-token',
+        HTTP_PROXY: 'http://user:password@proxy.example',
+        NODE_OPTIONS: '--require /untrusted/hook.cjs',
+        XDG_DATA_HOME: '/home/node/.agent-state',
+        UNRELATED_PROCESS_STATE: 'do-not-forward',
+      },
+    });
+
+    const [verdict] = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'linter',
+          severity: 'blocking',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+
+    expect(verdict).toMatchObject({ result: 'PASS', held: false });
+    expect(spawnOptions).toMatchObject({ cwd: ws, shell: false });
+    expect(spawnOptions.env).toEqual(requiredEnv);
+  });
+
+  it('emits only redacted harness details to persistence and rendering consumers', async () => {
+    await writeFile(path.join(ws, 'a.ts'), 'export const a = 1;');
+    await writeFile(path.join(ws, 'b.ts'), 'export const b = 2;');
+    const diagnostics = [
+      'Authorization: Token first-private-value\ncredential file /runtime/private/first-creds',
+      'Authorization: Digest second-private-value\ncredential file /runtime/private/second-creds',
+    ];
+    let spawned = 0;
+    const spawnFailure = () => {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {};
+      const diagnostic = diagnostics[spawned++];
+      setTimeout(() => {
+        child.stderr.emit('data', Buffer.from(diagnostic));
+        child.emit('close', 1);
+      }, 0);
+      return child;
+    };
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+      workspaceDir: ws,
+      spawnFn: spawnFailure,
+      childEnv: {
+        PATH: '/usr/bin:/bin',
+        PRIMARY_API_TOKEN: 'first-private-value',
+        SECONDARY_API_TOKEN: 'second-private-value',
+        AWS_SHARED_CREDENTIALS_FILE: '/runtime/private/first-creds',
+        GOOGLE_APPLICATION_CREDENTIALS: '/runtime/private/second-creds',
+      },
+    });
+
+    const [verdict] = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'type-check',
+          severity: 'advisory',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+
+    expect(verdict.detail.harnessFailures).toEqual([
+      expect.objectContaining({
+        fileCount: 2,
+        stderr: 'Authorization: [REDACTED]\ncredential file [REDACTED]',
+        sampleFiles: ['a.ts', 'b.ts'],
+      }),
+    ]);
+    expect(JSON.stringify(verdict)).not.toMatch(
+      /first-private-value|second-private-value|\/runtime\/private\/(?:first|second)-creds/,
+    );
+  });
+
+  it('uses a stdout-json sensor verdict mode for harness failures', async () => {
+    await writeFile(path.join(ws, 'a.ts'), 'export const x = 1;');
+    const spawnFailure = () => {
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      child.kill = () => {};
+      setTimeout(() => {
+        child.stderr.emit('data', Buffer.from('unable to load tsconfig'));
+        child.emit('close', 1);
+      }, 0);
+      return child;
+    };
+    const runner = createSensorRunner({
+      graph: null,
+      loadBlockScript: async () => 'SENSOR_SCRIPT_BODY',
+      workspaceDir: ws,
+      spawnFn: spawnFailure,
+      changedFileProvenance: unknownChangedFileProvenance(
+        'git_status_failed',
+        'fatal: status unavailable',
+      ),
+    });
+    const verdicts = await runner.runStageSensors({
+      sensors: [
+        {
+          sensorId: 'type-check',
+          severity: 'advisory',
+          runtime: 'bun',
+          command: 'bun x.ts',
+          matches: '**/*.ts',
+          timeoutSeconds: 5,
+        },
+      ],
+      stageId: 'code-generation',
+    });
+
+    expect(verdicts[0].result).toBe('INCONCLUSIVE');
+    expect(verdicts[0].detail.provenance).toEqual({
+      state: 'unknown',
+      reason: 'git_status_failed',
+      detail: 'fatal: status unavailable',
+    });
+    expect(verdicts[0].detail.harnessFailures).toHaveLength(1);
+    expect(verdicts[0].detail.harnessFailures[0]).toMatchObject({
+      reason: 'script-error',
+      exitCode: 1,
+      stderr: 'unable to load tsconfig',
+    });
   });
 
   it('BLOCKED when a script sensor has no script bytes', async () => {

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -5005,6 +5005,7 @@ const mapFeedbackBatch = (batch) => ({
   requestedByName: batch.requestedByName ?? null,
   stageInstanceId: batch.stageInstanceId ?? null,
   output: batch.output ?? null,
+  changedFileProvenance: batch.changedFileProvenance ?? null,
   changedFiles: batch.changedFiles ?? null,
   verification: batch.verification ?? null,
   commitSha: batch.commitSha ?? null,

--- a/lambda/shared/changed-file-provenance.js
+++ b/lambda/shared/changed-file-provenance.js
@@ -1,0 +1,54 @@
+// Changed-file provenance shared by Git collection, stage orchestration, and
+// sensor selection. An empty known list means "proved no files changed";
+// unknown always carries a collection-failure reason and widens sensor checks.
+
+export const knownChangedFileProvenance = (files = []) => ({
+  state: 'known',
+  files: [...files],
+});
+
+export const unknownChangedFileProvenance = (reason, detail = null) => ({
+  state: 'unknown',
+  reason: typeof reason === 'string' && reason.trim() ? reason.trim() : 'unspecified',
+  ...(detail ? { detail: String(detail) } : {}),
+});
+
+export const normalizeChangedFileProvenance = (provenance) => {
+  if (provenance?.state === 'known' && Array.isArray(provenance.files)) {
+    return knownChangedFileProvenance(provenance.files);
+  }
+  if (provenance?.state === 'unknown') {
+    return unknownChangedFileProvenance(provenance.reason, provenance.detail);
+  }
+  return unknownChangedFileProvenance('invalid_or_missing_provenance');
+};
+
+export const mapKnownChangedFiles = (provenance, mapFile) => {
+  const normalized = normalizeChangedFileProvenance(provenance);
+  if (normalized.state === 'unknown') return normalized;
+  return knownChangedFileProvenance(normalized.files.map(mapFile));
+};
+
+export const mergeChangedFileProvenance = (entries = []) => {
+  const normalized = entries.map(({ source = null, provenance }) => ({
+    source,
+    provenance: normalizeChangedFileProvenance(provenance),
+  }));
+  const unknown = normalized.filter((entry) => entry.provenance.state === 'unknown');
+  if (unknown.length > 0) {
+    const reason = [
+      ...new Set(
+        unknown.map(({ source, provenance }) =>
+          source ? `${source}: ${provenance.reason}` : provenance.reason,
+        ),
+      ),
+    ].join('; ');
+    const detail = [
+      ...new Set(unknown.map(({ provenance }) => provenance.detail).filter(Boolean)),
+    ].join('; ');
+    return unknownChangedFileProvenance(reason, detail || null);
+  }
+  return knownChangedFileProvenance(
+    [...new Set(normalized.flatMap(({ provenance }) => provenance.files))].toSorted(),
+  );
+};

--- a/lambda/shared/test/v2-execution-plan.test.js
+++ b/lambda/shared/test/v2-execution-plan.test.js
@@ -349,6 +349,96 @@ describe('buildExecutionPlan — plan shape', () => {
     expect(plan.stages[0].sensors[0].scriptRef).toBeNull();
   });
 
+  it('threads validated verdict mode, scope, and normalized project config into the plan', () => {
+    const lib = baseLibrary({
+      stagesById: { a: stage('a', { sensors: ['custom-checker'] }) },
+      sensorsById: {
+        'custom-checker': {
+          command: 'custom-checker.ts',
+          severity: 'advisory',
+          runtime: 'bun',
+          verdictMode: 'stdout-json',
+          scope: 'project',
+          projectConfig: 'config/pyproject.toml',
+        },
+      },
+    });
+    const { valid, errors, plan } = buildExecutionPlan({
+      workflow: workflow([placement('a')]),
+      scope: 'feature',
+      library: lib,
+    });
+    expect(valid).toBe(true);
+    expect(errors).toEqual([]);
+    expect(plan.stages[0].sensors[0]).toMatchObject({
+      verdictMode: 'stdout-json',
+      scope: 'project',
+      projectConfig: 'config/pyproject.toml',
+    });
+  });
+
+  it.each([
+    ['verdictMode', 'yaml', 'sensor_invalid_verdict_mode'],
+    ['scope', 'workspace', 'sensor_invalid_scope'],
+  ])('rejects an unsupported sensor %s while building the plan', (field, value, code) => {
+    const lib = baseLibrary({
+      stagesById: { a: stage('a', { sensors: ['custom-checker'] }) },
+      sensorsById: {
+        'custom-checker': {
+          command: 'custom-checker.ts',
+          runtime: 'bun',
+          [field]: value,
+        },
+      },
+    });
+    const { valid, errors, plan } = buildExecutionPlan({
+      workflow: workflow([placement('a')]),
+      scope: 'feature',
+      library: lib,
+    });
+
+    expect(valid).toBe(false);
+    expect(errors.find((error) => error.code === code)).toMatchObject({
+      stageId: 'a',
+      ref: 'custom-checker',
+      field,
+    });
+    expect(plan.stages[0].sensors[0][field]).not.toBe(value);
+  });
+
+  it.each([
+    ['absolute path', '/etc/tsconfig.json'],
+    ['Windows absolute path', 'C:\\secrets\\tsconfig.json'],
+    ['parent traversal', '../tsconfig.json'],
+    ['nested parent traversal', 'config/../../tsconfig.json'],
+    ['non-normalized traversal', 'config/../tsconfig.json'],
+  ])('rejects a sensor projectConfig containing %s', (_label, projectConfig) => {
+    const lib = baseLibrary({
+      stagesById: { a: stage('a', { sensors: ['custom-checker'] }) },
+      sensorsById: {
+        'custom-checker': {
+          command: 'custom-checker.ts',
+          runtime: 'bun',
+          scope: 'project',
+          projectConfig,
+        },
+      },
+    });
+    const { valid, errors, plan } = buildExecutionPlan({
+      workflow: workflow([placement('a')]),
+      scope: 'feature',
+      library: lib,
+    });
+
+    expect(valid).toBe(false);
+    expect(errors.find((error) => error.code === 'sensor_invalid_project_config')).toMatchObject({
+      stageId: 'a',
+      ref: 'custom-checker',
+      field: 'projectConfig',
+    });
+    expect(plan.stages[0].sensors[0].projectConfig).toBe('tsconfig.json');
+  });
+
   it('flags agent-team as not implemented without crashing', () => {
     const lib = baseLibrary({ stagesById: { a: stage('a', { mode: 'agent-team' }) } });
     const { plan } = buildExecutionPlan({

--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -1077,6 +1077,8 @@ describe('unit keys + builders', () => {
     expect(feedback).toMatchObject({
       sk: 'FEEDBACK#S2#auth#b1',
       state: 'QUEUED',
+      changedFileProvenance: null,
+      changedFiles: null,
       GSI2SK: 'TYPE#FEEDBACK#STATE#QUEUED#S2#auth#b1',
     });
   });

--- a/lambda/shared/test/v2-sensor-contract.test.js
+++ b/lambda/shared/test/v2-sensor-contract.test.js
@@ -5,6 +5,10 @@ import {
   severityGate,
   validateScriptSpec,
   resultFromExit,
+  TOOL_UNAVAILABLE_EXIT,
+  sensorVerdictMode,
+  sensorScope,
+  projectConfigFile,
   buildScriptArgv,
   evalRequiredSections,
   evalUpstreamCoverage,
@@ -70,6 +74,42 @@ describe('validateScriptSpec', () => {
   it('rejects an empty command', () => {
     expect(validateScriptSpec({ runtime: 'bun', command: '  ', timeoutSeconds: 5 }).ok).toBe(false);
   });
+
+  it.each([
+    ['verdictMode', 'yaml', /unsupported verdictMode/],
+    ['scope', 'workspace', /unsupported scope/],
+  ])('rejects an unsupported %s before a sensor can run', (field, value, error) => {
+    const result = validateScriptSpec({
+      sensorId: 'custom-checker',
+      runtime: 'bun',
+      command: 'bun checker.ts',
+      timeoutSeconds: 5,
+      [field]: value,
+    });
+
+    expect(result).toEqual({ ok: false, error: expect.stringMatching(error) });
+  });
+
+  it.each([
+    ['/etc/tsconfig.json', 'POSIX absolute path'],
+    ['C:\\secrets\\tsconfig.json', 'Windows absolute path'],
+    ['../tsconfig.json', 'parent traversal'],
+    ['config/../../tsconfig.json', 'nested parent traversal'],
+  ])('rejects unsafe projectConfig %s (%s)', (projectConfig) => {
+    const result = validateScriptSpec({
+      sensorId: 'type-check',
+      runtime: 'bun',
+      command: 'bun type-check.ts',
+      timeoutSeconds: 5,
+      scope: 'project',
+      projectConfig,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'projectConfig must be a normalized safe relative path',
+    });
+  });
 });
 
 describe('resultFromExit', () => {
@@ -78,6 +118,26 @@ describe('resultFromExit', () => {
     expect(resultFromExit(2)).toBe(SENSOR_RESULT.INCONCLUSIVE);
     expect(resultFromExit(1)).toBe(SENSOR_RESULT.FAIL);
     expect(resultFromExit(null)).toBe(SENSOR_RESULT.BLOCKED);
+  });
+});
+
+describe('sensor script metadata', () => {
+  it('classifies the reserved tool-unavailable exit as INCONCLUSIVE', () => {
+    expect(TOOL_UNAVAILABLE_EXIT).toBe(127);
+    expect(resultFromExit(TOOL_UNAVAILABLE_EXIT)).toBe(SENSOR_RESULT.INCONCLUSIVE);
+  });
+
+  it('uses explicit declarations and backward-compatible upstream defaults', () => {
+    expect(sensorVerdictMode({ sensorId: 'custom', verdictMode: 'stdout-json' })).toBe(
+      'stdout-json',
+    );
+    expect(sensorVerdictMode({ sensorId: 'linter' })).toBe('stdout-json');
+    expect(sensorVerdictMode({ sensorId: 'custom' })).toBe('exit-code');
+    expect(sensorScope({ sensorId: 'type-check' })).toBe('project');
+    expect(sensorScope({ sensorId: 'linter' })).toBe('file');
+    expect(sensorScope({ sensorId: 'linter', scope: 'project' })).toBe('project');
+    expect(projectConfigFile({ projectConfig: 'jsconfig.json' })).toBe('jsconfig.json');
+    expect(projectConfigFile({})).toBe('tsconfig.json');
   });
 });
 

--- a/lambda/shared/v2-execution-plan.js
+++ b/lambda/shared/v2-execution-plan.js
@@ -22,6 +22,7 @@
 
 import { createHash } from 'node:crypto';
 import { compileStageGraph, compileRules } from './compile.js';
+import { validateSensorContractFields } from './v2-sensor-contract.js';
 import { stageSkipBlockReason } from './stage-skip.js';
 
 // Stage modes the runtime can actually execute. `agent-team` is known but not
@@ -206,6 +207,16 @@ const resolveSensors = (stage, stageId, sensorsById, errors) =>
           err('sensor_missing_command', `sensor "${sid}" has no command`, { stageId, ref: sid }),
         );
       }
+      const contract = validateSensorContractFields({ ...sensor, sensorId: sid });
+      for (const issue of contract.errors) {
+        errors.push(
+          err(issue.code, `sensor "${sid}" ${issue.message}`, {
+            stageId,
+            ref: sid,
+            field: issue.field,
+          }),
+        );
+      }
       return {
         sensorId: sid,
         severity: sensor.severity ?? 'advisory',
@@ -215,6 +226,7 @@ const resolveSensors = (stage, stageId, sensorsById, errors) =>
         category: sensor.category ?? null,
         matches: sensor.matches ?? null,
         scriptRef: sensor.scriptRef ?? null,
+        ...contract.fields,
       };
     })
     .filter(Boolean);

--- a/lambda/shared/v2-process-keys.js
+++ b/lambda/shared/v2-process-keys.js
@@ -972,6 +972,7 @@ const buildFeedbackBatchRow = ({
   requestedByName,
   stageInstanceId: null,
   output: null,
+  changedFileProvenance: null,
   changedFiles: null,
   verification: null,
   commitSha: null,

--- a/lambda/shared/v2-sensor-contract.js
+++ b/lambda/shared/v2-sensor-contract.js
@@ -41,6 +41,16 @@ const SENSOR_RESULT = Object.freeze({
 });
 const SENSOR_RESULTS = Object.freeze(Object.values(SENSOR_RESULT));
 
+// Applicability is independent of a sensor's execution result. A sensor can be
+// definitively irrelevant to a known change set, or its relevance can be
+// unknown because changed-file provenance could not be collected. Only the
+// former may bypass a blocking severity gate.
+const SENSOR_APPLICABILITY = Object.freeze({
+  APPLICABLE: 'APPLICABLE',
+  NOT_APPLICABLE: 'NOT_APPLICABLE',
+  UNKNOWN: 'UNKNOWN',
+});
+
 // Runtime allowlist for the `script` kind — DELIBERATELY narrow. The baseline
 // code sensors ship `runtime: 'bun'`; `sh`/`node` are allowed for shell-form or
 // node deterministic checks. An unknown runtime is rejected (BLOCKED) so a
@@ -67,15 +77,104 @@ const sensorKind = (sensor) => {
   return GRAPH_SENSORS.includes(sensor.sensorId ?? sensor.id) ? 'graph' : 'script';
 };
 
-// Does a result + severity let the stage continue? Only a `blocking` sensor that
-// did not PASS holds the stage. An `advisory` sensor NEVER holds (it records a
-// note and the stage continues). BLOCKED/INCONCLUSIVE are non-PASS but only bite
-// when the sensor is blocking — an advisory tool-unavailable must not wedge a run.
-const severityGate = (result, severity) => {
+// Does a result + severity let the stage continue? A definitively irrelevant
+// sensor never holds a stage. Unknown applicability is deliberately NOT treated
+// as a skip: a blocking sensor still requires PASS after the runner widens its
+// selection to the full checkout. Advisory sensors never hold.
+const severityGate = (result, severity, applicability = SENSOR_APPLICABILITY.APPLICABLE) => {
+  if (applicability === SENSOR_APPLICABILITY.NOT_APPLICABLE) {
+    return { continues: true, held: false };
+  }
   const passed = result === SENSOR_RESULT.PASS;
   if (severity === 'blocking') return { continues: passed, held: !passed };
   return { continues: true, held: false };
 };
+
+const TOOL_UNAVAILABLE_EXIT = 127;
+const SENSOR_VERDICT_MODES = Object.freeze(['stdout-json', 'exit-code']);
+const STDOUT_JSON_SENSORS = Object.freeze(['linter', 'type-check']);
+const SENSOR_SCOPES = Object.freeze(['file', 'project']);
+const PROJECT_SCOPED_SENSORS = Object.freeze(['type-check']);
+const DEFAULT_PROJECT_CONFIG = 'tsconfig.json';
+
+const defaultVerdictMode = (sensor) =>
+  STDOUT_JSON_SENSORS.includes(sensor?.sensorId ?? sensor?.id) ? 'stdout-json' : 'exit-code';
+const defaultScope = (sensor) =>
+  PROJECT_SCOPED_SENSORS.includes(sensor?.sensorId ?? sensor?.id) ? 'project' : 'file';
+
+// A project config is interpreted relative to each detected project root. Keep
+// the accepted representation canonical and platform-independent so joining it
+// to a project root can never select an absolute path or escape that root.
+const validateProjectConfig = (value) => {
+  const invalid = (message) => ({ ok: false, error: message, value: DEFAULT_PROJECT_CONFIG });
+  if (value == null) return { ok: true, value: DEFAULT_PROJECT_CONFIG };
+  if (typeof value !== 'string' || value.length === 0) {
+    return invalid('projectConfig must be a non-empty relative path');
+  }
+  if (
+    value.includes('\\') ||
+    value.includes('\0') ||
+    value.startsWith('/') ||
+    /^[A-Za-z]:/.test(value)
+  ) {
+    return invalid('projectConfig must be a normalized safe relative path');
+  }
+  const segments = value.split('/');
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    return invalid('projectConfig must be a normalized safe relative path');
+  }
+  return { ok: true, value };
+};
+
+// Validate the fields shared by plan construction and runtime execution. The
+// returned fields are always safe defaults or validated declarations, even when
+// errors are present, so invalid authored values are never copied into a plan.
+const validateSensorContractFields = (sensor = {}) => {
+  sensor = sensor && typeof sensor === 'object' ? sensor : {};
+  const errors = [];
+  let verdictMode = defaultVerdictMode(sensor);
+  if (sensor.verdictMode != null) {
+    if (SENSOR_VERDICT_MODES.includes(sensor.verdictMode)) verdictMode = sensor.verdictMode;
+    else {
+      errors.push({
+        field: 'verdictMode',
+        code: 'sensor_invalid_verdict_mode',
+        message: `unsupported verdictMode "${sensor.verdictMode}"; allowed: ${SENSOR_VERDICT_MODES.join(', ')}`,
+      });
+    }
+  }
+
+  let scope = defaultScope(sensor);
+  if (sensor.scope != null) {
+    if (SENSOR_SCOPES.includes(sensor.scope)) scope = sensor.scope;
+    else {
+      errors.push({
+        field: 'scope',
+        code: 'sensor_invalid_scope',
+        message: `unsupported scope "${sensor.scope}"; allowed: ${SENSOR_SCOPES.join(', ')}`,
+      });
+    }
+  }
+
+  const projectConfig = validateProjectConfig(sensor.projectConfig);
+  if (!projectConfig.ok) {
+    errors.push({
+      field: 'projectConfig',
+      code: 'sensor_invalid_project_config',
+      message: projectConfig.error,
+    });
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    fields: { verdictMode, scope, projectConfig: projectConfig.value },
+  };
+};
+
+const sensorVerdictMode = (sensor) => validateSensorContractFields(sensor).fields.verdictMode;
+const sensorScope = (sensor) => validateSensorContractFields(sensor).fields.scope;
+const projectConfigFile = (sensor) => validateSensorContractFields(sensor).fields.projectConfig;
 
 // Validate + normalize a script-sensor's run spec, or return an error. Mirrors
 // the old v2-script-contract: `command` is SERVER-CONTROLLED (from the block),
@@ -96,6 +195,9 @@ const validateScriptSpec = (sensor) => {
   if (!Number.isFinite(seconds) || seconds <= 0) {
     return { ok: false, error: 'sensor timeout must be a positive number of seconds' };
   }
+  const contract = validateSensorContractFields(sensor);
+  if (!contract.ok) return { ok: false, error: contract.errors[0].message };
+
   return {
     ok: true,
     spec: {
@@ -103,6 +205,7 @@ const validateScriptSpec = (sensor) => {
       runtime,
       command: sensor.command,
       timeoutMs: Math.min(seconds, MAX_TIMEOUT_SECONDS) * 1000,
+      ...contract.fields,
     },
   };
 };
@@ -113,7 +216,7 @@ const validateScriptSpec = (sensor) => {
 // exit code alone: 0 PASS, 2 INCONCLUSIVE, null BLOCKED, else FAIL.
 const resultFromExit = (exitCode) => {
   if (exitCode === 0) return SENSOR_RESULT.PASS;
-  if (exitCode === 2) return SENSOR_RESULT.INCONCLUSIVE;
+  if (exitCode === 2 || exitCode === TOOL_UNAVAILABLE_EXIT) return SENSOR_RESULT.INCONCLUSIVE;
   if (exitCode === null || exitCode === undefined) return SENSOR_RESULT.BLOCKED;
   return SENSOR_RESULT.FAIL;
 };
@@ -443,9 +546,17 @@ const parseBoltDag = (body) => {
 export {
   SENSOR_RESULT,
   SENSOR_RESULTS,
+  SENSOR_APPLICABILITY,
   ALLOWED_SCRIPT_RUNTIMES,
   MAX_TIMEOUT_SECONDS,
   DEFAULT_TIMEOUT_SECONDS,
+  TOOL_UNAVAILABLE_EXIT,
+  SENSOR_VERDICT_MODES,
+  SENSOR_SCOPES,
+  validateSensorContractFields,
+  sensorVerdictMode,
+  sensorScope,
+  projectConfigFile,
   GRAPH_SENSORS,
   sensorKind,
   severityGate,
@@ -460,9 +571,17 @@ export {
 export default {
   SENSOR_RESULT,
   SENSOR_RESULTS,
+  SENSOR_APPLICABILITY,
   ALLOWED_SCRIPT_RUNTIMES,
   MAX_TIMEOUT_SECONDS,
   DEFAULT_TIMEOUT_SECONDS,
+  TOOL_UNAVAILABLE_EXIT,
+  SENSOR_VERDICT_MODES,
+  SENSOR_SCOPES,
+  validateSensorContractFields,
+  sensorVerdictMode,
+  sensorScope,
+  projectConfigFile,
   GRAPH_SENSORS,
   sensorKind,
   severityGate,

--- a/lambda/v2-orchestrator/section.js
+++ b/lambda/v2-orchestrator/section.js
@@ -50,6 +50,7 @@
 // wakes: a superseded gate (cancel/rewind) retires the run with NO writes.
 
 import processKeysPkg from '../shared/v2-process-keys.js';
+import { normalizeChangedFileProvenance } from '../shared/changed-file-provenance.js';
 import { stageIsNoopForUnit } from '../shared/unit-kind-pruning.js';
 import { buildIntentAttribution } from './pr-attribution.js';
 
@@ -1021,6 +1022,13 @@ export const runParallelSection = async (segment, toolkit) => {
       }
 
       const result = revision.result ?? {};
+      const changedFileProvenance = normalizeChangedFileProvenance(result.changedFileProvenance);
+      const changedFiles =
+        changedFileProvenance.state === 'known' ? changedFileProvenance.files : null;
+      const changedFilesSummary =
+        changedFileProvenance.state === 'known'
+          ? changedFiles.join(', ') || 'none'
+          : `unknown (${changedFileProvenance.reason})`;
       const refs = (next.comments ?? [])
         .map((comment) => `${comment.repository}#${comment.prNumber}:${comment.id}`)
         .join(', ');
@@ -1029,7 +1037,7 @@ export const runParallelSection = async (segment, toolkit) => {
         marker,
         '',
         `Handled comments: ${refs}`,
-        `Changed files: ${(result.changedFiles ?? []).join(', ') || 'none'}`,
+        `Changed files: ${changedFilesSummary}`,
         `Verification: ${result.verification ?? 'stage completed'}`,
         `Commit: ${result.commitSha ?? 'no new commit'}`,
       ].join('\n');
@@ -1057,7 +1065,8 @@ export const runParallelSection = async (segment, toolkit) => {
           fromStates: ['RUNNING'],
           fields: {
             output: summary,
-            changedFiles: result.changedFiles ?? [],
+            changedFileProvenance,
+            changedFiles,
             verification: result.verification ?? 'Stage completed',
             commitSha: result.commitSha ?? null,
           },

--- a/lambda/v2-orchestrator/section.js
+++ b/lambda/v2-orchestrator/section.js
@@ -116,6 +116,24 @@ const isIntegratedUnitPr = (row) => row?.state === 'MERGED' || row?.state === 'P
 export const laneSessionIdFor = (intentId, sectionIndex, slug) =>
   `aidlc-intent-${intentId}-s${sectionIndex}-${slug}`.padEnd(33, '0');
 
+export const feedbackChangedFileReport = (result = {}) => {
+  // Explicit provenance is authoritative. Older stage results may only carry
+  // changedFiles; preserve those as known provenance without allowing an
+  // explicit unknown state to collapse back to a file list.
+  const changedFileProvenance = normalizeChangedFileProvenance(
+    result.changedFileProvenance ??
+      (Array.isArray(result.changedFiles)
+        ? { state: 'known', files: result.changedFiles }
+        : undefined),
+  );
+  const changedFiles = changedFileProvenance.state === 'known' ? changedFileProvenance.files : null;
+  const changedFilesSummary =
+    changedFileProvenance.state === 'known'
+      ? changedFiles.join(', ') || 'none'
+      : `unknown (${changedFileProvenance.reason})`;
+  return { changedFileProvenance, changedFiles, changedFilesSummary };
+};
+
 // ── engine gates ─────────────────────────────────────────────────────────────
 // An approval gate the ENGINE opens (skeleton / ladder / batch / halt / the
 // per-stage validation gate in index.js) — same HUMAN# row + callback
@@ -1022,13 +1040,8 @@ export const runParallelSection = async (segment, toolkit) => {
       }
 
       const result = revision.result ?? {};
-      const changedFileProvenance = normalizeChangedFileProvenance(result.changedFileProvenance);
-      const changedFiles =
-        changedFileProvenance.state === 'known' ? changedFileProvenance.files : null;
-      const changedFilesSummary =
-        changedFileProvenance.state === 'known'
-          ? changedFiles.join(', ') || 'none'
-          : `unknown (${changedFileProvenance.reason})`;
+      const { changedFileProvenance, changedFiles, changedFilesSummary } =
+        feedbackChangedFileReport(result);
       const refs = (next.comments ?? [])
         .map((comment) => `${comment.repository}#${comment.prNumber}:${comment.id}`)
         .join(', ');

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -1794,6 +1794,21 @@ describe('PR per unit delivery', () => {
         };
       },
     });
+    deps.invokeRuntime = makeRuntime(ctx, (payload) => {
+      if (payload.command === 'init-ws') return { ok: true };
+      if (payload.reviewFeedback) {
+        return {
+          ok: true,
+          state: 'SUCCEEDED',
+          changedFileProvenance: {
+            state: 'unknown',
+            reason: 'git_status_failed',
+            detail: 'status unavailable',
+          },
+        };
+      }
+      return { ok: true, state: 'SUCCEEDED' };
+    });
     const batch = {
       batchId: 'batch-1',
       state: 'QUEUED',
@@ -1833,6 +1848,14 @@ describe('PR per unit delivery', () => {
         batchId: 'batch-1',
         state: 'SUCCEEDED',
         fromStates: ['RUNNING'],
+        fields: expect.objectContaining({
+          changedFileProvenance: {
+            state: 'unknown',
+            reason: 'git_status_failed',
+            detail: 'status unavailable',
+          },
+          changedFiles: null,
+        }),
       }),
     );
     const revision = stageStarts().find((payload) =>
@@ -1857,6 +1880,9 @@ describe('PR per unit delivery', () => {
     expect(deps.unitPrProvider.addComment).toHaveBeenCalledOnce();
     expect(deps.unitPrProvider.addComment.mock.calls[0][0].body).toContain(
       'AI-DLC feedback batch: batch-1',
+    );
+    expect(deps.unitPrProvider.addComment.mock.calls[0][0].body).toContain(
+      'Changed files: unknown (git_status_failed)',
     );
     expect(metrics).toContainEqual({ feedbackCycles: 1 });
   });

--- a/lambda/v2-orchestrator/test/section.test.js
+++ b/lambda/v2-orchestrator/test/section.test.js
@@ -6,6 +6,7 @@ import {
   validateFanoutOverrides,
   unitBranchFor,
   laneSessionIdFor,
+  feedbackChangedFileReport,
 } from '../section.js';
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
@@ -155,5 +156,54 @@ describe('lane naming (A2 rules 3 + 6)', () => {
     expect(id.length).toBeGreaterThanOrEqual(33);
     expect(laneSessionIdFor('i1', 1, 'billing')).not.toBe(id);
     expect(laneSessionIdFor('i1', 2, 'auth')).not.toBe(id);
+  });
+});
+
+describe('feedback changed-file provenance consumer', () => {
+  it('persists unknown provenance and reports it as unknown', () => {
+    const report = feedbackChangedFileReport({
+      changedFileProvenance: {
+        state: 'unknown',
+        reason: 'git_diff_failed',
+        detail: 'exit 128',
+      },
+      changedFiles: ['must-not-be-used.js'],
+    });
+
+    expect(report).toEqual({
+      changedFileProvenance: {
+        state: 'unknown',
+        reason: 'git_diff_failed',
+        detail: 'exit 128',
+      },
+      changedFiles: null,
+      changedFilesSummary: 'unknown (git_diff_failed)',
+    });
+  });
+
+  it('preserves known-empty provenance as an intentional empty set', () => {
+    expect(
+      feedbackChangedFileReport({
+        changedFileProvenance: { state: 'known', files: [] },
+      }),
+    ).toEqual({
+      changedFileProvenance: { state: 'known', files: [] },
+      changedFiles: [],
+      changedFilesSummary: 'none',
+    });
+  });
+
+  it('preserves known paths unchanged for persistence and reporting', () => {
+    const files = ['services/api/index.js', 'packages/ui/Button.tsx'];
+
+    expect(
+      feedbackChangedFileReport({
+        changedFileProvenance: { state: 'known', files },
+      }),
+    ).toEqual({
+      changedFileProvenance: { state: 'known', files },
+      changedFiles: files,
+      changedFilesSummary: 'services/api/index.js, packages/ui/Button.tsx',
+    });
   });
 });


### PR DESCRIPTION
## Problem / Motivation

PR #364 identified a valid v2 defect: sensor harness failures could be reported as code-quality failures, while incomplete changed-file provenance could either suppress required sensors or inspect the wrong projects. The submitted branch was not safe to merge because it double-prefixed multi-repository paths, lost rename sources, treated unknown provenance as an empty known list, and accepted malformed successful sensor output.

This is a maintainer-owned replacement, rebuilt on current `main` rather than merging the original head.

## Why it matters

Incorrect provenance can make blocking sensors fail open or hold unrelated stages. Unbounded or unredacted harness diagnostics can also persist credentials and create avoidable performance and UI risks.

## What changed

### Provenance and selection design

- Models changed-file provenance explicitly as `known` or `unknown`, including the reason for unknown state.
- Converts repository-relative paths to workspace-relative paths exactly once and preserves already-normalized multi-repository paths.
- Preserves both source and destination endpoints for staged, retry, unpushed, and cross-project renames.
- Handles missing/stale remote refs and aggregates multiple unpushed commits safely.
- Carries provenance through `commitAndPushAll` → `runStage` → sensor selection and through orchestrator feedback persistence.
- Preserves unknown provenance in the orchestrator consumer as `changedFiles: null` plus `changedFileProvenance: { state: "unknown", reason }`; unknown is never encoded or reported as `[]`/`none`.
- Runs blocking sensors when provenance is unknown, while skipping definitively inapplicable sensors.

### Security and contract design

- Gives sensor children an explicit minimal environment instead of inheriting repository credentials and unrelated process state.
- Redacts credential-shaped diagnostic values before logging, persistence, rendering, and deduplication; dedupe keys are derived from redacted text.
- Strictly validates `verdictMode`, `scope`, and safe relative `projectConfig` values.
- Treats empty, malformed, schema-invalid, or unsupported stdout JSON as bounded `INCONCLUSIVE`, never `PASS`.

### Bounded diagnostics

- Replaces repeated stringify-and-pop trimming with deterministic bounded rendering and accurate represented-file omission counts.
- Adds accessible frontend rendering for bounded harness diagnostics, omission metadata, redacted content, and empty details.

## Production-shaped seam coverage

The replacement now exercises the real orchestration seam rather than only helper functions:

- Git result → `commitAndPushAll` → `runStage` → sensor selection preserves both endpoints of a cross-repository rename, scopes the affected project files correctly, and rejects double-prefixing.
- Exit `127` / tool unavailable becomes blocking `INCONCLUSIVE`, holds the stage, retains two changed files, and redacts both secrets before persistence and broadcast.
- The original generic nonzero script failure (exit `1` with captured stderr) becomes blocking `INCONCLUSIVE`, holds the stage, retains the changed-file scope, and persists only redacted stderr.
- Git diff failure remains explicit `unknown` provenance with its reason, widens inspection to all applicable files, and cannot be collapsed to an empty known list.
- Exit `0` with invalid stdout JSON remains bounded `INCONCLUSIVE`, never `PASS`.

## Attribution

The original valid sensor-provenance direction was contributed by Olivier Rossant in PR #364. This replacement preserves that credit while reworking the implementation to address the correctness, security, provenance, and performance gaps found during review.

## Validation

Baseline SHA: `671502e5da02a2fe182d3043462ed75d17c7d564`

Current head SHA: `93760487ead209376dbe93089ba6142222cdb33f`

Validated with repository-pinned Node `v22.22.1` and Vitest `4.1.10` (frontend Vitest `4.1.9`):

### Focused remediation suites

- Orchestrator provenance consumer: 1/1 file, 14/14 tests passed.
- Git-to-stage and production-orchestration seam: 1/1 file, 147/147 tests passed.
- Assertions cover known-empty versus unknown provenance persistence, cross-repository rename scoping, no double-prefixing, exit `127`, generic exit `1` with stderr, invalid successful JSON, changed-file scoping, stage hold behavior, and pre-persistence/pre-broadcast credential redaction.

### Affected regressions

- Backend: 88 files and 1,515 tests passed; 1 file / 3 explicitly container-runtime-dependent tests skipped; 0 failures.
- Included suites: sensor runner 45/45, orchestrator replay 6/6, orchestrator 93/93, run-stage 147/147, v2 process 94/94, v2 execution plan 67/67, section integration 3/3, section 14/14, v2 sensor contract 42/42, and Git engine 89/89.
- Frontend diagnostics and adjacent intent regression: 2/2 files, 30/30 tests passed (SensorDiagnostics 8/8; UnitLaneBoard 22/22).

### Final quality gates

- Root format: 834 files checked, passed.
- Frontend format: 386 files checked, passed.
- Root lint: 735 files checked, 0 errors and 16 pre-existing warnings outside the remediation scope.
- Frontend lint: 375 files checked, 0 errors and 5 pre-existing warnings.
- Frontend typecheck passed.
- Frontend production build passed.
- Secretlint passed with no findings.
- Git diff check passed.

## Local hook and container-runtime evidence

- The committed Husky hook was not changed (`sha256:03ec8be4211f2c0980329c3954e3b17c3c3089be23ab74bd202672f13cc6126c`).
- No supported local container runtime was available: Docker, Podman, Nerdctl, Finch, and Colima CLIs and conventional runtime sockets were absent; a direct Testcontainers probe failed with `Could not find a working container runtime strategy`.
- Therefore the native final Husky command, `npx vitest run --changed --passWithNoTests`, is **environmentally blocked and is not claimed green** because the root Vitest setup unconditionally starts Gremlin and DynamoDB Local containers.
- A temporary untracked adapter preserved the non-container hook phases and replaced only that unavailable final phase with the focused no-container suites. It passed lint-staged (oxfmt, oxlint, secretlint), audits at the configured threshold, 14/14 section tests, 147/147 run-stage tests, 1,515 backend tests (3 container-only skipped), and 30/30 frontend tests. The adapter was removed, the index restored, and the repository hook restored byte-for-byte.
- **Container-backed validation remains mandatory and must pass on this exact head in CI before the replacement is considered review-ready or PR #364 is closed as superseded.**

## Residual risks

- Local validation cannot make a green claim for the 3 container-runtime-dependent tests or the native container-backed Husky phase; CI is the required authority for both.
- The root production audit reports one moderate `qs` advisory; the configured high-severity threshold passed, and the frontend audit reported 0 vulnerabilities.
- No visual screenshot was captured for the bounded diagnostics UI; focused accessibility/rendering coverage, typecheck, and the production build passed.

Supersedes #364

no linked issue: this PR replaces an existing pull request rather than resolving a separately tracked issue.