### PR TITLE
fix(agentcore): trust restored conflict checkouts

### DIFF
--- a/lambda/agentcore/commands/resolve-conflict.js
+++ b/lambda/agentcore/commands/resolve-conflict.js
@@ -33,6 +33,7 @@ import {
   repoTargetDir,
   runGit,
 } from '../git-engine.js';
+import { ensureWorkspaceSource as defaultEnsureWorkspaceSource } from '../workspace.js';
 import { getDriver, selectCli } from '../cli/drivers.js';
 import { runChild as defaultRunChild } from '../cli/spawn.js';
 import { resolveStageModel } from '../model-resolver.js';
@@ -112,6 +113,7 @@ export const resolveConflict = async (
     runChild = defaultRunChild,
     beginConflictMerge = defaultBeginConflictMerge,
     concludeConflictMerge = defaultConcludeConflictMerge,
+    ensureWorkspaceSource = defaultEnsureWorkspaceSource,
     materializeMcpConfig = defaultMaterializeMcpConfig,
     materializeKiroAgent = defaultMaterializeKiroAgent,
     materializeOpenCodeConfig = defaultMaterializeOpenCodeConfig,
@@ -133,6 +135,27 @@ export const resolveConflict = async (
   if (!unitSlug) return { ok: false, reason: 'missing_unit_slug' };
   if (repos.length === 0) return { ok: false, reason: 'no_repos' };
   if (!unitBranch || !intentBranch) return { ok: false, reason: 'missing_branch' };
+
+  // The lane session may have been stopped after review/integration and then
+  // remounted for this command. Re-clone a wiped checkout or re-establish the
+  // exact safe.directory entry before beginConflictMerge's first `git fetch`.
+  const heal = await ensureWorkspaceSource({
+    repos,
+    branch: unitBranch,
+    baseBranch: intentBranch,
+    gitProvider,
+    repoProviders,
+    projectId,
+    executionId,
+    workspaceDir,
+  }).catch((error) => ({ error: error?.message ?? String(error) }));
+  if (heal?.error || heal?.failed?.length) {
+    return {
+      ok: false,
+      reason: 'workspace_restore_failed',
+      detail: heal?.error ?? `could not restore or trust: ${heal.failed.join(', ')}`,
+    };
+  }
 
   const multi = repos.length > 1;
   const dirFor = (url) => repoTargetDir({ url, workspaceDir, multi });

--- a/lambda/agentcore/test/resolve-conflict.test.js
+++ b/lambda/agentcore/test/resolve-conflict.test.js
@@ -125,6 +125,48 @@ describe('buildConflictPrompt', () => {
 });
 
 describe('resolveConflict', () => {
+  it('restores and trusts the lane checkout before the first fetch', async () => {
+    const ws = path.join(root, 'restored-lane-ws');
+    const calls = [];
+    const res = await resolveConflict(basePayload(ws), {
+      ensureWorkspaceSource: async (options) => {
+        calls.push('restore');
+        expect(options).toMatchObject({
+          repos: ['o/r'],
+          branch: 'aidlc/i1--s1-unit-u',
+          baseBranch: 'aidlc/i1',
+          projectId: 'p1',
+          executionId: 'e1',
+          workspaceDir: ws,
+        });
+        return { restored: false, repos: [], failed: [] };
+      },
+      beginConflictMerge: async ({ dir }) => {
+        calls.push('fetch');
+        expect(dir).toBe(ws);
+        return { conflicted: false, merged: 'up_to_date' };
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(calls).toEqual(['restore', 'fetch']);
+  });
+
+  it('fails before fetching when the lane checkout cannot be restored or trusted', async () => {
+    const beginConflictMerge = vi.fn();
+    const res = await resolveConflict(basePayload('/restored-lane-ws'), {
+      ensureWorkspaceSource: async () => ({ restored: false, repos: [], failed: ['o/r'] }),
+      beginConflictMerge,
+    });
+
+    expect(res).toMatchObject({
+      ok: false,
+      reason: 'workspace_restore_failed',
+      detail: 'could not restore or trust: o/r',
+    });
+    expect(beginConflictMerge).not.toHaveBeenCalled();
+  });
+
   it('resolves a real conflict: engine merges, agent edits, engine verifies + concludes + pushes', async () => {
     const { remote, ws } = await conflictWorld();
     const store = spyStore();


### PR DESCRIPTION
## Summary

- Restore and trust a remounted lane checkout before resolve-conflict performs its first Git fetch.
- Re-clone a wiped checkout and fail before fetching when workspace preparation is unsuccessful.
- Add regression tests for ordering and failure short-circuiting.

## Root cause

- This is the same restored-checkout ownership issue addressed by #434, in a separate command path.
- The unit integration flow can stop the lane session before merge-back. If merge-back conflicts, resolve-conflict remounts that lane workspace and previously called beginConflictMerge directly. Its first Git fetch could therefore fail with detected dubious ownership.

## Validation

- 51 tests passed in the commit hook.
- Formatting, lint, and secret scanning passed.
- Section-level conflict-resolution integration passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.