### PR TITLE
fix: lost answers in human-gate races

### DIFF
--- a/lambda/agentcore/commands/run-stage.js
+++ b/lambda/agentcore/commands/run-stage.js
@@ -87,6 +87,7 @@ import {
   stageInstanceId as planStageInstanceId,
   UNIT_FOR_EACH,
 } from '../../shared/v2-execution-plan.js';
+import { humanTaskMatchesOwner } from '../../shared/v2-process-keys.js';
 import { credentialProviderForCli } from '../../shared/agent-credentials.js';
 import { pruneOutputArtifactsForUnit } from '../../shared/unit-kind-pruning.js';
 // The typed-extraction registry gates the platform-injected graph-coverage
@@ -887,28 +888,33 @@ export const isBenignKiroEmptyCompletion = (stderrTail = '') => {
   return !transportCause.test(s);
 };
 
-// Return THIS stage's still-pending HUMAN gate. Stage ownership is the source
-// of truth because one META pointer cannot represent concurrent lane questions.
-// The META fallback supports old rows, but only when the gate names this exact
-// stage; a sibling's question can therefore never park the current stage.
-const pendingGate = async ({ store, executionId, stageInstanceId, unitSlug, sectionIndex }) => {
-  const stage = await store.getStage(executionId, stageInstanceId).catch(() => null);
+// Return the HUMAN gate still owned by THIS stage at CLI exit. Stage ownership
+// is the source of truth because one META pointer cannot represent concurrent
+// lane questions. The META fallback supports old rows, but only when the gate
+// names this exact stage; a sibling's question can therefore never park the
+// current stage.
+//
+// Deliberately do NOT require gate.status === 'pending'. The human answer can
+// land after ask_question's grace window but before the CLI exits. In that
+// window the stage row still owns the gate and the conversation still needs a
+// resume turn with the answer; treating the answered gate as absent would let
+// the stage continue to sensors/success without ever delivering the answer.
+const ownedGateAtExit = async ({ store, executionId, stageInstanceId, unitSlug, sectionIndex }) => {
+  const stage = await store
+    .getStage(executionId, stageInstanceId, { consistentRead: true })
+    .catch(() => null);
   let humanTaskId = stage?.pendingHumanTaskId ?? null;
   if (!humanTaskId) {
-    const meta = await store.getExecution(executionId).catch(() => null);
+    const meta = await store.getExecution(executionId, { consistentRead: true }).catch(() => null);
     humanTaskId = meta?.pendingHumanTaskId ?? null;
   }
   if (!humanTaskId) return null;
-  const gate = await store.getHumanTask(executionId, humanTaskId).catch(() => null);
-  const ownsStage = gate?.stageInstanceId === stageInstanceId;
-  const ownsUnit = (gate?.unitSlug ?? null) === (unitSlug ?? null);
-  const ownsSection =
-    gate?.sectionIndex == null ||
-    sectionIndex == null ||
-    Number(gate.sectionIndex) === Number(sectionIndex);
+  const gate = await store
+    .getHumanTask(executionId, humanTaskId, { consistentRead: true })
+    .catch(() => null);
   // createdAt rides along for wait accounting: the park's parkedAt is the ASK
   // moment, not the (later) CLI exit.
-  return gate && gate.status === 'pending' && ownsStage && ownsUnit && ownsSection
+  return humanTaskMatchesOwner({ task: gate, stageInstanceId, unitSlug, sectionIndex })
     ? { humanTaskId, createdAt: gate.createdAt ?? null }
     : null;
 };
@@ -1415,12 +1421,16 @@ export const runStage = async (
       stageInstanceId,
     });
     resumeGate = resumeFrom
-      ? await store.getHumanTask(executionId, resumeFrom).catch(() => null)
+      ? await store
+          .getHumanTask(executionId, resumeFrom, { consistentRead: true })
+          .catch(() => null)
       : null;
     if (resumeFrom && !resumeGate) return fail(stageInstanceId, 'gate_not_found', resumeFrom);
     if (resumeFrom && resumeGate.status === 'pending')
       return fail(stageInstanceId, 'gate_not_answered', resumeFrom);
-    const row = await store.getStage(executionId, stageInstanceId).catch(() => null);
+    const row = await store
+      .getStage(executionId, stageInstanceId, { consistentRead: true })
+      .catch(() => null);
     cli = row?.cli ?? null;
     const priorSessionId = row?.cliSessionId ?? null;
     if ((!cli || !priorSessionId) && !reviewFeedback) {
@@ -2331,13 +2341,15 @@ export const runStage = async (
     }
   }
 
-  // 5. Park check — did the agent leave a pending question? ask_question parks
-  // (returns a sentinel) instead of blocking, so the agent is told to stop. The
-  // durable pending gate — NOT the CLI exit code — is the source of truth for a
-  // park: a clean exit OR a non-zero exit AFTER parking both mean "waiting on a
-  // human". We therefore check the gate BEFORE treating a non-zero exit as failure,
-  // so a Kiro run that parks then errors on its next turn parks rather than fails.
-  const parked = await pendingGate({
+  // 5. Park check — did the agent leave a question-owned stage boundary?
+  // ask_question parks (returns a sentinel) instead of blocking, so the agent is
+  // told to stop. The durable stage pointer — NOT the gate's current status or
+  // the CLI exit code — is the source of truth for a park. The gate may already
+  // be answered here if the answer landed while the CLI was shutting down; that
+  // still requires a resume turn so the conversation receives the answer.
+  // Therefore a clean exit OR a non-zero exit after asking both mean "park and
+  // hand control back to the orchestrator".
+  const parked = await ownedGateAtExit({
     store,
     executionId,
     stageInstanceId,

--- a/lambda/agentcore/test/run-stage.test.js
+++ b/lambda/agentcore/test/run-stage.test.js
@@ -128,16 +128,16 @@ const spyStore = (seed = {}) => {
       calls.push(['recordMetric', args]);
       return { metricId: 'm-test' };
     },
-    async getHumanTask(_e, id) {
-      calls.push(['getHumanTask', id]);
+    async getHumanTask(_e, id, options) {
+      calls.push(['getHumanTask', id, options]);
       return seed.humanTask ?? null;
     },
-    async getStage(_e, id) {
-      calls.push(['getStage', id]);
+    async getStage(_e, id, options) {
+      calls.push(['getStage', id, options]);
       return seed.stage ?? null;
     },
-    async getExecution(_e) {
-      calls.push(['getExecution']);
+    async getExecution(_e, options) {
+      calls.push(['getExecution', options]);
       return seed.execution ?? null;
     },
     async getUnitPlan(_e) {
@@ -1511,6 +1511,47 @@ describe('runStage — fresh run persists the CLI session + parks on a pending g
     expect(
       deps.store.calls.some((c) => c[0] === 'appendEvent' && c[1].type === 'v2.stage.parked'),
     ).toBe(true);
+  });
+
+  it('parks and resumes when the gate is answered after grace but before CLI exit', async () => {
+    const deps = baseDeps({
+      spawnFn: okSpawn,
+      ids: () => 'forced-uuid',
+      store: spyStore(
+        pendingGateSeed('q-late-answer', {
+          status: 'answered',
+          answer: { answers: [{ selectedOptions: [0] }] },
+        }),
+      ),
+    });
+
+    const res = await runStage(baseArgs, deps);
+
+    expect(res).toMatchObject({
+      ok: true,
+      state: 'WAITING_FOR_HUMAN',
+      humanTaskId: 'q-late-answer',
+    });
+    const states = deps.store.calls
+      .filter((call) => call[0] === 'updateStageState')
+      .map((call) => call[1].state);
+    expect(states).toContain('WAITING_FOR_HUMAN');
+    expect(states).not.toContain('SUCCEEDED');
+    expect(
+      deps.store.calls.some(
+        (call) => call[0] === 'appendEvent' && call[1].type === 'v2.stage.succeeded',
+      ),
+    ).toBe(false);
+    expect(deps.store.calls).toContainEqual([
+      'getStage',
+      BASE_STAGE_INSTANCE_ID,
+      { consistentRead: true },
+    ]);
+    expect(deps.store.calls).toContainEqual([
+      'getHumanTask',
+      'q-late-answer',
+      { consistentRead: true },
+    ]);
   });
 
   it('re-stamps parkedAt with the gate ASK time so the exit-time write never shortens the wait', async () => {

--- a/lambda/intents/index.js
+++ b/lambda/intents/index.js
@@ -36,6 +36,7 @@ import {
 } from '../shared/environment-snapshot.js';
 import { runtimeTargetInput } from '../shared/runtime-target.js';
 import { createProcessStore } from '../shared/v2-process-store.js';
+import { isHumanTaskAnswerStatus } from '../shared/v2-process-keys.js';
 import { deleteIntentCascade, IntentRunningError } from '../shared/intent-deletion.js';
 import { buildResponse } from '../shared/response.js';
 import { fetchMembershipRole, projectTrackersFoldStep, mapBinding } from '../shared/trackers.js';
@@ -2474,6 +2475,13 @@ export const handler = async (event) => {
       if (!meta || meta.projectId !== projectId) {
         return response(404, { error: 'Intent not found' });
       }
+      const answerStatus = data.status ?? 'answered';
+      if (!isHumanTaskAnswerStatus(answerStatus)) {
+        return response(400, {
+          error: 'status must be answered, approved, or rejected',
+          code: 'invalid_gate_status',
+        });
+      }
       // A live Quorum edit is mutating this intent's artifacts; answering the
       // gate would resume the parked stage RIGHT INTO those writes. The run is
       // already parked — waiting for the edit to finish costs nothing (mirror
@@ -2495,7 +2503,7 @@ export const handler = async (event) => {
       const answered = await store.answerHumanTask({
         executionId: intentId,
         humanTaskId,
-        status: data.status || 'answered',
+        status: answerStatus,
         answer: data.answer ?? null,
         answeredBy: responder.sub,
         answeredByName: responder.displayName,

--- a/lambda/intents/test/intents.test.js
+++ b/lambda/intents/test/intents.test.js
@@ -3863,6 +3863,23 @@ describe('POST /start — preconditions', () => {
 });
 
 describe('POST /gates/{humanTaskId}/answer', () => {
+  it('rejects an unknown status without consuming the pending gate', async () => {
+    const sub = `u-${randomUUID()}`;
+    const projectId = await seedV2Project(sub);
+    const intent = JSON.parse((await createIntent(sub, projectId)).body);
+    seedGate(intent.id, 'h1', { status: 'pending', callbackId: 'cb-h1' });
+
+    const invalid = await answerGate(sub, projectId, intent.id, 'h1', {
+      status: 'banana',
+      answer: { ok: 1 },
+    });
+    expect(invalid.statusCode).toBe(400);
+    expect(JSON.parse(invalid.body)).toMatchObject({ code: 'invalid_gate_status' });
+
+    // Validation happens before the answer CAS, so the same gate remains usable.
+    expect((await answerGate(sub, projectId, intent.id, 'h1')).statusCode).toBe(200);
+  });
+
   it('answers a pending gate (CAS) and resumes the durable callback when bound', async () => {
     const sub = `u-${randomUUID()}`;
     const projectId = await seedV2Project(sub);

--- a/lambda/shared/test/v2-process.test.js
+++ b/lambda/shared/test/v2-process.test.js
@@ -38,6 +38,9 @@ import {
   buildTrackerSyncRow,
   executionTypeStateIndex,
   HUMAN_TASK_STATUSES,
+  HUMAN_TASK_ANSWER_STATUSES,
+  isHumanTaskAnswerStatus,
+  humanTaskMatchesOwner,
   STEERING_KINDS,
   STEERING_STATUSES,
   UNIT_STATES,
@@ -102,6 +105,36 @@ describe('v2-process-keys', () => {
       now: 'T',
     });
     expect(linked).toMatchObject({ cli: 'claude', cliSessionId: 'sess-7' });
+  });
+
+  it('defines one answer-status and legacy-compatible ownership contract for human gates', () => {
+    expect(HUMAN_TASK_ANSWER_STATUSES).toEqual(['answered', 'approved', 'rejected']);
+    expect(HUMAN_TASK_ANSWER_STATUSES.every(isHumanTaskAnswerStatus)).toBe(true);
+    expect(isHumanTaskAnswerStatus('pending')).toBe(false);
+    expect(isHumanTaskAnswerStatus('superseded')).toBe(false);
+
+    const owner = {
+      stageInstanceId: 'si-a',
+      unitSlug: 'auth',
+      sectionIndex: 2,
+    };
+    expect(humanTaskMatchesOwner({ task: owner, ...owner })).toBe(true);
+    expect(humanTaskMatchesOwner({ task: { ...owner, sectionIndex: null }, ...owner })).toBe(true);
+    expect(humanTaskMatchesOwner({ task: owner, ...owner, sectionIndex: null })).toBe(true);
+    expect(
+      humanTaskMatchesOwner({
+        task: owner,
+        ...owner,
+        sectionIndex: 3,
+      }),
+    ).toBe(false);
+    expect(
+      humanTaskMatchesOwner({
+        task: owner,
+        ...owner,
+        unitSlug: 'catalog',
+      }),
+    ).toBe(false);
   });
 
   it('builds a question human-task carrying the structured payload', () => {
@@ -182,6 +215,29 @@ describe('createProcessStore', () => {
     expect(eventual).not.toHaveProperty('ConsistentRead');
     expect(consistent).toMatchObject({
       Key: executionMetaKey('e1'),
+      ConsistentRead: true,
+    });
+  });
+
+  it('opts into strongly consistent stage and human-gate reads only when requested', async () => {
+    ddb.on(GetCommand).resolves({ Item: { executionId: 'e1' } });
+
+    await store.getStage('e1', 'si-1');
+    await store.getStage('e1', 'si-1', { consistentRead: true });
+    await store.getHumanTask('e1', 'h1');
+    await store.getHumanTask('e1', 'h1', { consistentRead: true });
+
+    const [eventualStage, consistentStage, eventualGate, consistentGate] = ddb
+      .commandCalls(GetCommand)
+      .map((call) => call.args[0].input);
+    expect(eventualStage).not.toHaveProperty('ConsistentRead');
+    expect(consistentStage).toMatchObject({
+      Key: stageKey('e1', 'si-1'),
+      ConsistentRead: true,
+    });
+    expect(eventualGate).not.toHaveProperty('ConsistentRead');
+    expect(consistentGate).toMatchObject({
+      Key: humanTaskKey('e1', 'h1'),
       ConsistentRead: true,
     });
   });
@@ -413,6 +469,10 @@ describe('createProcessStore', () => {
     expect(input.ExpressionAttributeValues[':scb']).toBe('cb-2');
     expect(input.UpdateExpression).toContain('aidlcRepoRef = :aidlcRepoRef');
     expect(input.ExpressionAttributeValues[':aidlcRepoRef']).toBe('a'.repeat(40));
+    expect(ddb.commandCalls(GetCommand)[0].args[0].input).toMatchObject({
+      Key: stageKey('e1', 'si-1'),
+      ConsistentRead: true,
+    });
   });
 
   it('resumeStageRow tolerates a missing/unparsable park stamp (waitMs unchanged, no NaN)', async () => {

--- a/lambda/shared/v2-process-keys.js
+++ b/lambda/shared/v2-process-keys.js
@@ -199,7 +199,21 @@ const STAGE_STATE = ['PENDING', 'RUNNING', 'WAITING_FOR_HUMAN', 'SUCCEEDED', 'FA
 // Human gate kinds + lifecycle. `superseded` retires a still-pending gate whose
 // run was cancelled/rewound — never answered, kept as the audit record.
 const HUMAN_TASK_KINDS = ['approval', 'question', 'review-verdict', 'validation'];
-const HUMAN_TASK_STATUSES = ['pending', 'answered', 'approved', 'rejected', 'superseded'];
+const HUMAN_TASK_ANSWER_STATUSES = ['answered', 'approved', 'rejected'];
+const HUMAN_TASK_STATUSES = ['pending', ...HUMAN_TASK_ANSWER_STATUSES, 'superseded'];
+const isHumanTaskAnswerStatus = (status) => HUMAN_TASK_ANSWER_STATUSES.includes(status);
+// Stage + lane ownership for a human gate. sectionIndex is legacy-compatible:
+// older rows can omit it, so either side being null falls back to the exact
+// stageInstanceId + unitSlug match.
+const humanTaskMatchesOwner = ({ task, stageInstanceId, unitSlug = null, sectionIndex = null }) => {
+  if (!task || task.stageInstanceId !== stageInstanceId) return false;
+  if ((task.unitSlug ?? null) !== (unitSlug ?? null)) return false;
+  return (
+    task.sectionIndex == null ||
+    sectionIndex == null ||
+    Number(task.sectionIndex) === Number(sectionIndex)
+  );
+};
 // Human steering (course-correction) messages. Immutable once written; a
 // correction of a correction supersedes the old row. Delivery ("consumed") only
 // happens at a deterministic injection point: a gate resume or a fresh stage
@@ -1176,7 +1190,10 @@ export {
   ACTIVE_EXECUTION_STATUSES,
   STAGE_STATE,
   HUMAN_TASK_KINDS,
+  HUMAN_TASK_ANSWER_STATUSES,
   HUMAN_TASK_STATUSES,
+  isHumanTaskAnswerStatus,
+  humanTaskMatchesOwner,
   STEERING_KINDS,
   STEERING_STATUSES,
   UNIT_STATES,
@@ -1244,7 +1261,10 @@ export default {
   ACTIVE_EXECUTION_STATUSES,
   STAGE_STATE,
   HUMAN_TASK_KINDS,
+  HUMAN_TASK_ANSWER_STATUSES,
   HUMAN_TASK_STATUSES,
+  isHumanTaskAnswerStatus,
+  humanTaskMatchesOwner,
   STEERING_KINDS,
   STEERING_STATUSES,
   UNIT_STATES,

--- a/lambda/shared/v2-process-store.js
+++ b/lambda/shared/v2-process-store.js
@@ -488,9 +488,13 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     return item;
   };
 
-  const getStage = async (executionId, stageInstanceId) => {
+  const getStage = async (executionId, stageInstanceId, { consistentRead = false } = {}) => {
     const { Item } = await ddb.send(
-      new GetCommand({ TableName: table(), Key: stageKey(executionId, stageInstanceId) }),
+      new GetCommand({
+        TableName: table(),
+        Key: stageKey(executionId, stageInstanceId),
+        ...(consistentRead ? { ConsistentRead: true } : {}),
+      }),
     );
     return Item ?? null;
   };
@@ -620,7 +624,7 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     stageCallbackId,
     aidlcRepoRef,
   }) => {
-    const existing = await getStage(executionId, stageInstanceId);
+    const existing = await getStage(executionId, stageInstanceId, { consistentRead: true });
     const ts = now();
     // Fold the open park window into the accumulator. Guarded parses: an
     // unparsable timestamp contributes 0 rather than poisoning waitMs with NaN.
@@ -810,9 +814,13 @@ const createProcessStore = ({ ddb, tableName, clock, ids } = {}) => {
     }
   };
 
-  const getHumanTask = async (executionId, humanTaskId) => {
+  const getHumanTask = async (executionId, humanTaskId, { consistentRead = false } = {}) => {
     const { Item } = await ddb.send(
-      new GetCommand({ TableName: table(), Key: humanTaskKey(executionId, humanTaskId) }),
+      new GetCommand({
+        TableName: table(),
+        Key: humanTaskKey(executionId, humanTaskId),
+        ...(consistentRead ? { ConsistentRead: true } : {}),
+      }),
     );
     return Item ?? null;
   };

--- a/lambda/v2-orchestrator/index.js
+++ b/lambda/v2-orchestrator/index.js
@@ -42,6 +42,7 @@ import {
   planSegments,
   stageInstanceId as planStageInstanceId,
 } from '../shared/v2-execution-plan.js';
+import { humanTaskMatchesOwner, isHumanTaskAnswerStatus } from '../shared/v2-process-keys.js';
 import { resolveSkipTo, skipTargetsFrom, resolveRecomposeSkips } from '../shared/stage-skip.js';
 import { broadcastToIntentChannel } from '../shared/ws-fanout.js';
 import { resolveRuntimeTarget } from '../shared/runtime-target.js';
@@ -846,23 +847,64 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         // Create a durable callback and stamp it on the gate so the answer path
         // can resume THIS execution. Then suspend (zero compute) until answered.
         const [callbackPromise, callbackId] = await ctxArg.createCallback(`await-${humanTaskId}`);
+        const expectedStageInstanceId = result.stageInstanceId ?? stage.stageInstanceId ?? null;
+        const expectedCallbackOwner = `stage:${expectedStageInstanceId ?? label}`;
         const callbackBound = await ctxArg.step(`bind-callback-${humanTaskId}`, () =>
           store.setGateCallbackId({
             executionId,
             humanTaskId,
             callbackId,
-            stageInstanceId: result.stageInstanceId ?? stage.stageInstanceId ?? null,
-            callbackOwner: `stage:${result.stageInstanceId ?? stage.stageInstanceId ?? label}`,
+            stageInstanceId: expectedStageInstanceId,
+            callbackOwner: expectedCallbackOwner,
           }),
         );
+        let answeredEarly = false;
         if (!callbackBound) {
-          return {
-            state: 'TERMINAL',
-            value: await fail(
-              'gate_callback_conflict',
-              `gate ${humanTaskId} is already bound to a different stage callback`,
-            ),
-          };
+          // The answer can win the CAS immediately before this bind. In that
+          // case setGateCallbackId returns null because the gate is no longer
+          // pending, but no callback is needed: resume directly with the
+          // persisted answer. Any still-pending, differently owned, or already
+          // bound gate remains an invariant violation.
+          const gateAfterBindFailure = await ctxArg.step(
+            `gate-after-bind-failure-${humanTaskId}`,
+            () => store.getHumanTask(executionId, humanTaskId, { consistentRead: true }),
+          );
+          if (gateAfterBindFailure?.status === 'superseded') {
+            ctx.logger?.info?.('run retired before gate callback bind', {
+              intentId,
+              humanTaskId,
+            });
+            return {
+              state: 'TERMINAL',
+              value: { ok: false, reason: 'retired', intentId, humanTaskId },
+            };
+          }
+          const ownsExpectedStage = humanTaskMatchesOwner({
+            task: gateAfterBindFailure,
+            stageInstanceId: expectedStageInstanceId,
+            unitSlug,
+            sectionIndex,
+          });
+          const callbackIdCompatible =
+            gateAfterBindFailure?.callbackId == null ||
+            gateAfterBindFailure.callbackId === callbackId;
+          const callbackOwnerCompatible =
+            gateAfterBindFailure?.callbackOwner == null ||
+            gateAfterBindFailure.callbackOwner === expectedCallbackOwner;
+          answeredEarly =
+            isHumanTaskAnswerStatus(gateAfterBindFailure?.status) &&
+            ownsExpectedStage &&
+            callbackIdCompatible &&
+            callbackOwnerCompatible;
+          if (!answeredEarly) {
+            return {
+              state: 'TERMINAL',
+              value: await fail(
+                'gate_callback_conflict',
+                `gate ${humanTaskId} bind failed without an unbound answer owned by this stage`,
+              ),
+            };
+          }
         }
 
         // Answer/bind race (field incident): a fast human can answer in the
@@ -872,10 +914,14 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         // parkReleaseSeconds stall the human reads as "my answer was
         // ignored"). Re-read AFTER binding: an already-answered gate skips
         // the wait entirely and resumes now.
-        const answeredEarly = await ctxArg.step(`gate-answered-early-${humanTaskId}`, async () => {
-          const gate = await store.getHumanTask(executionId, humanTaskId);
-          return Boolean(gate?.status) && gate.status !== 'pending';
-        });
+        if (callbackBound) {
+          answeredEarly = await ctxArg.step(`gate-answered-early-${humanTaskId}`, async () => {
+            const gate = await store.getHumanTask(executionId, humanTaskId, {
+              consistentRead: true,
+            });
+            return isHumanTaskAnswerStatus(gate?.status) || gate?.status === 'superseded';
+          });
+        }
         if (!answeredEarly) {
           // D1 release-on-park: if no human answers within parkReleaseSeconds, free
           // the warm microVM compute (StopRuntimeSession) while we keep waiting —
@@ -893,7 +939,9 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
               ctxArg.wait(`release-timer-${humanTaskId}`, { seconds: parkReleaseSeconds }),
             ]);
             const stillPending = await ctxArg.step(`gate-status-${humanTaskId}`, async () => {
-              const gate = await store.getHumanTask(executionId, humanTaskId);
+              const gate = await store.getHumanTask(executionId, humanTaskId, {
+                consistentRead: true,
+              });
               return gate?.status === 'pending';
             });
             if (stillPending) {
@@ -909,7 +957,7 @@ const handler = async (event, ctx, deps = defaultDeps()) => {
         // wakes this callback with a cancel sentinel. The cancel/rewind path owns
         // META from here — exit WITHOUT any further write (docs/v2-steering.md).
         const gateAfter = await ctxArg.step(`gate-after-${humanTaskId}`, () =>
-          store.getHumanTask(executionId, humanTaskId),
+          store.getHumanTask(executionId, humanTaskId, { consistentRead: true }),
         );
         if (gateAfter?.status === 'superseded') {
           ctx.logger?.info?.('run retired while parked', { intentId, humanTaskId });

--- a/lambda/v2-orchestrator/test/orchestrator.test.js
+++ b/lambda/v2-orchestrator/test/orchestrator.test.js
@@ -261,7 +261,122 @@ describe('orchestrator durable handler', () => {
       .mockResolvedValueOnce(META)
       .mockResolvedValue({ ...META, pendingHumanTaskId: 'h1' });
     deps.store.setGateCallbackId.mockResolvedValueOnce(null);
+    deps.store.getHumanTask.mockResolvedValue({ status: 'pending' });
     deps.loadPlan.mockResolvedValue({ valid: true, plan: { stages: [{ stageId: 'a' }] } });
+    deps.invokeRuntime = makeRuntime(ctx, (payload, n) => {
+      if (n === 1) return { ok: true };
+      return { ok: true, state: 'WAITING_FOR_HUMAN', humanTaskId: 'h1' };
+    });
+
+    const res = await __durableHandler(
+      { action: 'start', intentId: 'i1', executionId: 'i1' },
+      ctx,
+      deps,
+    );
+
+    expect(res).toMatchObject({ ok: false, reason: 'gate_callback_conflict' });
+    expect(stageStarts()).toHaveLength(1);
+  });
+
+  it.each(['answered', 'approved', 'rejected'])(
+    'resumes when a %s decision wins before the gate callback can be bound',
+    async (status) => {
+      deps.store.getExecution
+        .mockResolvedValueOnce(META)
+        .mockResolvedValue({ ...META, pendingHumanTaskId: 'h1' });
+      deps.store.setGateCallbackId.mockResolvedValueOnce(null);
+      deps.store.getHumanTask.mockResolvedValue({
+        status,
+        answer: { choice: 'A' },
+        stageInstanceId: 'si-a',
+        unitSlug: null,
+        sectionIndex: null,
+      });
+      deps.loadPlan.mockResolvedValue({
+        valid: true,
+        plan: { stages: [{ stageId: 'a', stageInstanceId: 'si-a' }] },
+      });
+      deps.invokeRuntime = makeRuntime(ctx, (payload, n) => {
+        if (n === 1) return { ok: true };
+        if (n === 2) return { ok: true, state: 'WAITING_FOR_HUMAN', humanTaskId: 'h1' };
+        return { ok: true, state: 'SUCCEEDED' };
+      });
+
+      const res = await __durableHandler(
+        { action: 'start', intentId: 'i1', executionId: 'i1' },
+        ctx,
+        deps,
+      );
+
+      expect(res.ok).toBe(true);
+      expect(stageStarts()).toHaveLength(2);
+      expect(stageStarts()[1].resumeFrom).toBe('h1');
+      expect(deps.stopSession).not.toHaveBeenCalled();
+      expect(deps.store.getHumanTask).toHaveBeenCalledWith('i1', 'h1', {
+        consistentRead: true,
+      });
+    },
+  );
+
+  it.each([
+    [
+      'stage ownership mismatch',
+      {
+        status: 'answered',
+        stageInstanceId: 'si-other',
+        unitSlug: null,
+        sectionIndex: null,
+      },
+    ],
+    [
+      'unit ownership mismatch',
+      {
+        status: 'answered',
+        stageInstanceId: 'si-a',
+        unitSlug: 'other-unit',
+        sectionIndex: null,
+      },
+    ],
+    [
+      'callback ID mismatch',
+      {
+        status: 'answered',
+        stageInstanceId: 'si-a',
+        unitSlug: null,
+        sectionIndex: null,
+        callbackId: 'cb-other',
+        callbackOwner: 'stage:si-a',
+      },
+    ],
+    [
+      'callback owner mismatch',
+      {
+        status: 'answered',
+        stageInstanceId: 'si-a',
+        unitSlug: null,
+        sectionIndex: null,
+        callbackOwner: 'stage:si-other',
+      },
+    ],
+    [
+      'unexpected terminal status',
+      {
+        status: 'banana',
+        stageInstanceId: 'si-a',
+        unitSlug: null,
+        sectionIndex: null,
+      },
+    ],
+  ])('keeps the callback conflict on bind failure with a %s', async (_case, gate) => {
+    deps.store.getExecution
+      .mockResolvedValueOnce(META)
+      .mockResolvedValue({ ...META, pendingHumanTaskId: 'h1' });
+    deps.store.setGateCallbackId.mockResolvedValueOnce(null);
+    deps.store.getHumanTask.mockResolvedValue(gate);
+    deps.loadPlan.mockResolvedValue({
+      valid: true,
+      plan: { stages: [{ stageId: 'a', stageInstanceId: 'si-a' }] },
+    });
     deps.invokeRuntime = makeRuntime(ctx, (payload, n) => {
       if (n === 1) return { ok: true };
       return { ok: true, state: 'WAITING_FOR_HUMAN', humanTaskId: 'h1' };


### PR DESCRIPTION
## Issue

A human answer could arrive after the question grace window but before the CLI exited or the orchestrator bound its callback. The persisted answer was then either treated as no gate, allowing the stage to complete without delivering it, or misclassified as a callback conflict.

## Fix

- Keep a stage parked when it still owns a pending or already-decided gate, then resume the conversation with the persisted answer.
- Recover the answer-before-bind race using strongly consistent DynamoDB reads and strict stage, lane, and callback ownership checks.
- Share one legacy-compatible ownership predicate across runtime and orchestrator paths.
- Validate gate decisions against the supported answered, approved, and rejected statuses.

## Validation

- npm test: 158 files, 2,846 tests passed.
- Frontend: 77 files, 540 tests passed.
- TypeScript, formatting, lint-staged, secret scanning, and pre-commit checks passed.